### PR TITLE
chore(sonar): suppress S4830/S5527 false positives on opt-in TLS paths

### DIFF
--- a/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientFactory.java
+++ b/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientFactory.java
@@ -56,6 +56,7 @@ public class OkHttpClientFactory implements HttpClient.Factory {
    * @return returns an HTTP client builder
    */
   @Override
+  @SuppressWarnings("java:S5527") // hostname verification is disabled only when the user explicitly opts in via trustCerts or disableHostnameVerification
   public OkHttpClientBuilderImpl newBuilder(Config config) {
     try {
       OkHttpClientBuilderImpl builderWrapper = newBuilder();

--- a/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/process/ProcessReadinessChecker.java
+++ b/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/process/ProcessReadinessChecker.java
@@ -185,6 +185,7 @@ public class ProcessReadinessChecker {
     return getHttpClient(null);
   }
 
+  @SuppressWarnings("java:S4830") // test infrastructure: polls a locally launched API server with ephemeral self-signed certs over localhost
   private static HttpClient getHttpClient(CertManager certManager) {
     try {
       SSLContext sslContext = SSLContext.getInstance("TLS");

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/internal/SSLUtils.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/internal/SSLUtils.java
@@ -118,6 +118,7 @@ public final class SSLUtils {
         config.getTrustStorePassphrase());
   }
 
+  @SuppressWarnings("java:S4830") // trust-all TrustManager is gated by the documented isTrustCerts opt-in for dev clusters with self-signed certs
   public static TrustManager[] trustManagers(String certData, String certFile, boolean isTrustCerts, String trustStoreFile,
       String trustStorePassphrase) throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
     TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());


### PR DESCRIPTION
## Description

Suppresses 13 SonarCloud HIGH-severity security findings (rules `java:S4830` and `java:S5527`) that fall on SSL/TLS code paths gated behind explicit user opt-ins or on test infrastructure.

Each suppression is accompanied by a one-line comment explaining the gating condition, so the rationale travels with the code.

### Suppressed findings

| Rule  | File | Reason |
|-------|------|--------|
| S4830 (6 issues) | `kubernetes-client-api/.../SSLUtils.java` | Trust-all `X509ExtendedTrustManager` is only built when `isTrustCerts` is set, i.e. the user explicitly opts in via `config.trustCerts(true)` for dev clusters with self-signed certs |
| S4830 (6 issues) | `junit/kube-api-test/.../ProcessReadinessChecker.java` | Test infrastructure: polls a locally launched API server with ephemeral self-signed certs over `localhost` |
| S5527 (1 issue)  | `httpclient-okhttp/.../OkHttpClientFactory.java` | Hostname verification disabled only when user opts in via `trustCerts` or `disableHostnameVerification` |

### Related

Companion to:
- #7829 — Verify chaos-mesh `install.sh` before piping to bash in e2e workflow (S8482)

Together this PR + that issue take SonarCloud HIGH-severity security findings on this project from 14 → 0.