### PR TITLE
fix(kube-api-test): idempotent stop() and 120s default startupTimeout

### DIFF
--- a/doc/kube-api-test.md
+++ b/doc/kube-api-test.md
@@ -112,6 +112,11 @@ annotation, since might not make sense to do it for an individual test case. How
 [`KubeApiServer`](https://github.com/fabric8io/kubernetes-client/blob/main/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/KubeAPIServer.java)
 and also configured globally using environment variables, see [KubeAPIServerConfigBuilder](https://github.com/fabric8io/kubernetes-client/blob/main/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/KubeAPIServerConfigBuilder.java)
 
+The API Server startup wait defaults to 120 seconds (raised from 60 s in [#7834](https://github.com/fabric8io/kubernetes-client/pull/7836)
+to absorb scheduling pressure on shared CI runners). Override per instance with
+`KubeAPIServerConfigBuilder.withStartupTimeout(int)`, or globally via the
+`KUBE_API_TEST_STARTUP_TIMEOUT` environment variable (milliseconds).
+
 
 ### Updating kube config file
 

--- a/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/KubeAPIServer.java
+++ b/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/KubeAPIServer.java
@@ -34,6 +34,7 @@ public class KubeAPIServer implements UnexpectedProcessStopHandler {
   private final KubeConfig kubeConfig;
   private final EtcdProcess etcdProcess;
   private final KubeAPIServerProcess kubeApiServerProcess;
+  private volatile boolean stopped = false;
 
   public KubeAPIServer() {
     this(KubeAPIServerConfigBuilder.anAPIServerConfig().build());
@@ -62,7 +63,15 @@ public class KubeAPIServer implements UnexpectedProcessStopHandler {
     logger.debug("API Server ready to use");
   }
 
-  public void stop() {
+  // Guarded so the JUnit afterAll path and the processStopped() callback
+  // (fired on unexpected child-process exit during startup) can both call
+  // stop() without the second invocation crashing in cleanEtcdData() once
+  // the temp dirs have already been removed. See #7834.
+  public synchronized void stop() {
+    if (stopped) {
+      return;
+    }
+    stopped = true;
     logger.debug("Stopping");
     kubeApiServerProcess.stopApiServer();
     etcdProcess.stopEtcd();

--- a/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/KubeAPIServer.java
+++ b/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/KubeAPIServer.java
@@ -34,7 +34,7 @@ public class KubeAPIServer implements UnexpectedProcessStopHandler {
   private final KubeConfig kubeConfig;
   private final EtcdProcess etcdProcess;
   private final KubeAPIServerProcess kubeApiServerProcess;
-  private volatile boolean stopped = false;
+  private boolean stopped = false;
 
   public KubeAPIServer() {
     this(KubeAPIServerConfigBuilder.anAPIServerConfig().build());
@@ -63,10 +63,12 @@ public class KubeAPIServer implements UnexpectedProcessStopHandler {
     logger.debug("API Server ready to use");
   }
 
-  // Guarded so the JUnit afterAll path and the processStopped() callback
-  // (fired on unexpected child-process exit during startup) can both call
-  // stop() without the second invocation crashing in cleanEtcdData() once
-  // the temp dirs have already been removed. See #7834.
+  // stop() can be invoked twice: from the processStopped() callback (fired
+  // on unexpected child-process exit during startup) and from JUnit's
+  // afterAll. The stopped guard makes the second call a no-op so
+  // cleanEtcdData() doesn't crash on the already-removed temp dirs;
+  // synchronized closes the rarer window where the two callers overlap
+  // concurrently and would otherwise race past the guard. See #7834.
   public synchronized void stop() {
     if (stopped) {
       return;

--- a/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/KubeAPIServerConfigBuilder.java
+++ b/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/KubeAPIServerConfigBuilder.java
@@ -68,7 +68,7 @@ public final class KubeAPIServerConfigBuilder {
     this.apiServerVersion = finalConfigValue(this.apiServerVersion, KUBE_API_TEST_API_SERVER_VERSION, null);
     this.waitForEtcdHealthCheckOnStartup = finalConfigValue(this.waitForEtcdHealthCheckOnStartup,
         KUBE_API_TEST_WAIT_FOR_ETCD_HEALTH_CHECK, false);
-    this.startupTimeout = finalConfigValue(this.startupTimeout, KUBE_API_TEST_STARTUP_TIMEOUT, 60_000);
+    this.startupTimeout = finalConfigValue(this.startupTimeout, KUBE_API_TEST_STARTUP_TIMEOUT, 120_000);
 
     return new KubeAPIServerConfig(apiTestDir, apiServerVersion, offlineMode, apiServerFlags,
         updateKubeConfig, waitForEtcdHealthCheckOnStartup, startupTimeout);

--- a/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/KubeAPIServerConfigBuilderTest.java
+++ b/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/KubeAPIServerConfigBuilderTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubeapitest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KubeAPIServerConfigBuilderTest {
+
+  // Default raised from 60s to 120s under #7834: the 2.6s idle startup of
+  // kube-apiserver scales ~20× under -T 1C + forkCount=1C CI contention,
+  // landing right on the 60s boundary. 120s gives a 2× buffer; the
+  // KUBE_API_TEST_STARTUP_TIMEOUT env var still lets users tune it.
+  @Test
+  void defaultStartupTimeoutIs120Seconds() {
+    var config = KubeAPIServerConfigBuilder.anAPIServerConfig().build();
+
+    assertThat(config.getStartupTimeout()).isEqualTo(120_000);
+  }
+
+  @Test
+  void explicitStartupTimeoutOverridesDefault() {
+    var config = KubeAPIServerConfigBuilder.anAPIServerConfig()
+        .withStartupTimeout(42_000)
+        .build();
+
+    assertThat(config.getStartupTimeout()).isEqualTo(42_000);
+  }
+}

--- a/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/sample/KubeApiServerTest.java
+++ b/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/sample/KubeApiServerTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import static io.fabric8.kubeapitest.sample.TestCaseUtils.simpleTest;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class KubeApiServerTest {
@@ -87,6 +88,21 @@ class KubeApiServerTest {
         .withStartupTimeout(500)
         .build());
     assertThrows(KubeAPITestException.class, kubeApi::start);
+  }
+
+  // Regression for #7834: when an unexpected child-process exit fires the
+  // processStopped() callback during startup, KubeAPIServer.stop() runs from
+  // the callback AND again from JUnit's afterAll. The second invocation used
+  // to crash in EtcdProcess.cleanEtcdData() with NoSuchFileException because
+  // the first call already deleted the temp dirs. stop() must therefore be
+  // idempotent.
+  @Test
+  void stopCanBeCalledMultipleTimes() {
+    var kubeApi = new KubeAPIServer();
+    kubeApi.start();
+    kubeApi.stop();
+
+    assertThatNoException().isThrownBy(kubeApi::stop);
   }
 
   void testWithAPIServer(KubeAPIServer kubeApi) {


### PR DESCRIPTION
## Summary

#7834 reports `KubernetesValidationHookHandlingTest` flaking on CI with `Kube API Server did not start properly` at the 60s startup boundary, with a *suppressed* `NoSuchFileException: /tmp/etcddata...` from `EtcdProcess.cleanEtcdData` in JUnit's `afterAll`. Two related defects, fixed at their respective layers:

- **`KubeAPIServer.stop()` is now idempotent.** When an unexpected child-process exit fires the `onExit` callback during startup, `processStopped()` → `stop()` runs on the callback thread *and* JUnit's `afterAll` runs `stop()` a second time once the readiness wait times out. The second invocation crashed in `cleanEtcdData()` because the etcd temp dirs were already removed; a `stopped` guard short-circuits subsequent calls, and `synchronized` covers the rarer window where the two callers overlap concurrently.
- **Default `startupTimeout` bumped 60 000 → 120 000 ms.** Per #7807, the ~2.6 s idle kube-apiserver startup scales ~20× under `-T 1C` + `forkCount=1C` on 2-vCPU CI runners — landing right on the 60 s boundary (`Time elapsed: 60.17 s` in the issue trace confirms it). 120 s gives a 2× buffer; `KUBE_API_TEST_STARTUP_TIMEOUT` still overrides.

Regression tests:

- `KubeApiServerTest#stopCanBeCalledMultipleTimes` — `start() → stop() → stop()` reproduces the exact `NoSuchFileException` from the issue trace without the fix and passes with it.
- `KubeAPIServerConfigBuilderTest` (new fast unit) — asserts the new 120 s default and that explicit overrides still win.

Closes #7834. Refs #7807.