### PR TITLE
fix(mockwebserver): two-phase Dispatcher shutdown to avoid WS race (7841)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 7.8-SNAPSHOT
 
 #### Bugs
+* Fix #7841: (mockwebserver) split `Dispatcher` shutdown into two phases so `MockDispatcher` only tears down per-session `WebSocketSession` executors after the HTTP server has drained, removing the window where an in-flight upgrade's `onOpen` could land on a shut-down executor. `shutdown()` still runs before `httpServer.close()` to unblock blocked dispatches (e.g. `QueueDispatcher.take()`); the new `releaseResources()` runs after. `WebSocketSession.send()` additionally catches `RejectedExecutionException` defensively so any residual shutdown race stays silent instead of bubbling as a Vert.x `Unhandled exception`. `KubernetesMixedDispatcher` now delegates both lifecycle hooks to its inner `MockDispatcher`, fixing a pre-existing leak where CRUD-mode WebSocket session executors were never shut down
 * Fix #7779: (kubernetes-client) ExecWebSocketListener now notifies the user-supplied ExecListener on transport-level errors that race with `terminateOnError` / channel-3 exit-status completion — `listener.onFailure` (or `onClose`) fires exactly once, gated by a dedicated flag, instead of being silently swallowed when the deferred onError task observes `exitCode.isDone()`
 * Fix #7765: (kubernetes-client) `BaseOperation.informOnCondition` now stops the informer inline when the inner predicate completes the future, closing a CompletableFuture `postComplete` race where a waiter helping drain dependents could fire `informer.stop` after `cf.complete` had already triggered a spurious `?watch=true` HTTP request
 

--- a/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMixedDispatcher.java
+++ b/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMixedDispatcher.java
@@ -68,6 +68,18 @@ public class KubernetesMixedDispatcher extends Dispatcher implements Resetable, 
   }
 
   @Override
+  public void shutdown() {
+    mockDispatcher.shutdown();
+    kubernetesCrudDispatcher.shutdown();
+  }
+
+  @Override
+  public void releaseResources() {
+    mockDispatcher.releaseResources();
+    kubernetesCrudDispatcher.releaseResources();
+  }
+
+  @Override
   public void reset() {
     this.kubernetesCrudDispatcher.reset();
   }

--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/MockWebServer.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/MockWebServer.java
@@ -182,8 +182,13 @@ public class MockWebServer implements Closeable {
       throw new IllegalStateException("shutdown() before start()");
     }
     shutdown = true;
+    // Two-phase: shutdown() unblocks any blocked dispatches (e.g. QueueDispatcher.take()) so
+    // httpServer.close() can drain in-flight requests; releaseResources() then tears down per-
+    // connection state (e.g. WebSocketSession executors) that an in-flight upgrade may still
+    // have been about to touch via onOpen — avoiding a RejectedExecutionException race.
     dispatcher.shutdown();
     await(httpServer.close(), "Unable to close MockWebServer");
+    dispatcher.releaseResources();
     info("done accepting connections");
     await(vertx.close(), "Unable to close Vertx");
   }

--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/http/Dispatcher.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/http/Dispatcher.java
@@ -33,4 +33,21 @@ public abstract class Dispatcher {
    */
   public void shutdown() {
   }
+
+  /**
+   * Release any per-connection resources that must outlive in-flight dispatches.
+   * <p>
+   * Called after the HTTP server has stopped accepting new connections, so it is safe to tear
+   * down state that an in-flight handler might otherwise touch (for example a WebSocket
+   * session's {@code ScheduledExecutorService} used to deliver {@code onOpen} messages).
+   * <p>
+   * Note: Vert.x {@code HttpServer.close()} does not strictly wait for every in-flight WebSocket
+   * upgrade to deliver its {@code onOpen} callback before completing, so callers that schedule
+   * onto resources released here must still be defensive against a shutdown that races with a
+   * late upgrade (see {@code WebSocketSession.send}).
+   * <p>
+   * The default implementation is a no-op.
+   */
+  public void releaseResources() {
+  }
 }

--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/internal/MockDispatcher.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/internal/MockDispatcher.java
@@ -70,8 +70,8 @@ public class MockDispatcher extends Dispatcher {
   }
 
   @Override
-  public void shutdown() {
+  public void releaseResources() {
     webSocketSessions.forEach(WebSocketSession::shutdown);
-    super.shutdown();
+    super.releaseResources();
   }
 }

