### PR TITLE
test(kubernetes-client-api): add TestWebSocket fake for listener tests

### DIFF
--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/TestWebSocket.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/TestWebSocket.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.http;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+/**
+ * Hand-written {@link WebSocket} fake intended to replace {@code Mockito.mock(WebSocket.class)} in
+ * listener tests. It captures sent payloads (defensive copies), publishes the first
+ * {@link #send(ByteBuffer)} and the first {@link #sendClose(int, String)} through
+ * {@link CompletableFuture}s for race-free happens-before assertions, and supports scripted
+ * per-{@link #request()} actions.
+ * <p>
+ * Each call to {@link #getSent()} and {@link #firstSent()} returns a fresh read-only view over
+ * the captured bytes, so reads through one view never advance the position observed by another
+ * caller.
+ */
+public final class TestWebSocket implements WebSocket {
+
+  private final List<ByteBuffer> sent = new CopyOnWriteArrayList<>();
+  private final CompletableFuture<ByteBuffer> firstSent = new CompletableFuture<>();
+  private final CompletableFuture<CloseFrame> firstClose = new CompletableFuture<>();
+  private final Deque<Runnable> onRequestActions = new ConcurrentLinkedDeque<>();
+  private final AtomicInteger requestCount = new AtomicInteger();
+
+  /**
+   * Registers an action to run on the next un-handled {@link #request()} call. Actions run in FIFO
+   * order, one per {@code request()}; once the queue is exhausted, subsequent {@code request()}
+   * calls only increment the counter.
+   */
+  public TestWebSocket onRequest(Runnable action) {
+    onRequestActions.addLast(Objects.requireNonNull(action, "action"));
+    return this;
+  }
+
+  /**
+   * Snapshot of all payloads sent so far, in send order. Each entry is a fresh read-only view
+   * over the defensive copy taken at {@link #send(ByteBuffer)} time; reads through one view do
+   * not affect the position observed by other callers.
+   */
+  public List<ByteBuffer> getSent() {
+    return Collections.unmodifiableList(
+        sent.stream().map(ByteBuffer::asReadOnlyBuffer).collect(Collectors.toList()));
+  }
+
+  /**
+   * Completes with a fresh read-only view over the defensive copy of the first
+   * {@link #send(ByteBuffer)} payload. A new view is produced for each call so reads do not leak
+   * position state between callers.
+   */
+  public CompletableFuture<ByteBuffer> firstSent() {
+    return firstSent.thenApply(ByteBuffer::asReadOnlyBuffer);
+  }
+
+  /**
+   * Completes with the {@link CloseFrame} captured from the first {@link #sendClose(int, String)}
+   * call.
+   */
+  public CompletableFuture<CloseFrame> firstClose() {
+    return firstClose;
+  }
+
+  /**
+   * Number of {@link #request()} invocations observed so far.
+   */
+  public int requestCount() {
+    return requestCount.get();
+  }
+
+  @Override
+  public boolean send(ByteBuffer buffer) {
+    final ByteBuffer copy = ByteBuffer.allocate(buffer.remaining());
+    copy.put(buffer.duplicate());
+    copy.flip();
+    sent.add(copy);
+    firstSent.complete(copy);
+    return true;
+  }
+
+  @Override
+  public boolean sendClose(int code, String reason) {
+    firstClose.complete(new CloseFrame(code, reason));
+    return true;
+  }
+
+  @Override
+  public long queueSize() {
+    return 0L;
+  }
+
+  @Override
+  public void request() {
+    requestCount.incrementAndGet();
+    final Runnable action = onRequestActions.pollFirst();
+    if (action != null) {
+      action.run();
+    }
+  }
+
+  /**
+   * Immutable capture of a {@link #sendClose(int, String)} call.
+   */
+  public static final class CloseFrame {
+
+    private final int code;
+    private final String reason;
+
+    public CloseFrame(int code, String reason) {
+      this.code = code;
+      this.reason = reason;
+    }
+
+    public int getCode() {
+      return code;
+    }
+
+    public String getReason() {
+      return reason;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof CloseFrame)) {
+        return false;
+      }
+      final CloseFrame other = (CloseFrame) o;
+      return code == other.code && Objects.equals(reason, other.reason);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(code, reason);
+    }
+
+    @Override
+    public String toString() {
+      return "CloseFrame{code=" + code + ", reason=" + reason + "}";
+    }
+  }
+}

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/TestWebSocketTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/TestWebSocketTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.http;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class TestWebSocketTest {
+
+  @Test
+  void send_capturesDefensiveCopyOfPayload() {
+    final TestWebSocket ws = new TestWebSocket();
+    final byte[] backing = "hello".getBytes(StandardCharsets.UTF_8);
+    final ByteBuffer source = ByteBuffer.wrap(backing);
+
+    ws.send(source);
+    // Mutate the original backing array after send returns: the capture must not be affected.
+    backing[0] = 'X';
+
+    assertThat(ws.getSent()).singleElement().satisfies(captured -> {
+      final byte[] out = new byte[captured.remaining()];
+      captured.duplicate().get(out);
+      assertThat(new String(out, StandardCharsets.UTF_8)).isEqualTo("hello");
+      assertThat(captured.isReadOnly()).isTrue();
+    });
+  }
+
+  @Test
+  void send_completesFirstSent() {
+    final TestWebSocket ws = new TestWebSocket();
+
+    ws.send(ByteBuffer.wrap("payload".getBytes(StandardCharsets.UTF_8)));
+
+    assertThat(ws.firstSent())
+        .succeedsWithin(1, TimeUnit.SECONDS)
+        .satisfies(captured -> {
+          final byte[] out = new byte[captured.remaining()];
+          captured.duplicate().get(out);
+          assertThat(new String(out, StandardCharsets.UTF_8)).isEqualTo("payload");
+        });
+  }
+
+  @Test
+  void send_capturesIndependentlyWhenSourceBufferIsReusedAcrossSends() {
+    // Mirrors PortForwarderWebsocketListener.pipe(): a single buffer is cleared, filled, and
+    // sent on each iteration. Captures must remain independent across iterations.
+    final TestWebSocket ws = new TestWebSocket();
+    final ByteBuffer reused = ByteBuffer.allocate(4);
+
+    reused.put("AAAA".getBytes(StandardCharsets.UTF_8)).flip();
+    ws.send(reused);
+    reused.clear();
+    reused.put("BBBB".getBytes(StandardCharsets.UTF_8)).flip();
+    ws.send(reused);
+
+    assertThat(ws.getSent()).hasSize(2).satisfies(snapshots -> {
+      final byte[] first = new byte[snapshots.get(0).remaining()];
+      final byte[] second = new byte[snapshots.get(1).remaining()];
+      snapshots.get(0).duplicate().get(first);
+      snapshots.get(1).duplicate().get(second);
+      assertThat(new String(first, StandardCharsets.UTF_8)).isEqualTo("AAAA");
+      assertThat(new String(second, StandardCharsets.UTF_8)).isEqualTo("BBBB");
+    });
+  }
+
+  @Test
+  void getSent_andFirstSent_returnIndependentViews() {
+    // Reading bytes through one accessor must not advance the position seen by another caller.
+    final TestWebSocket ws = new TestWebSocket();
+    ws.send(ByteBuffer.wrap("payload".getBytes(StandardCharsets.UTF_8)));
+
+    // Drain the read-only view returned by getSent() — its position advances to limit.
+    final ByteBuffer first = ws.getSent().get(0);
+    final byte[] drained = new byte[first.remaining()];
+    first.get(drained);
+    assertThat(first.hasRemaining()).isFalse();
+
+    // A subsequent caller through either accessor must see a fresh, undrained view.
+    assertThat(ws.getSent().get(0).remaining()).isEqualTo("payload".length());
+    assertThat(ws.firstSent().getNow(null)).isNotNull()
+        .satisfies(buf -> assertThat(buf.remaining()).isEqualTo("payload".length()));
+  }
+
+  @Test
+  void firstSent_capturesFirstPayloadOnly() {
+    final TestWebSocket ws = new TestWebSocket();
+
+    ws.send(ByteBuffer.wrap("first".getBytes(StandardCharsets.UTF_8)));
+    ws.send(ByteBuffer.wrap("second".getBytes(StandardCharsets.UTF_8)));
+
+    assertThat(ws.firstSent())
+        .succeedsWithin(1, TimeUnit.SECONDS)
+        .satisfies(captured -> {
+          final byte[] out = new byte[captured.remaining()];
+          captured.duplicate().get(out);
+          assertThat(new String(out, StandardCharsets.UTF_8)).isEqualTo("first");
+        });
+    assertThat(ws.getSent()).hasSize(2);
+  }
+
+  @Test
+  void sendClose_completesFirstCloseWithCodeAndReason() {
+    final TestWebSocket ws = new TestWebSocket();
+
+    ws.sendClose(1002, "Protocol error");
+
+    assertThat(ws.firstClose())
+        .succeedsWithin(1, TimeUnit.SECONDS)
+        .isEqualTo(new TestWebSocket.CloseFrame(1002, "Protocol error"));
+  }
+
+  @Test
+  void sendClose_capturesFirstCallOnly() {
+    final TestWebSocket ws = new TestWebSocket();
+
+    ws.sendClose(1000, "normal");
+    ws.sendClose(1002, "second");
+
+    assertThat(ws.firstClose())
+        .succeedsWithin(1, TimeUnit.SECONDS)
+        .isEqualTo(new TestWebSocket.CloseFrame(1000, "normal"));
+  }
+
+  @Test
+  void request_runsScriptedActionsInOrderThenIsNoOp() {
+    final TestWebSocket ws = new TestWebSocket();
+    final StringBuilder trace = new StringBuilder();
+    ws.onRequest(() -> trace.append("a")).onRequest(() -> trace.append("b"));
+
+    ws.request();
+    ws.request();
+    ws.request();
+
+    assertThat(trace.toString()).isEqualTo("ab");
+    assertThat(ws.requestCount()).isEqualTo(3);
+  }
+
+  @Test
+  void request_incrementsCounterEvenWithoutScriptedActions() {
+    final TestWebSocket ws = new TestWebSocket();
+
+    ws.request();
+    ws.request();
+
+    assertThat(ws.requestCount()).isEqualTo(2);
+  }
+
+  @Test
+  void onRequest_rejectsNullAction() {
+    final TestWebSocket ws = new TestWebSocket();
+
+    assertThatNullPointerException().isThrownBy(() -> ws.onRequest(null));
+  }
+
+  @Test
+  void queueSize_returnsZero() {
+    final TestWebSocket ws = new TestWebSocket();
+
+    ws.send(ByteBuffer.wrap(new byte[] { 1, 2, 3 }));
+
+    assertThat(ws.queueSize()).isZero();
+  }
+
+  @Test
+  void closeFrame_equalsAndHashCode() {
+    final TestWebSocket.CloseFrame a = new TestWebSocket.CloseFrame(1000, "normal");
+    final TestWebSocket.CloseFrame b = new TestWebSocket.CloseFrame(1000, "normal");
+    final TestWebSocket.CloseFrame c = new TestWebSocket.CloseFrame(1002, "normal");
+
+    assertThat(a).isEqualTo(b).hasSameHashCodeAs(b);
+    assertThat(a).isNotEqualTo(c);
+  }
+}

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListenerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListenerTest.java
@@ -21,12 +21,11 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.ExecListener;
 import io.fabric8.kubernetes.client.dsl.internal.PodOperationContext.StreamContext;
 import io.fabric8.kubernetes.client.http.StandardHttpRequest;
