### PR TITLE
fix(sonar): re-interrupt and clean up examples reliability bugs

### DIFF
--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extended/leaderelection/LeaderElector.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extended/leaderelection/LeaderElector.java
@@ -310,6 +310,6 @@ public class LeaderElector {
    */
   protected static Duration jitter(Duration duration, double maxFactor) {
     maxFactor = maxFactor > 0 ? maxFactor : 1.0;
-    return duration.plusMillis(Double.valueOf(duration.toMillis() * Math.random() * maxFactor).longValue());
+    return duration.plusMillis((long) (duration.toMillis() * Math.random() * maxFactor));
   }
 }

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CRDExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CRDExample.java
@@ -186,6 +186,9 @@ public class CRDExample {
       watch.close();
     } catch (KubernetesClientException e) {
       logger.error(e.getMessage(), e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      logger.error(e.getMessage(), e);
     } catch (Exception e) {
       logger.error(e.getMessage(), e);
     }

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/FullExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/FullExample.java
@@ -221,6 +221,9 @@ public class FullExample {
         client.namespaces().withName("thisisatest").delete();
         log("Deleted namespace");
       }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      logger.error(e.getMessage(), e);
     } catch (Exception e) {
       logger.error(e.getMessage(), e);
       Throwable[] suppressed = e.getSuppressed();

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/GenericKubernetesResourceExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/GenericKubernetesResourceExample.java
@@ -92,7 +92,9 @@ public class GenericKubernetesResourceExample {
           }
         }
       });
-      closeLatch.await(10, TimeUnit.MINUTES);
+      if (!closeLatch.await(10, TimeUnit.MINUTES)) {
+        logger.warn("Watch did not close within 10 minutes");
+      }
       watch.close();
 
       // Cleanup

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/PodLogExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/PodLogExample.java
@@ -46,6 +46,9 @@ public class PodLogExample {
         KubernetesClient client = new KubernetesClientBuilder().build();
         LogWatch ignore = client.pods().inNamespace(namespace).withName(podName).tailingLines(10).watchLog(System.out)) {
       Thread.sleep(5 * 1000L);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      logger.error(e.getMessage(), e);
     } catch (Exception e) {
       logger.error(e.getMessage(), e);
     }

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/PortForwardExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/PortForwardExample.java
@@ -64,6 +64,9 @@ public class PortForwardExample {
       Thread.sleep(60 * 1000L);
       logger.info("Closing forwarded port");
       portForward.close();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      logger.error("Exception occurred: {}", e.getMessage(), e);
     } catch (Exception e) {
       logger.error("Exception occurred: {}", e.getMessage(), e);
     }


### PR DESCRIPTION
## Description

Fixes 6 SonarCloud reliability BUG findings that were trivially addressable from a backlog-grooming pass.

### Changes

| Rule  | File | Fix |
|-------|------|-----|
| S2142 | `kubernetes-examples/.../CRDExample.java` | Add `catch (InterruptedException)` arm that calls `Thread.currentThread().interrupt()` |
| S2142 | `kubernetes-examples/.../PodLogExample.java` | Same |
| S2142 | `kubernetes-examples/.../PortForwardExample.java` | Same |
| S2142 | `kubernetes-examples/.../FullExample.java` | Same |
| S899  | `kubernetes-examples/.../GenericKubernetesResourceExample.java` | `closeLatch.await(...)`'s boolean result was discarded; now log a warning if the latch doesn't reach zero in time |
| S2153 | `kubernetes-client-api/.../LeaderElector.java` | Replace `Double.valueOf(...).longValue()` with a direct `(long)` cast |

### Related

Remaining reliability findings are tracked in:
- #7831 — S3077 thread-safety cluster (14 issues)
- #7832 — Production-code S2142 + miscellaneous reliability findings (~15 issues)