--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/internal/WebSocketSession.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/internal/WebSocketSession.java
@@ -31,6 +31,7 @@ import java.util.Queue;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -155,17 +156,24 @@ public class WebSocketSession extends WebSocketListener {
   private void send(final WebSocket ws, final WebSocketMessage message) {
     final UUID id = UUID.randomUUID();
     pendingMessages.add(id);
-    executor.schedule(() -> {
-      if (ws != null) {
-        if (message.isBinary()) {
-          ws.send(message.getBytes());
-        } else {
-          ws.send(message.getBody());
+    try {
+      executor.schedule(() -> {
+        if (ws != null) {
+          if (message.isBinary()) {
+            ws.send(message.getBytes());
+          } else {
+            ws.send(message.getBody());
+          }
+          pendingMessages.remove(id);
         }
-        pendingMessages.remove(id);
-      }
-      closeActiveSocketsIfApplicable();
-    }, message.getDelay(), TimeUnit.MILLISECONDS);
+        closeActiveSocketsIfApplicable();
+      }, message.getDelay(), TimeUnit.MILLISECONDS);
+    } catch (RejectedExecutionException ex) {
+      // Session is shutting down (or already shut down): an in-flight WebSocket upgrade
+      // may still invoke onOpen after MockDispatcher.shutdown() has terminated the executor.
+      // Silently drop the message — the connection is being torn down anyway.
+      pendingMessages.remove(id);
+    }
   }
 
   public void closeActiveSocketsIfApplicable() {

--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/internal/WebSocketSession.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/internal/WebSocketSession.java
@@ -169,9 +169,9 @@ public class WebSocketSession extends WebSocketListener {
         closeActiveSocketsIfApplicable();
       }, message.getDelay(), TimeUnit.MILLISECONDS);
     } catch (RejectedExecutionException ex) {
-      // Session is shutting down (or already shut down): an in-flight WebSocket upgrade
-      // may still invoke onOpen after MockDispatcher.shutdown() has terminated the executor.
-      // Silently drop the message — the connection is being torn down anyway.
+      // Executor has been shut down: an in-flight WebSocket upgrade may still invoke onOpen
+      // after MockDispatcher.releaseResources() has terminated it. Silently drop the message
+      // — the connection is being torn down anyway.
       pendingMessages.remove(id);
     }
   }

--- a/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/internal/WebSocketSessionTest.groovy
+++ b/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/internal/WebSocketSessionTest.groovy
@@ -15,7 +15,6 @@
  */
 package io.fabric8.mockwebserver.internal
 
-import io.fabric8.mockwebserver.http.Response
 import io.fabric8.mockwebserver.http.WebSocket
 import spock.lang.Specification
 
@@ -29,10 +28,9 @@ class WebSocketSessionTest extends Specification {
 		def session = new WebSocketSession(open, null, null)
 		session.shutdown()
 		def ws = Mock(WebSocket)
-		def response = Mock(Response)
 
 		when: "onOpen is invoked after the executor was shut down (race window between in-flight WebSocket upgrade and MockWebServer.shutdown())"
-		session.onOpen(ws, response)
+		session.onOpen(ws, null)
 
 		then: "No exception is propagated to the caller (Vert.x event loop)"
 		noExceptionThrown()

--- a/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/internal/WebSocketSessionTest.groovy
+++ b/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/internal/WebSocketSessionTest.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.mockwebserver.internal
+
+import io.fabric8.mockwebserver.http.Response
+import io.fabric8.mockwebserver.http.WebSocket
+import spock.lang.Specification
+
+class WebSocketSessionTest extends Specification {
+
+	def "onOpen after shutdown does not propagate RejectedExecutionException"() {
+		given: "A WebSocketSession with open messages whose executor has already been shut down"
+		def open = [
+			new WebSocketMessage(0L, "hello", true)
+		]
+		def session = new WebSocketSession(open, null, null)
+		session.shutdown()
+		def ws = Mock(WebSocket)
+		def response = Mock(Response)
+
+		when: "onOpen is invoked after the executor was shut down (race window between in-flight WebSocket upgrade and MockWebServer.shutdown())"
+		session.onOpen(ws, response)
+
+		then: "No exception is propagated to the caller (Vert.x event loop)"
+		noExceptionThrown()
+	}
+}


### PR DESCRIPTION
## Description

Fixes #7841.

Under `@RepeatedTest` stress, `WebSocketSession.send()` could throw `RejectedExecutionException` from `executor.schedule(...)` during `onOpen` — the per-session `ScheduledExecutorService` had been shut down by `MockDispatcher.shutdown()` while a Vert.x WebSocket upgrade was still in flight, so the upgrade's `onOpen` landed on a dead executor and Vert.x logged it as an `Unhandled exception`.

## Changes

- **`Dispatcher`** — new `releaseResources()` default no-op method. `shutdown()` keeps its existing contract (unblock blocked dispatches like `QueueDispatcher.take()`); `releaseResources()` runs later, after the HTTP server has stopped accepting.
- **`MockDispatcher`** — `WebSocketSession::shutdown` moved from `shutdown()` to `releaseResources()`.
- **`MockWebServer.shutdown()`** — now orchestrates two phases: `dispatcher.shutdown()` → `httpServer.close()` → `dispatcher.releaseResources()`.
- **`WebSocketSession.send()`** — defensive `catch (RejectedExecutionException)` for the residual window (Vert.x's `HttpServer.close()` doesn't strictly drain every in-flight upgrade callback).
- **`KubernetesMixedDispatcher`** — overrides both lifecycle hooks to delegate to its inner `MockDispatcher`. Fixes a pre-existing leak where CRUD-mode WebSocket session executors were never shut down (the old `shutdown()` wasn't being called either).
- Regression test in `WebSocketSessionTest.groovy` reproduces the rejection deterministically.