### PR TITLE
test: fix WatchConnectionManagerTest.testFailSafeReconnect Windows flake (#7813)

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManager.java
@@ -167,7 +167,8 @@ public abstract class AbstractWatchManager<T extends HasMetadata> implements Wat
   /**
    * Schedule a delayed task on the operation executor. Test-overridable seam so unit tests
    * can drive the fail-safe / reconnect timing deterministically without touching
-   * {@link Utils#schedule}'s shared scheduler.
+   * {@link Utils#schedule}'s shared scheduler. Must return a non-null future:
+   * {@link #closeRequest()} attaches a cancellation callback to it and will NPE otherwise.
    */
   protected CompletableFuture<Void> schedule(Runnable command, long delay, TimeUnit unit) {
     return Utils.schedule(baseOperation.getOperationContext().getExecutor(), command, delay, unit);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManager.java
@@ -159,11 +159,18 @@ public abstract class AbstractWatchManager<T extends HasMetadata> implements Wat
     if (state != null && state.closed.compareAndSet(false, true)) {
       logger.debug("Closing the current watch");
       closeCurrentRequest();
-      CompletableFuture<Void> future = Utils.schedule(baseOperation.getOperationContext().getExecutor(),
-          () -> failSafeReconnect(state), watchEndCheckMs,
-          TimeUnit.MILLISECONDS);
+      CompletableFuture<Void> future = schedule(() -> failSafeReconnect(state), watchEndCheckMs, TimeUnit.MILLISECONDS);
       state.ended.whenComplete((v, t) -> future.cancel(true));
     }
+  }
+
+  /**
+   * Schedule a delayed task on the operation executor. Test-overridable seam so unit tests
+   * can drive the fail-safe / reconnect timing deterministically without touching
+   * {@link Utils#schedule}'s shared scheduler.
+   */
+  protected CompletableFuture<Void> schedule(Runnable command, long delay, TimeUnit unit) {
+    return Utils.schedule(baseOperation.getOperationContext().getExecutor(), command, delay, unit);
   }
 
   private synchronized void failSafeReconnect(WatchRequestState state) {
@@ -230,8 +237,7 @@ public abstract class AbstractWatchManager<T extends HasMetadata> implements Wat
     logger.debug("Scheduling reconnect task in {} ms", delay);
 
     synchronized (this) {
-      reconnectAttempt = Utils.schedule(baseOperation.getOperationContext().getExecutor(), this::reconnect, delay,
-          TimeUnit.MILLISECONDS);
+      reconnectAttempt = schedule(this::reconnect, delay, TimeUnit.MILLISECONDS);
       if (isForceClosed()) {
         cancelReconnect();
       }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManagerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManagerTest.java
@@ -22,12 +22,9 @@ import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.WatcherException;
 import io.fabric8.kubernetes.client.dsl.internal.AbstractWatchManager.WatchRequestState;
 import io.fabric8.kubernetes.client.http.TestStandardHttpClientFactory;
-import io.fabric8.kubernetes.client.utils.CommonThreadPool;
 import io.fabric8.kubernetes.client.utils.KubernetesSerialization;
-import io.fabric8.kubernetes.client.utils.Utils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.net.MalformedURLException;
@@ -35,18 +32,15 @@ import java.net.ProtocolException;
 import java.net.URL;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -138,21 +132,24 @@ class AbstractWatchManagerTest {
   @DisplayName("cancelReconnect, with non-null attempt, should cancel")
   void cancelReconnectNonNullAttempt() throws MalformedURLException {
     // Given
-    final CompletableFuture<?> cf = mock(CompletableFuture.class);
-    ExecutorService executor = CommonThreadPool.get();
-    try (MockedStatic<Utils> utils = mockStatic(Utils.class)) {
-      utils.when(() -> Utils.schedule(any(), any(), anyLong(), any())).thenReturn(cf);
-      final WatcherAdapter<HasMetadata> watcher = new WatcherAdapter<>();
-      final WatchManager<HasMetadata> awm = withDefaultWatchManager(watcher);
-      awm.baseOperation.context = Mockito.mock(OperationContext.class);
-      Mockito.when(awm.baseOperation.context.getExecutor()).thenReturn(executor);
+    final WatcherAdapter<HasMetadata> watcher = new WatcherAdapter<>();
+    final AtomicReference<CompletableFuture<Void>> scheduled = new AtomicReference<>();
+    final WatchManager<HasMetadata> awm = new WatchManager<HasMetadata>(
+        watcher, mock(ListOptions.class, RETURNS_DEEP_STUBS), 1, 60_000) {
+      @Override
+      protected CompletableFuture<Void> schedule(Runnable command, long delay, TimeUnit unit) {
+        CompletableFuture<Void> f = new CompletableFuture<>();
+        scheduled.set(f);
+        return f;
+      }
+    };
 
-      awm.scheduleReconnect(new WatchRequestState());
-      // When
-      awm.cancelReconnect();
-      // Then
-      verify(cf, times(1)).cancel(true);
-    }
+    awm.scheduleReconnect(new WatchRequestState());
+    // When
+    awm.cancelReconnect();
+    // Then
+    assertThat(scheduled.get()).isNotNull();
+    assertThat(scheduled.get().isCancelled()).isTrue();
   }
 
   @Test

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManagerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManagerTest.java
@@ -104,11 +104,10 @@ class WatchConnectionManagerTest {
   @Test
   void testFailSafeReconnect() throws MalformedURLException {
     CompletableFuture<WebSocket> future = new CompletableFuture<>();
-    CountDownLatch reconnect = new CountDownLatch(1);
     AtomicReference<Runnable> scheduledTask = new AtomicReference<>();
     AtomicReference<Long> scheduledDelayMs = new AtomicReference<>();
 
-    WatchConnectionManager<?, ?> manager = setupWebSocketWatch(future, reconnect, (command, delay, unit) -> {
+    WatchConnectionManager<?, ?> manager = setupWebSocketWatch(future, (command, delay, unit) -> {
       scheduledTask.set(command);
       scheduledDelayMs.set(unit.toMillis(delay));
       return new CompletableFuture<>();
@@ -136,6 +135,11 @@ class WatchConnectionManagerTest {
   private WatchConnectionManager<?, ?> setupWebSocketWatch(CompletableFuture<WebSocket> future, CountDownLatch reconnect)
       throws MalformedURLException {
     return setupWebSocketWatch(future, reconnect, null);
+  }
+
+  private WatchConnectionManager<?, ?> setupWebSocketWatch(CompletableFuture<WebSocket> future, TestScheduler testScheduler)
+      throws MalformedURLException {
+    return setupWebSocketWatch(future, new CountDownLatch(1), testScheduler);
   }
 
   private WatchConnectionManager<?, ?> setupWebSocketWatch(CompletableFuture<WebSocket> future, CountDownLatch reconnect,

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManagerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManagerTest.java
@@ -20,8 +20,9 @@ import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.internal.AbstractWatchManager.WatchRequestState;
 import io.fabric8.kubernetes.client.http.HttpClient;
 import io.fabric8.kubernetes.client.http.WebSocket;
-import org.awaitility.Awaitility;
+import io.fabric8.kubernetes.client.utils.Utils;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -30,8 +31,12 @@ import java.net.URL;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -109,9 +114,28 @@ class WatchConnectionManagerTest {
     future.complete(mock);
 
     WatchRequestState state = manager.latestRequestState;
-    manager.setWatchEndCheckMs(0); // should nearly immediately trigger another start
-    manager.closeRequest();
-    Awaitility.await().atMost(1, TimeUnit.SECONDS).until(() -> state != manager.latestRequestState);
+    manager.setWatchEndCheckMs(0);
+
+    // Intercept Utils.schedule so the fail-safe reconnect runs on the test thread
+    // instead of going through SHARED_SCHEDULER, which made this assertion timing-sensitive.
+    AtomicReference<Runnable> scheduledTask = new AtomicReference<>();
+    AtomicReference<Long> scheduledDelay = new AtomicReference<>();
+    try (MockedStatic<Utils> utils = Mockito.mockStatic(Utils.class, Mockito.CALLS_REAL_METHODS)) {
+      utils.when(() -> Utils.schedule(Mockito.any(), Mockito.any(Runnable.class), Mockito.anyLong(), Mockito.any()))
+          .thenAnswer(inv -> {
+            scheduledTask.set(inv.getArgument(1));
+            scheduledDelay.set(inv.getArgument(2));
+            return new CompletableFuture<Void>();
+          });
+
+      manager.closeRequest();
+
+      assertNotNull(scheduledTask.get(), "expected closeRequest to schedule the fail-safe reconnect");
+      assertEquals(0L, scheduledDelay.get(), "fail-safe reconnect should be scheduled with watchEndCheckMs");
+      scheduledTask.get().run();
+      assertNotSame(state, manager.latestRequestState,
+          "fail-safe reconnect should have replaced latestRequestState with a new watch");
+    }
   }
 
   private WatchConnectionManager<?, ?> setupWebSocketWatch(CompletableFuture<WebSocket> future, CountDownLatch reconnect)

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManagerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManagerTest.java
@@ -20,9 +20,7 @@ import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.internal.AbstractWatchManager.WatchRequestState;
 import io.fabric8.kubernetes.client.http.HttpClient;
 import io.fabric8.kubernetes.client.http.WebSocket;
-import io.fabric8.kubernetes.client.utils.Utils;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -104,42 +102,44 @@ class WatchConnectionManagerTest {
   }
 
   @Test
-  void testFailSafeReconnect() throws MalformedURLException, InterruptedException {
+  void testFailSafeReconnect() throws MalformedURLException {
     CompletableFuture<WebSocket> future = new CompletableFuture<>();
     CountDownLatch reconnect = new CountDownLatch(1);
+    AtomicReference<Runnable> scheduledTask = new AtomicReference<>();
+    AtomicReference<Long> scheduledDelayMs = new AtomicReference<>();
 
-    WatchConnectionManager<?, ?> manager = setupWebSocketWatch(future, reconnect);
+    WatchConnectionManager<?, ?> manager = setupWebSocketWatch(future, reconnect, (command, delay, unit) -> {
+      scheduledTask.set(command);
+      scheduledDelayMs.set(unit.toMillis(delay));
+      return new CompletableFuture<>();
+    });
 
     WebSocket mock = Mockito.mock(WebSocket.class);
     future.complete(mock);
 
     WatchRequestState state = manager.latestRequestState;
     manager.setWatchEndCheckMs(0);
+    manager.closeRequest();
 
-    // Intercept Utils.schedule so the fail-safe reconnect runs on the test thread
-    // instead of going through SHARED_SCHEDULER, which made this assertion timing-sensitive.
-    AtomicReference<Runnable> scheduledTask = new AtomicReference<>();
-    AtomicReference<Long> scheduledDelay = new AtomicReference<>();
-    try (MockedStatic<Utils> utils = Mockito.mockStatic(Utils.class, Mockito.CALLS_REAL_METHODS)) {
-      utils.when(() -> Utils.schedule(Mockito.any(), Mockito.any(Runnable.class), Mockito.anyLong(), Mockito.any()))
-          .thenAnswer(inv -> {
-            scheduledTask.set(inv.getArgument(1));
-            scheduledDelay.set(inv.getArgument(2));
-            return new CompletableFuture<Void>();
-          });
+    assertNotNull(scheduledTask.get(), "expected closeRequest to schedule the fail-safe reconnect");
+    assertEquals(0L, scheduledDelayMs.get(), "fail-safe reconnect should be scheduled with watchEndCheckMs");
+    scheduledTask.get().run();
+    assertNotSame(state, manager.latestRequestState,
+        "fail-safe reconnect should have replaced latestRequestState with a new watch");
+  }
 
-      manager.closeRequest();
-
-      assertNotNull(scheduledTask.get(), "expected closeRequest to schedule the fail-safe reconnect");
-      assertEquals(0L, scheduledDelay.get(), "fail-safe reconnect should be scheduled with watchEndCheckMs");
-      scheduledTask.get().run();
-      assertNotSame(state, manager.latestRequestState,
-          "fail-safe reconnect should have replaced latestRequestState with a new watch");
-    }
+  @FunctionalInterface
+  private interface TestScheduler {
+    CompletableFuture<Void> schedule(Runnable command, long delay, TimeUnit unit);
   }
 
   private WatchConnectionManager<?, ?> setupWebSocketWatch(CompletableFuture<WebSocket> future, CountDownLatch reconnect)
       throws MalformedURLException {
+    return setupWebSocketWatch(future, reconnect, null);
+  }
+
+  private WatchConnectionManager<?, ?> setupWebSocketWatch(CompletableFuture<WebSocket> future, CountDownLatch reconnect,
+      TestScheduler testScheduler) throws MalformedURLException {
     HttpClient client = Mockito.mock(HttpClient.class, Mockito.RETURNS_DEEP_STUBS);
     BaseOperation baseOperation = AbstractWatchManagerTest.mockOperation();
     Mockito.when(baseOperation.getNamespacedUrl()).thenReturn(new URL("http://localhost"));
@@ -152,6 +152,14 @@ class WatchConnectionManagerTest {
       @Override
       void scheduleReconnect(WatchRequestState state) {
         reconnect.countDown();
+      }
+
+      @Override
+      protected CompletableFuture<Void> schedule(Runnable command, long delay, TimeUnit unit) {
+        if (testScheduler != null) {
+          return testScheduler.schedule(command, delay, unit);
+        }
+        return super.schedule(command, delay, unit);
       }
     };
   }


### PR DESCRIPTION
## Summary

`WatchConnectionManagerTest.testFailSafeReconnect` was flaky on Windows CI: the 1-second `Awaitility.await()` raced `Utils.schedule` → `SHARED_SCHEDULER` under load, occasionally timing out before the fail-safe reconnect runnable could fire.

This change introduces a `protected schedule(Runnable, long, TimeUnit)` seam on `AbstractWatchManager` that wraps `Utils.schedule(executor, ...)`. The two prior direct call sites in `closeRequest()` and `scheduleReconnect()` now route through it. Tests override the seam in anonymous subclasses to drive the timing deterministically — no `MockedStatic<Utils>` needed.

- `testFailSafeReconnect` captures the scheduled runnable + delay, runs it on the test thread, and asserts a new `latestRequestState` was assigned.
- `cancelReconnectNonNullAttempt` drops `MockedStatic<Utils>` in favor of overriding the seam and asserting `CompletableFuture#isCancelled()` on a real future.

Verified with 10/10 stress runs in a constrained Docker container (`--cpus=2 --memory=7g --cpuset-cpus="0,1"`) approximating Windows CI scheduling pressure.

Closes #7813