### PR TITLE
chore(deps): pin org.junit* to v5, bump approvaltests to 30.1.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,9 @@ updates:
   ignore:
   - dependency-name: "io.vertx:*"
     update-types: ["version-update:semver-major"]
+  # JUnit 6 raises the runtime baseline to Java 17; we still target Java 11.
+  - dependency-name: "org.junit*:*"
+    update-types: ["version-update:semver-major"]
   groups:
     bouncycastle:
       patterns:

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <junit.version>5.13.4</junit.version>
     <assertj.core.version>3.27.7</assertj.core.version>
     <awaitility.version>4.3.0</awaitility.version>
-    <approvaltests.version>30.1.0</approvaltests.version>
+    <approvaltests.version>30.1.1</approvaltests.version>
     <bouncycastle.version>1.84</bouncycastle.version>
     <bc-fips.version>2.1.2</bc-fips.version>
     <bcpkix-fips.version>2.1.11</bcpkix-fips.version>


### PR DESCRIPTION
## Summary

JUnit 6 raises the runtime baseline to Java 17, but this project still
targets Java 11. Dependabot grouped `org.junit*` together with `approvaltests`
under `testing` in #7791 and proposed both bumps in a single PR, which blocks
the harmless approvaltests patch behind a JUnit 5 → 6 major we can't take yet.

This PR:

- Adds an `ignore` rule in `.github/dependabot.yml` for `org.junit*:*`
  semver-major updates. JUnit 5 minors keep flowing through the existing
  `testing` group.
- Bumps `approvaltests.version` 30.1.0 → 30.1.1 (the only safe slice of
  #7791).

Once this lands, #7791 should be closed; Dependabot will re-issue the
testing-group bump without the JUnit 6 piece.

Closes #7791