### PR TITLE
fix(sonar): remove duplicated logger and resource fields (S1845, S2387)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix #7765: (kubernetes-client) `BaseOperation.informOnCondition` now stops the informer inline when the inner predicate completes the future, closing a CompletableFuture `postComplete` race where a waiter helping drain dependents could fire `informer.stop` after `cf.complete` had already triggered a spurious `?watch=true` HTTP request
 
 #### Improvements
+* Fix #7825: (kubernetes-client, kubernetes-client-api) Remove duplicated logger and resource fields (Sonar S1845, S2387)
 * Fix #7675: (mockwebserver) `MockWebServer.dispatcher` field marked `volatile` so a `setDispatcher(...)` call is reliably visible to the Vert.x request handler thread without further synchronization. `MockWebServer.reset()` Javadoc tightened to make its non-destructive contract explicit (no change to the running server, dispatcher, listeners, SSL/TLS state, port, or protocols)
 * Fix #7809: (kubernetes-client) Support for shard selectors for list and watch - including informers
 * Fix #7837: (kubernetes-client) Follow-ups on shard selector

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ExtensibleResourceAdapter.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ExtensibleResourceAdapter.java
@@ -30,7 +30,6 @@ import java.util.function.Function;
  */
 public abstract class ExtensibleResourceAdapter<T> extends ResourceAdapter<T> implements ExtensibleResource<T> {
 
-  protected ExtensibleResource<T> resource;
   protected Client client;
 
   public ExtensibleResourceAdapter() {
@@ -40,85 +39,89 @@ public abstract class ExtensibleResourceAdapter<T> extends ResourceAdapter<T> im
   public abstract ExtensibleResourceAdapter<T> newInstance();
 
   public ExtensibleResourceAdapter<T> init(ExtensibleResource<T> resource, Client client) {
-    super.resource = resource;
     this.resource = resource;
     this.client = client;
     return this;
   }
 
+  @SuppressWarnings("unchecked")
+  private ExtensibleResource<T> extensibleResource() {
+    return (ExtensibleResource<T>) resource;
+  }
+
   @Override
   public ExtensibleResource<T> lockResourceVersion(String resourceVersion) {
-    return newInstance().init(resource.lockResourceVersion(resourceVersion), client);
+    return newInstance().init(extensibleResource().lockResourceVersion(resourceVersion), client);
   }
 
   @Override
   public ExtensibleResource<T> withResourceVersion(String resourceVersion) {
-    return newInstance().init(resource.withResourceVersion(resourceVersion), client);
+    return newInstance().init(extensibleResource().withResourceVersion(resourceVersion), client);
   }
 
   @Override
   public ExtensibleResource<T> fromServer() {
-    return newInstance().init(resource.fromServer(), client);
+    return newInstance().init(extensibleResource().fromServer(), client);
   }
 
   @Override
   public ExtensibleResource<T> withGracePeriod(long gracePeriodSeconds) {
-    return newInstance().init(resource.withGracePeriod(gracePeriodSeconds), client);
+    return newInstance().init(extensibleResource().withGracePeriod(gracePeriodSeconds), client);
   }
 
   @Override
   public ExtensibleResource<T> withPropagationPolicy(DeletionPropagation propagationPolicy) {
-    return newInstance().init(resource.withPropagationPolicy(propagationPolicy), client);
+    return newInstance().init(extensibleResource().withPropagationPolicy(propagationPolicy), client);
   }
 
   @Override
   public ExtensibleResource<T> withIndexers(Map<String, Function<T, List<String>>> indexers) {
-    return newInstance().init(resource.withIndexers(indexers), client);
+    return newInstance().init(extensibleResource().withIndexers(indexers), client);
   }
 
   @Override
   public ExtensibleResource<T> dryRun(boolean isDryRun) {
-    return newInstance().init(resource.dryRun(isDryRun), client);
+    return newInstance().init(extensibleResource().dryRun(isDryRun), client);
   }
 
   @Override
   public ExtensibleResource<T> withLimit(Long limit) {
-    return newInstance().init(resource.withLimit(limit), client);
+    return newInstance().init(extensibleResource().withLimit(limit), client);
   }
 
   @Override
   public <C extends Client> C inWriteContext(Class<C> clazz) {
-    return resource.inWriteContext(clazz);
+    return extensibleResource().inWriteContext(clazz);
   }
 
   @Override
   public ExtensibleResource<T> lockResourceVersion() {
-    return newInstance().init(resource.lockResourceVersion(), client);
+    return newInstance().init(extensibleResource().lockResourceVersion(), client);
   }
 
   @Override
   public T getItem() {
-    return resource.getItem();
+    return extensibleResource().getItem();
   }
 
   @Override
   public ExtensibleResource<T> fieldValidation(Validation fieldValidation) {
-    return newInstance().init(resource.fieldValidation(fieldValidation), client);
+    return newInstance().init(extensibleResource().fieldValidation(fieldValidation), client);
   }
 
   @Override
   public ExtensibleResource<T> fieldManager(String manager) {
-    return newInstance().init(resource.fieldManager(manager), client);
+    return newInstance().init(extensibleResource().fieldManager(manager), client);
   }
 
   @Override
   public ExtensibleResource<T> forceConflicts() {
-    return newInstance().init(resource.forceConflicts(), client);
+    return newInstance().init(extensibleResource().forceConflicts(), client);
   }
 
   @Override
   public ExtensibleResource<T> withTimeout(long timeout, TimeUnit unit) {
-    return newInstance().init(resource.withTimeout(timeout, unit), client);
+    return newInstance().init(extensibleResource().withTimeout(timeout, unit), client);
   }
 
   @Override
@@ -128,12 +131,12 @@ public abstract class ExtensibleResourceAdapter<T> extends ResourceAdapter<T> im
 
   @Override
   public ExtensibleResource<T> unlock() {
-    return newInstance().init(resource.unlock(), client);
+    return newInstance().init(extensibleResource().unlock(), client);
   }
 
   @Override
   public ExtensibleResource<T> subresource(String subresource) {
-    return newInstance().init(resource.subresource(subresource), client);
+    return newInstance().init(extensibleResource().subresource(subresource), client);
   }
 
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ResourceAdapter.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ResourceAdapter.java
@@ -58,7 +58,7 @@ import java.util.function.UnaryOperator;
  */
 public class ResourceAdapter<T> implements Resource<T> {
 
-  protected Resource<T> resource;
+  Resource<T> resource;
 
   public ResourceAdapter() {
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ResourceAdapter.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ResourceAdapter.java
@@ -58,7 +58,7 @@ import java.util.function.UnaryOperator;
  */
 public class ResourceAdapter<T> implements Resource<T> {
 
-  Resource<T> resource;
+  protected Resource<T> resource;
 
   public ResourceAdapter() {
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
@@ -106,7 +106,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     ExtensibleResource<T>,
     ListerWatcher<T, L> {
 
-  static final Logger LOGGER = LoggerFactory.getLogger(BaseOperation.class);
+  static final Logger logger = LoggerFactory.getLogger(BaseOperation.class);
 
   private static final String WATCH = "watch";
   private static final String READ_ONLY_UPDATE_EXCEPTION_MESSAGE = "Cannot update read-only resources";
@@ -780,13 +780,13 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
               // If the HTTP return code is 200 or 503, we retry the watch again using a persistent hanging
               // HTTP GET. This is meant to handle cases like kubectl local proxy which does not support
               // websockets. Issue: https://github.com/kubernetes/kubernetes/issues/25126
-              LOGGER.debug(
+              logger.debug(
                   "Websocket hanshake failed with code {}, but an httpwatch may be possible.  Use Config.onlyHttpWatches to disable websocket watches.",
                   ke.getCode());
               httpWatch = true;
             }
           } else {
-            LOGGER.debug(
+            logger.debug(
                 "Failed to establish a websocket watch, will try regular http instead.  Use Config.onlyHttpWatches to disable websocket watches.",
                 t);
             httpWatch = true;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
@@ -781,7 +781,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
               // HTTP GET. This is meant to handle cases like kubectl local proxy which does not support
               // websockets. Issue: https://github.com/kubernetes/kubernetes/issues/25126
               logger.debug(
-                  "Websocket hanshake failed with code {}, but an httpwatch may be possible.  Use Config.onlyHttpWatches to disable websocket watches.",
+                  "Websocket handshake failed with code {}, but an httpwatch may be possible.  Use Config.onlyHttpWatches to disable websocket watches.",
                   ke.getCode());
               httpWatch = true;
             }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/HasMetadataOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/HasMetadataOperation.java
@@ -29,8 +29,6 @@ import io.fabric8.kubernetes.client.dsl.base.PatchContext;
 import io.fabric8.kubernetes.client.dsl.base.PatchType;
 import io.fabric8.kubernetes.client.utils.KubernetesResourceUtil;
 import io.fabric8.kubernetes.client.utils.Utils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -43,8 +41,6 @@ import java.util.function.UnaryOperator;
 
 public class HasMetadataOperation<T extends HasMetadata, L extends KubernetesResourceList<T>, R extends Resource<T>>
     extends BaseOperation<T, L, R> {
-
-  private static final Logger logger = LoggerFactory.getLogger(HasMetadataOperation.class);
 
   public static final DeletionPropagation DEFAULT_PROPAGATION_POLICY = DeletionPropagation.BACKGROUND;
   public static final long DEFAULT_GRACE_PERIOD_IN_SECONDS = -1L;


### PR DESCRIPTION
## Summary
- Rename `BaseOperation.LOGGER` → `logger` to align with the project convention and remove the shadowing `logger` field in `HasMetadataOperation` (S1845)
- Remove the duplicate `resource` field in `ExtensibleResourceAdapter` that shadows `ResourceAdapter.resource` (S2387), using a private cast helper instead
- Make `ResourceAdapter.resource` `protected` so subclasses in other packages retain access

Closes #7825

## Test plan
- [x] `make quickly` — BUILD SUCCESS
- [x] `ExtensibleResourceAdapterTest` — 1 test, 0 failures
- [x] `BaseOperationTest`, `BaseOperationWatchTest`, `HasMetadataOperationsImplTest` — 15 tests, 0 failures
- [x] `kubernetes-tests` — 1302 tests, 0 failures
- [x] `extensions/volumesnapshot/tests` — 3 tests, 0 failures
- [x] `spotless:check` — formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)