-import io.fabric8.kubernetes.client.http.WebSocket;
+import io.fabric8.kubernetes.client.http.TestWebSocket;
 import io.fabric8.kubernetes.client.http.WebSocketHandshakeException;
 import io.fabric8.kubernetes.client.http.WebSocketUpgradeResponse;
 import io.fabric8.kubernetes.client.utils.KubernetesSerialization;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -50,8 +49,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.verify;
-import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 class ExecWebSocketListenerTest {
 
@@ -87,18 +84,17 @@ class ExecWebSocketListenerTest {
 
   @Test
   void testSendShouldTruncateAndSendFlaggedWebSocketData() {
-    final WebSocket mockedWebSocket = Mockito.mock(WebSocket.class);
-    Mockito.when(mockedWebSocket.send(Mockito.any())).thenReturn(true);
-
+    final TestWebSocket webSocket = new TestWebSocket();
     ExecWebSocketListener listner = newExecWebSocketListener(new PodOperationContext());
 
-    listner.onOpen(mockedWebSocket);
+    listner.onOpen(webSocket);
     final byte[] toSend = new byte[] { 1, 3, 3, 7, 0 };
 
     listner.sendWithErrorChecking(toSend, 0, 4);
 
-    verify(mockedWebSocket, times(1))
-        .send(ByteBuffer.wrap(new byte[] { (byte) 0, (byte) 1, (byte) 3, (byte) 3, (byte) 7 }));
+    assertThat(webSocket.getSent())
+        .singleElement()
+        .isEqualTo(ByteBuffer.wrap(new byte[] { (byte) 0, (byte) 1, (byte) 3, (byte) 3, (byte) 7 }));
   }
 
   @Test
@@ -127,19 +123,18 @@ class ExecWebSocketListenerTest {
   @Test
   void testGracefulClose() {
     ExecWebSocketListener listener = newExecWebSocketListener(new PodOperationContext());
-    WebSocket mock = Mockito.mock(WebSocket.class);
-    listener.onOpen(mock);
+    TestWebSocket webSocket = new TestWebSocket();
+    listener.onOpen(webSocket);
     listener.close();
 
     assertFalse(listener.exitCode().isDone());
-    verify(mock).sendClose(Mockito.anyInt(), Mockito.anyString());
+    assertThat(webSocket.firstClose()).succeedsWithin(1, TimeUnit.SECONDS);
   }
 
   @Test
   void testOnClose() {
     ExecWebSocketListener listener = newExecWebSocketListener(new PodOperationContext());
-    WebSocket mock = Mockito.mock(WebSocket.class);
-    listener.onClose(mock, 1000, "testing");
+    listener.onClose(new TestWebSocket(), 1000, "testing");
 
     assertNull(listener.exitCode().join());
   }
@@ -172,11 +167,11 @@ class ExecWebSocketListenerTest {
     final ExecutorService asyncExecutor = Executors.newSingleThreadExecutor();
     try {
       final ExecWebSocketListener listener = new ExecWebSocketListener(context, asyncExecutor, new KubernetesSerialization());
-      final WebSocket mockedWebSocket = Mockito.mock(WebSocket.class);
-      listener.onOpen(mockedWebSocket);
+      final TestWebSocket webSocket = new TestWebSocket();
+      listener.onOpen(webSocket);
 
       // Channel 1 (stdout) message: queues an async write that will block until released
-      listener.onMessage(mockedWebSocket, ByteBuffer.wrap(new byte[] { (byte) 1, (byte) 'p', (byte) 'a', (byte) 'y' }));
+      listener.onMessage(webSocket, ByteBuffer.wrap(new byte[] { (byte) 1, (byte) 'p', (byte) 'a', (byte) 'y' }));
       assertTrue(writeStarted.await(2, TimeUnit.SECONDS), "expected the channel 1 async write to start");
 
       // Channel 3 (exit-success) message fires while the previous write is still in flight
@@ -184,7 +179,7 @@ class ExecWebSocketListenerTest {
           .getBytes(StandardCharsets.UTF_8);
       final ByteBuffer channel3 = ByteBuffer.allocate(successJson.length + 1).put((byte) 3).put(successJson);
       channel3.flip();
-      listener.onMessage(mockedWebSocket, channel3);
+      listener.onMessage(webSocket, channel3);
 
       // The exitCode must NOT complete before the pending channel 1 write has been processed.
       // Without the fix, exitCode is completed synchronously inside onMessage and this assertion fails.
@@ -208,8 +203,8 @@ class ExecWebSocketListenerTest {
 
     final ExecWebSocketListener listener = new ExecWebSocketListener(new PodOperationContext(), manualExecutor,
         new KubernetesSerialization());
-    final WebSocket mockedWebSocket = Mockito.mock(WebSocket.class);
-    listener.onOpen(mockedWebSocket);
+    final TestWebSocket webSocket = new TestWebSocket();
+    listener.onOpen(webSocket);
 
     // Channel 3: NonZeroExitCode=1 status frame
     final byte[] failureJson = new KubernetesSerialization().asJson(new StatusBuilder()
@@ -220,12 +215,12 @@ class ExecWebSocketListenerTest {
     final ByteBuffer channel3 = ByteBuffer.allocate(failureJson.length + 1)
         .put((byte) 3).put(failureJson);
     channel3.flip();
-    listener.onMessage(mockedWebSocket, channel3);
+    listener.onMessage(webSocket, channel3);
     assertFalse(listener.exitCode().isDone(),
         "exitCode must remain pending while handleExitStatus is queued in the executor");
 
     // The connection closes before the deferred handleExitStatus has a chance to run
-    listener.onError(mockedWebSocket, new IOException("Connection was closed"));
+    listener.onError(webSocket, new IOException("Connection was closed"));
     assertFalse(listener.exitCode().isDone(),
         "exitCode must not be completed exceptionally while the queued handleExitStatus is still pending");
 
@@ -261,7 +256,7 @@ class ExecWebSocketListenerTest {
         .execListener(execListener)
         .build();
     final ExecWebSocketListener listener = new ExecWebSocketListener(context, manualExecutor, new KubernetesSerialization());
-    listener.onOpen(Mockito.mock(WebSocket.class));
+    listener.onOpen(new TestWebSocket());
 
     final IOException boom = new IOException("boom");
     listener.onError(null, boom);
@@ -301,7 +296,7 @@ class ExecWebSocketListenerTest {
         .execListener(execListener)
         .build();
     final ExecWebSocketListener listener = new ExecWebSocketListener(context, manualExecutor, new KubernetesSerialization());
-    listener.onOpen(Mockito.mock(WebSocket.class));
+    listener.onOpen(new TestWebSocket());
 
     final WebSocketUpgradeResponse upgradeResponse = new WebSocketUpgradeResponse(
         new StandardHttpRequest.Builder().uri("https://localhost:8443/api/v1/namespaces/ns/pods/mypod").build(),
@@ -331,7 +326,7 @@ class ExecWebSocketListenerTest {
     final Executor manualExecutor = manualQueue::offer;
     final ExecWebSocketListener listener = new ExecWebSocketListener(new PodOperationContext(), manualExecutor,
         new KubernetesSerialization());
-    listener.onOpen(Mockito.mock(WebSocket.class));
+    listener.onOpen(new TestWebSocket());
 
     listener.onError(null, new IOException("boom"));
     assertFalse(listener.exitCode().isDone(),
@@ -374,15 +369,15 @@ class ExecWebSocketListenerTest {
     final ExecutorService asyncExecutor = Executors.newSingleThreadExecutor();
     try {
       final ExecWebSocketListener listener = new ExecWebSocketListener(context, asyncExecutor, new KubernetesSerialization());
-      final WebSocket mockedWebSocket = Mockito.mock(WebSocket.class);
-      listener.onOpen(mockedWebSocket);
+      final TestWebSocket webSocket = new TestWebSocket();
+      listener.onOpen(webSocket);
 
       // Channel 1 (stdout) message: queues an async write that will block until released
-      listener.onMessage(mockedWebSocket, ByteBuffer.wrap(new byte[] { (byte) 1, (byte) 'p', (byte) 'a', (byte) 'y' }));
+      listener.onMessage(webSocket, ByteBuffer.wrap(new byte[] { (byte) 1, (byte) 'p', (byte) 'a', (byte) 'y' }));
       assertTrue(writeStarted.await(2, TimeUnit.SECONDS), "expected the channel 1 async write to start");
 
       // Channel 2 (stderr) with terminateOnError=true: completes exitCode exceptionally
-      listener.onMessage(mockedWebSocket,
+      listener.onMessage(webSocket,
           ByteBuffer.wrap(new byte[] { (byte) 2, (byte) 'b', (byte) 'o', (byte) 'o', (byte) 'm' }));
 
       // The exitCode must NOT complete (exceptionally) before the pending channel 1 write has been processed.
@@ -426,7 +421,7 @@ class ExecWebSocketListenerTest {
         .terminateOnError(true)
         .build();
     final ExecWebSocketListener listener = new ExecWebSocketListener(context, manualExecutor, new KubernetesSerialization());
-    listener.onOpen(Mockito.mock(WebSocket.class));
+    listener.onOpen(new TestWebSocket());
 
     // Channel 2 with terminateOnError=true: queues exitCode.completeExceptionally(...)
     listener.onMessage(null,
@@ -481,14 +476,14 @@ class ExecWebSocketListenerTest {
         .execListener(execListener)
         .build();
     final ExecWebSocketListener listener = new ExecWebSocketListener(context, manualExecutor, new KubernetesSerialization());
-    final WebSocket mockedWebSocket = Mockito.mock(WebSocket.class);
-    listener.onOpen(mockedWebSocket);
+    final TestWebSocket webSocket = new TestWebSocket();
+    listener.onOpen(webSocket);
 
     // First terminal event: transport-level error.
-    listener.onError(mockedWebSocket, new IOException("first"));
+    listener.onError(webSocket, new IOException("first"));
     // Follow-up events that the framework may still deliver: a second onError, plus a late onClose.
-    listener.onError(mockedWebSocket, new IOException("second"));
-    listener.onClose(mockedWebSocket, 1000, "late");
+    listener.onError(webSocket, new IOException("second"));
+    listener.onClose(webSocket, 1000, "late");
 
     Runnable next;
     while ((next = manualQueue.poll()) != null) {

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/PortForwarderWebsocketListenerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/PortForwarderWebsocketListenerTest.java
@@ -15,7 +15,7 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal;
 
-import io.fabric8.kubernetes.client.http.WebSocket;
+import io.fabric8.kubernetes.client.http.TestWebSocket;
 import io.fabric8.kubernetes.client.utils.CommonThreadPool;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.Awaitility;
@@ -31,24 +31,17 @@ import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class PortForwarderWebsocketListenerTest {
 
-  private WebSocket webSocket;
+  private TestWebSocket webSocket;
   private ReadableByteChannel in;
   private WritableByteChannel out;
   private ByteArrayOutputStream outputContent;
@@ -56,7 +49,7 @@ class PortForwarderWebsocketListenerTest {
 
   @BeforeEach
   void setUp() {
-    webSocket = mock(WebSocket.class);
+    webSocket = new TestWebSocket();
     in = Channels.newChannel(new ByteArrayInputStream("THIS IS A TEST".getBytes(StandardCharsets.UTF_8)));
     outputContent = new ByteArrayOutputStream();
     out = Channels.newChannel(outputContent);
@@ -74,28 +67,18 @@ class PortForwarderWebsocketListenerTest {
 
   @Test
   void onOpen_shouldPipeInChannelToWebSocket() {
-    // Snapshot the bytes synchronously inside send() and publish via a future.
-    // The ByteBuffer mutates across pipe() iterations (clear/put/read), so the
-    // bytes must be copied before the next iteration. Publishing via a future
-    // also avoids the verify(timeout) -> read race: Mockito records the
-    // invocation BEFORE the doAnswer body runs, so a verify(timeout) barrier
-    // can return while the captured value is still unset.
-    final CompletableFuture<String> sent = new CompletableFuture<>();
-    doAnswer(i -> {
-      ByteBuffer buf = i.getArgument(0);
-      byte[] copy = new byte[buf.remaining()];
-      buf.duplicate().get(copy);
-      sent.complete(new String(copy, StandardCharsets.UTF_8));
-      return true;
-    }).when(webSocket).send(any(ByteBuffer.class));
     listener = new PortForwarderWebsocketListener(in, out, CommonThreadPool.get());
     listener.onOpen(webSocket);
     // Then
-    assertThat(sent)
-        .succeedsWithin(10, TimeUnit.SECONDS, InstanceOfAssertFactories.STRING)
-        .startsWith("\u0000THIS IS A TEST");
+    assertThat(webSocket.firstSent())
+        .succeedsWithin(10, TimeUnit.SECONDS, InstanceOfAssertFactories.type(ByteBuffer.class))
+        .satisfies(buf -> {
+          final byte[] copy = new byte[buf.remaining()];
+          buf.duplicate().get(copy);
+          assertThat(new String(copy, StandardCharsets.UTF_8)).startsWith("\u0000THIS IS A TEST");
+        });
     // Single send for the 14-byte payload; pipe() exits on EOF before a second send.
-    verify(webSocket, times(1)).send(any(ByteBuffer.class));
+    assertThat(webSocket.getSent()).hasSize(1);
     assertThat(in.isOpen()).isTrue();
     assertThat(out.isOpen()).isTrue();
   }
@@ -107,7 +90,7 @@ class PortForwarderWebsocketListenerTest {
     listener = new PortForwarderWebsocketListener(inWithException, out, CommonThreadPool.get());
     listener.onOpen(webSocket);
     // Then
-    verify(webSocket, timeout(10_000).times(1)).sendClose(anyInt(), anyString());
+    assertThat(webSocket.firstClose()).succeedsWithin(10, TimeUnit.SECONDS);
     assertThat(listener.getClientThrowables())
         .singleElement()
         .asInstanceOf(InstanceOfAssertFactories.throwable(IOException.class))
@@ -140,35 +123,29 @@ class PortForwarderWebsocketListenerTest {
   @Test
   void onMessage_shouldSkipTwoMessagesAndPipeTheThird() {
     listener = new PortForwarderWebsocketListener(in, out, CommonThreadPool.get());
-    doAnswer(i -> {
-      listener.onMessage(webSocket, "SKIP 2");
-      return true;
-    }).doAnswer(i -> {
-      listener.onMessage(webSocket, ByteBuffer.wrap(
-          ByteBuffer.allocate(18).put((byte) 0).put("PROCESSED MESSAGE".getBytes(StandardCharsets.UTF_8)).array()));
-      return true;
-    })
-        .doNothing()
-        .when(webSocket).request();
+    webSocket
+        .onRequest(() -> listener.onMessage(webSocket, "SKIP 2"))
+        .onRequest(() -> listener.onMessage(webSocket, ByteBuffer.wrap(
+            ByteBuffer.allocate(18).put((byte) 0).put("PROCESSED MESSAGE".getBytes(StandardCharsets.UTF_8)).array())));
+    // third request is intentionally unscripted (no-op)
     listener.onMessage(webSocket, "SKIP 1");
     // Then
-    verify(webSocket, timeout(10_000).times(3)).request();
+    await().atMost(10, TimeUnit.SECONDS).until(() -> webSocket.requestCount() >= 3);
+    assertThat(webSocket.requestCount()).isEqualTo(3);
     assertThat(outputContent.toString()).contains("PROCESSED MESSAGE");
   }
 
   @Test
   void onMessage_withEmptyMessage_shouldEndWithError() {
     listener = new PortForwarderWebsocketListener(in, out, CommonThreadPool.get());
-    doAnswer(i -> {
-      listener.onMessage(webSocket, "SKIP 2");
-      return true;
-    }).doAnswer(i -> {
-      listener.onMessage(webSocket, ByteBuffer.wrap(new byte[0]));
-      return true;
-    }).when(webSocket).request();
+    webSocket
+        .onRequest(() -> listener.onMessage(webSocket, "SKIP 2"))
+        .onRequest(() -> listener.onMessage(webSocket, ByteBuffer.wrap(new byte[0])));
     listener.onMessage(webSocket, "SKIP 1");
     // Then
-    verify(webSocket, timeout(10_000)).sendClose(1002, "Protocol error");
+    assertThat(webSocket.firstClose())
+        .succeedsWithin(10, TimeUnit.SECONDS)
+        .isEqualTo(new TestWebSocket.CloseFrame(1002, "Protocol error"));
     await().atMost(10, TimeUnit.SECONDS).until(() -> !listener.isAlive());
     assertThat(outputContent.toString()).isEmpty();
     assertThat(listener.errorOccurred()).isTrue();
@@ -180,17 +157,11 @@ class PortForwarderWebsocketListenerTest {
   @Test
   void onMessage_withServerClose_shouldSkipTwoMessagesAndPipeTheThird() {
     listener = new PortForwarderWebsocketListener(in, out, CommonThreadPool.get());
-    doAnswer(i -> {
-      listener.onMessage(webSocket, "SKIP 2");
-      return true;
-    }).doAnswer(i -> {
-      listener.onMessage(webSocket, ByteBuffer.wrap(
-          ByteBuffer.allocate(18).put((byte) 0).put("PROCESSED MESSAGE".getBytes(StandardCharsets.UTF_8)).array()));
-      return true;
-    }).doAnswer(i -> {
-      listener.onClose(webSocket, 31337, "Transmission complete");
-      return true;
-    }).when(webSocket).request();
+    webSocket
+        .onRequest(() -> listener.onMessage(webSocket, "SKIP 2"))
+        .onRequest(() -> listener.onMessage(webSocket, ByteBuffer.wrap(
+            ByteBuffer.allocate(18).put((byte) 0).put("PROCESSED MESSAGE".getBytes(StandardCharsets.UTF_8)).array())))
+        .onRequest(() -> listener.onClose(webSocket, 31337, "Transmission complete"));
     listener.onMessage(webSocket, "SKIP 1");
     // Then
     await().atMost(10, TimeUnit.SECONDS).until(() -> !listener.isAlive());
@@ -203,19 +174,16 @@ class PortForwarderWebsocketListenerTest {
   @Test
   void onMessage_withWrongChannel_shouldLogAndEndWithError() {
     listener = new PortForwarderWebsocketListener(in, out, CommonThreadPool.get());
-    doAnswer(i -> {
-      listener.onMessage(webSocket, "SKIP 2");
-      return true;
-    }).doAnswer(i -> {
-      listener.onMessage(webSocket, ByteBuffer.wrap(
-          ByteBuffer.allocate(18).put((byte) 5).put("WRONG CHANNEL".getBytes(StandardCharsets.UTF_8)).array()));
-      return true;
-    })
-        .doNothing()
-        .when(webSocket).request();
+    webSocket
+        .onRequest(() -> listener.onMessage(webSocket, "SKIP 2"))
+        .onRequest(() -> listener.onMessage(webSocket, ByteBuffer.wrap(
+            ByteBuffer.allocate(18).put((byte) 5).put("WRONG CHANNEL".getBytes(StandardCharsets.UTF_8)).array())));
+    // third request is intentionally unscripted (no-op)
     listener.onMessage(webSocket, "SKIP 1");
     // Then
-    verify(webSocket, timeout(10_000)).sendClose(1002, "Protocol error");
+    assertThat(webSocket.firstClose())
+        .succeedsWithin(10, TimeUnit.SECONDS)
+        .isEqualTo(new TestWebSocket.CloseFrame(1002, "Protocol error"));
     await().atMost(10, TimeUnit.SECONDS).until(() -> !listener.isAlive());
     assertThat(outputContent.toString()).isEmpty();
     assertThat(listener.errorOccurred()).isTrue();

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ServiceOperationsImplTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ServiceOperationsImplTest.java
@@ -22,7 +22,7 @@ import io.fabric8.kubernetes.client.LocalPortForward;
 import io.fabric8.kubernetes.client.PortForward;
 import io.fabric8.kubernetes.client.http.TestStandardHttpClient;
 import io.fabric8.kubernetes.client.http.TestStandardHttpClientFactory;
-import io.fabric8.kubernetes.client.http.WebSocket;
+import io.fabric8.kubernetes.client.http.TestWebSocket;
 import io.fabric8.kubernetes.client.http.WebSocketResponse;
 import io.fabric8.kubernetes.client.http.WebSocketUpgradeResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,7 +42,6 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
 
 class ServiceOperationsImplTest {
 
@@ -145,7 +144,7 @@ class ServiceOperationsImplTest {
                 "\"spec\":{\"selector\":{\"app\":\"test\"},\"ports\":[{\"port\":8080,\"targetPort\":9090}]}}");
         httpClient.expect("/api/v1/namespaces/test/pods", 200, POD_LIST_JSON);
         httpClient.wsExpect(".*/portforward.*",
-            new WebSocketResponse(new WebSocketUpgradeResponse(null), mock(WebSocket.class)));
+            new WebSocketResponse(new WebSocketUpgradeResponse(null), new TestWebSocket()));
 
         // When - Use channel-based portForward which triggers WebSocket connection immediately
         PipedOutputStream out = new PipedOutputStream();
@@ -183,7 +182,7 @@ class ServiceOperationsImplTest {
                 "\"spec\":{\"selector\":{\"app\":\"test\"},\"ports\":[{\"port\":8080,\"targetPort\":9090}]}}");
         httpClient.expect("/api/v1/namespaces/test/pods", 200, POD_LIST_JSON);
         httpClient.wsExpect(".*/portforward.*",
-            new WebSocketResponse(new WebSocketUpgradeResponse(null), mock(WebSocket.class)));
+            new WebSocketResponse(new WebSocketUpgradeResponse(null), new TestWebSocket()));
 
         // When - Use port 3000 which is not defined in the service
         PipedOutputStream out = new PipedOutputStream();
@@ -220,7 +219,7 @@ class ServiceOperationsImplTest {
                 "\"spec\":{\"selector\":{\"app\":\"test\"},\"ports\":[{\"port\":80,\"targetPort\":\"http\"}]}}");
         httpClient.expect("/api/v1/namespaces/test/pods", 200, POD_LIST_JSON);
         httpClient.wsExpect(".*/portforward.*",
-            new WebSocketResponse(new WebSocketUpgradeResponse(null), mock(WebSocket.class)));
+            new WebSocketResponse(new WebSocketUpgradeResponse(null), new TestWebSocket()));
 
         // When
         PipedOutputStream out = new PipedOutputStream();
@@ -261,7 +260,7 @@ class ServiceOperationsImplTest {
                 "]}}");
         httpClient.expect("/api/v1/namespaces/test/pods", 200, POD_LIST_JSON);
         httpClient.wsExpect(".*/portforward.*",
-            new WebSocketResponse(new WebSocketUpgradeResponse(null), mock(WebSocket.class)));
+            new WebSocketResponse(new WebSocketUpgradeResponse(null), new TestWebSocket()));
 
         // When - Forward the HTTPS port (443)
         PipedOutputStream out = new PipedOutputStream();


### PR DESCRIPTION
Three test files Mockito-mocked the `WebSocket` interface and combined it with `verify(timeout)` barriers, producing the CI flake tracked in #7793 (fixed in #7794). The underlying pattern — using Mockito as a stand-in for a WebSocket whose behavior is scripted — remained, leaving similar timing windows on the other `verify(timeout)` call sites and at odds with `CLAUDE.md`'s "avoid excessive mocking" guidance.

This PR introduces a hand-written `TestWebSocket` fake (plus 12 self-tests) under `kubernetes-client-api` test sources and migrates `PortForwarderWebsocketListenerTest`, `ExecWebSocketListenerTest`, and `ServiceOperationsImplTest` off `mock(WebSocket.class)`. The fake:

- captures sent payloads via defensive `ByteBuffer` copy
- publishes first `send` / first `sendClose` through `CompletableFuture` for race-free happens-before assertions
- supports scripted per-`request()` actions (replaces chained `doAnswer`)
- returns fresh read-only views from `getSent()` / `firstSent()` per call so reads cannot leak position state between callers

The race window from #7794 is closed at every `verify(timeout)` call site in the migrated files, not only the one originally reported.

Closes #7795