### PR TITLE
chore(sonar): suppress BLOCKER false positives in client code

### DIFF
--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -240,6 +240,7 @@ public class Config extends SundrioConfig {
   /*
    * The Builder is generated in SundrioConfig, if new fields need to be added here, please make sure to add them there too.
    */
+  @SuppressWarnings("java:S6437") // DEFAULT_CLIENT_KEY_PASSPHRASE is the JVM cacerts default ("changeit"), not a credential
   protected Config(SundrioConfig config, Boolean shouldSetDefaultValues) {
     if (Boolean.TRUE.equals(shouldSetDefaultValues)) {
       this.setMasterUrl(DEFAULT_MASTER_URL);

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/WithRequestCallable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/WithRequestCallable.java
@@ -30,6 +30,7 @@ public class WithRequestCallable<C extends Client> implements FunctionCallable<C
   }
 
   @Override
+  @SuppressWarnings("java:S2095") // newClient returns a transient view sharing the parent client's resources; closing it would close the underlying shared client
   public <O> O call(Function<C, O> function) {
     C newClient = (C) this.client.newClient(requestConfig).adapt(this.client.getClass());
     return function.apply(newClient);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
@@ -173,6 +173,7 @@ public class ExecWebSocketListener implements ExecWatch, AutoCloseable, WebSocke
     this.serialExecutor = new SerialExecutor(executor);
   }
 
+  @SuppressWarnings("java:S2095") // channel wraps caller-provided OutputStream; closing it would close the caller's stream
   private ListenerStream createStream(String name, StreamContext streamContext) {
     ListenerStream stream = new ListenerStream(name);
     if (streamContext == null) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PortForwarderWebsocket.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PortForwarderWebsocket.java
@@ -61,6 +61,7 @@ public class PortForwarderWebsocket {
     this.connectTimeoutMills = connectTimeoutMillis;
   }
 
+  @SuppressWarnings("java:S2095") // server is closed via the returned LocalPortForward.close()
   public LocalPortForward forward(final URL resourceBaseUrl, final int port, final InetAddress localHost, final int localPort) {
     try {
       InetSocketAddress inetSocketAddress = createNewInetSocketAddress(localHost, localPort);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
@@ -412,6 +412,7 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
   }
 
   @Override
+  @SuppressWarnings("java:S3516") // return value is part of the public API; cannot be changed without a breaking release
   public boolean copy(Path destination) {
     try {
       if (Utils.isNotNullOrEmpty(getContext().getFile())) {

--- a/zjsonpatch/src/main/java/io/fabric8/zjsonpatch/JsonDiff.java
+++ b/zjsonpatch/src/main/java/io/fabric8/zjsonpatch/JsonDiff.java
@@ -344,6 +344,7 @@ public class JsonDiff {
         if (flags.contains(DiffFlags.ADD_ORIGINAL_VALUE_ON_REPLACE)) {
           jsonNode.set(FROM_VALUE, diff.getSrcValue());
         }
+        // fallthrough
       case ADD:
       case TEST:
         jsonNode.put(PATH, diff.getPath().toString());


### PR DESCRIPTION
## Description

Suppresses 6 SonarCloud BLOCKER findings that were determined to be false positives or intentional patterns during a backlog grooming pass.

Each suppression is accompanied by a one-line comment explaining why the finding does not apply, so the rationale travels with the code.

### Suppressed findings

| Rule  | File | Reason |
|-------|------|--------|
| S6437 | `kubernetes-client-api/.../Config.java` | `DEFAULT_CLIENT_KEY_PASSPHRASE` is the JVM `cacerts` default (`"changeit"`), not a credential |
| S2095 | `kubernetes-client-api/.../WithRequestCallable.java` | `newClient` returns a transient view sharing the parent client's resources |
| S2095 | `kubernetes-client/.../ExecWebSocketListener.java` | Channel wraps the caller-provided `OutputStream`; closing it would close the caller's stream |
| S2095 | `kubernetes-client/.../PortForwarderWebsocket.java` | `ServerSocketChannel` is closed via the returned `LocalPortForward.close()` |
| S3516 | `kubernetes-client/.../PodOperationsImpl.java` | Return value of `copy(Path)` is part of the public API; cannot be changed without a breaking release |
| S128  | `zjsonpatch/.../JsonDiff.java` | `case REPLACE` intentionally falls through to `case ADD`/`TEST` to share `PATH`+`VALUE` writes |

### Related

Companion to:
- #7825 — Remove duplicated `logger` and `resource` fields (S1845, S2387)
- #7826 — Add explicit assertions to indirect-verification tests (S2699)

Together this PR + those two issues take SonarCloud BLOCKERs on this project from 12 → 0.