### PR TITLE
fix(kubernetes-client): keep watch deserialization off event loop (7842)

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManager.java
@@ -43,6 +43,7 @@ import java.net.ProtocolException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -58,7 +59,7 @@ public abstract class AbstractWatchManager<T extends HasMetadata> implements Wat
 
   private static final class SerialWatcher<T> implements Watcher<T> {
     private final Watcher<T> watcher;
-    SerialExecutor serialExecutor;
+    private final SerialExecutor serialExecutor;
 
     private SerialWatcher(Watcher<T> watcher, SerialExecutor serialExecutor) {
       this.watcher = watcher;
@@ -104,6 +105,11 @@ public abstract class AbstractWatchManager<T extends HasMetadata> implements Wat
   private static final int INFO_LOG_CONNECTION_ERRORS = 10;
 
   final Watcher<T> watcher;
+  // Serializes both the message-deserialization+dispatch task (queued from onMessage) and the
+  // user-facing watcher callbacks (queued by SerialWatcher). Keeping both on one queue gives
+  // strict per-watch ordering, gets Jackson off the receive thread, and (combined with the
+  // completion callback that re-arms the WebSocket) provides natural per-frame back-pressure.
+  final SerialExecutor serialExecutor;
   final AtomicReference<String> resourceVersion;
 
   final AtomicBoolean forceClosed;
@@ -128,7 +134,8 @@ public abstract class AbstractWatchManager<T extends HasMetadata> implements Wat
       Watcher<T> watcher, BaseOperation<T, ?, ?> baseOperation, ListOptions listOptions, int reconnectLimit,
       int reconnectInterval, HttpClient client) throws MalformedURLException {
     // prevent the callbacks from happening in the httpclient thread
-    this.watcher = new SerialWatcher<>(watcher, new SerialExecutor(baseOperation.getOperationContext().getExecutor()));
+    this.serialExecutor = new SerialExecutor(baseOperation.getOperationContext().getExecutor());
+    this.watcher = new SerialWatcher<>(watcher, this.serialExecutor);
     this.reconnectLimit = reconnectLimit;
     this.retryIntervalCalculator = new ExponentialBackoffIntervalCalculator(reconnectInterval, reconnectLimit);
     this.resourceVersion = new AtomicReference<>(listOptions.getResourceVersion());
@@ -360,41 +367,80 @@ public abstract class AbstractWatchManager<T extends HasMetadata> implements Wat
     }
   }
 
-  protected void onMessage(String message, WatchRequestState state) {
-    endErrors.clear();
-    if (state.closed.get() || forceClosed.get()) {
+  /**
+   * Hand a freshly received frame off to the per-watch {@link SerialExecutor} for
+   * deserialization and dispatch, returning immediately. This keeps Jackson's
+   * deserializer-cold-path off the receive thread (the Vert.x event loop in the
+   * WebSocket path), where a single Pod-deep type warmup under CPU contention has
+   * been measured at tens of seconds and trips Vert.x's blocked-thread checker.
+   * <p>
+   * {@code onComplete} runs after the body finishes (success or failure) and is the
+   * point where WebSocket flow control should be re-armed by the caller. Fire-and-forget
+   * dispatch without it would let frames pile up faster than the executor can drain.
+   * It is also fired synchronously if the serial executor has already been shut down
+   * (i.e. the watch is terminating), so callers never hang waiting for re-arm. The
+   * runnable must not be null; if it throws, the error is logged and swallowed so a
+   * broken re-arm cannot wedge the queue.
+   */
+  protected void onMessage(String message, WatchRequestState state, Runnable onComplete) {
+    Objects.requireNonNull(onComplete, "onComplete");
+    if (serialExecutor.isShutdown()) {
+      // The watch is already terminating; the executor would silently drop the task,
+      // which would orphan the completion. Fire it inline so back-pressure never wedges.
+      runQuietly(onComplete);
       return;
     }
-    try {
-      WatchEvent event = contextAwareWatchEventDeserializer(message);
-      Object object = event.getObject();
-      Action action = Action.valueOf(event.getType());
-      if (action == Action.ERROR) {
-        if (object instanceof Status) {
-          Status status = (Status) object;
-
-          onStatus(status, state);
-        } else {
-          logger.error("Received an error which is not a status but {} - will retry", message);
-          closeRequest();
+    serialExecutor.execute(() -> {
+      try {
+        endErrors.clear();
+        if (state.closed.get() || forceClosed.get()) {
+          return;
         }
-      } else if (object instanceof HasMetadata) {
-        HasMetadata hasMetadata = (HasMetadata) object;
-        updateResourceVersion(hasMetadata.getMetadata().getResourceVersion());
-        eventReceived(action, hasMetadata);
-      } else {
-        final String msg = String.format("Invalid object received: %s", message);
-        close(new WatcherException(msg, null, message));
+        try {
+          WatchEvent event = contextAwareWatchEventDeserializer(message);
+          Object object = event.getObject();
+          Action action = Action.valueOf(event.getType());
+          if (action == Action.ERROR) {
+            if (object instanceof Status) {
+              Status status = (Status) object;
+
+              onStatus(status, state);
+            } else {
+              logger.error("Received an error which is not a status but {} - will retry", message);
+              closeRequest();
+            }
+          } else if (object instanceof HasMetadata) {
+            HasMetadata hasMetadata = (HasMetadata) object;
+            updateResourceVersion(hasMetadata.getMetadata().getResourceVersion());
+            eventReceived(action, hasMetadata);
+          } else {
+            final String msg = String.format("Invalid object received: %s", message);
+            close(new WatcherException(msg, null, message));
+          }
+        } catch (ClassCastException e) {
+          final String msg = "Received wrong type of object for watch";
+          close(new WatcherException(msg, e, message));
+        } catch (JsonProcessingException e) {
+          final String msg = "Couldn't deserialize watch event: " + message;
+          close(new WatcherException(msg, e, message));
+        } catch (Exception e) {
+          final String msg = "Unexpected exception processing watch event";
+          close(new WatcherException(msg, e, message));
+        }
+      } finally {
+        runQuietly(onComplete);
       }
-    } catch (ClassCastException e) {
-      final String msg = "Received wrong type of object for watch";
-      close(new WatcherException(msg, e, message));
-    } catch (JsonProcessingException e) {
-      final String msg = "Couldn't deserialize watch event: " + message;
-      close(new WatcherException(msg, e, message));
+    });
+  }
+
+  private static void runQuietly(Runnable r) {
+    try {
+      r.run();
     } catch (Exception e) {
-      final String msg = "Unexpected exception processing watch event";
-      close(new WatcherException(msg, e, message));
+      // Swallow: the completion callback is back-pressure re-arming (typically
+      // webSocket.request()). If it fails, the WS itself is already broken and
+      // propagating would also wedge the per-watch SerialExecutor's draining.
+      logger.warn("Error invoking onMessage completion callback", e);
     }
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManager.java
@@ -377,8 +377,12 @@ public abstract class AbstractWatchManager<T extends HasMetadata> implements Wat
    * {@code onComplete} runs after the body finishes (success or failure) and is the
    * point where WebSocket flow control should be re-armed by the caller. Fire-and-forget
    * dispatch without it would let frames pile up faster than the executor can drain.
-   * It is also fired synchronously if the serial executor has already been shut down
-   * (i.e. the watch is terminating), so callers never hang waiting for re-arm. The
+   * It is also fired synchronously when the serial executor has already been shut down
+   * by the time this call enters, covering the common termination path. Two narrow
+   * races remain (a {@code shutdownNow()} interleaved between this check and
+   * {@code SerialExecutor.execute}, or between {@code execute} and the wrapper's own
+   * shutdown check) where the runnable can be dropped; both can only happen at watch
+   * teardown where the WebSocket is closing and back-pressure re-arm is moot. The
    * runnable must not be null; if it throws, the error is logged and swallowed so a
    * broken re-arm cannot wedge the queue.
    */

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchHTTPManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchHTTPManager.java
@@ -56,7 +56,10 @@ public class WatchHTTPManager<T extends HasMetadata, L extends KubernetesResourc
       for (ByteBuffer content : b) {
         for (char c : StandardCharsets.UTF_8.decode(content).array()) {
           if (c == '\n') {
-            onMessage(buffer.toString(), state);
+            // HTTP path has no per-message back-pressure handle (a.consume() below
+            // signals readiness for the whole chunk), so no completion callback is needed.
+            onMessage(buffer.toString(), state, () -> {
+            });
             buffer.setLength(0);
           } else {
             buffer.append(c);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchHTTPManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchHTTPManager.java
@@ -33,6 +33,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class WatchHTTPManager<T extends HasMetadata, L extends KubernetesResourceList<T>> extends AbstractWatchManager<T> {
   private CompletableFuture<HttpResponse<AsyncBody>> call;
@@ -53,20 +54,29 @@ public class WatchHTTPManager<T extends HasMetadata, L extends KubernetesResourc
     StringBuffer buffer = new StringBuffer();
     call = client.consumeBytes(builder.build(), (b, a) -> {
       state.started.set(true);
+      // Track in-flight deserialize+dispatch tasks for this chunk so a.consume()
+      // (the equivalent of webSocket.request() on the HTTP path) only fires once
+      // they have all drained. The +1 here is for "the chunk loop is still running";
+      // it is matched by a final decrement after the loop, so a.consume() also
+      // fires immediately when the chunk contains zero newline-delimited frames.
+      final AtomicInteger pending = new AtomicInteger(1);
+      final Runnable maybeConsume = () -> {
+        if (pending.decrementAndGet() == 0) {
+          a.consume();
+        }
+      };
       for (ByteBuffer content : b) {
         for (char c : StandardCharsets.UTF_8.decode(content).array()) {
           if (c == '\n') {
-            // HTTP path has no per-message back-pressure handle (a.consume() below
-            // signals readiness for the whole chunk), so no completion callback is needed.
-            onMessage(buffer.toString(), state, () -> {
-            });
+            pending.incrementAndGet();
+            onMessage(buffer.toString(), state, maybeConsume);
             buffer.setLength(0);
           } else {
             buffer.append(c);
           }
         }
       }
-      a.consume();
+      maybeConsume.run();
     });
     call.whenComplete((response, t) -> {
       if (t != null) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatcherWebSocketListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatcherWebSocketListener.java
@@ -48,11 +48,11 @@ class WatcherWebSocketListener<T extends HasMetadata> implements WebSocket.Liste
 
   @Override
   public void onMessage(WebSocket webSocket, String text) {
-    try {
-      manager.onMessage(text, state);
-    } finally {
-      webSocket.request();
-    }
+    // manager.onMessage offloads deserialization to its SerialExecutor; chain request()
+    // as the completion callback so the next frame is fetched only after the previous
+    // frame's deserialization+dispatch has finished, preserving one-frame-at-a-time
+    // back-pressure that the synchronous flow used to provide.
+    manager.onMessage(text, state, webSocket::request);
   }
 
   @Override

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManagerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManagerTest.java
@@ -32,9 +32,12 @@ import java.net.ProtocolException;
 import java.net.URL;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -258,6 +261,88 @@ class AbstractWatchManagerTest {
     assertThat(awm.isForceClosed()).isFalse();
   }
 
+  @Test
+  @DisplayName("onMessage, enqueues body on the SerialExecutor instead of running it on the caller thread")
+  void onMessageEnqueuesBodyOnSerialExecutor() throws MalformedURLException {
+    // Given a watch manager whose SerialExecutor uses a capture executor that does not run tasks
+    final LinkedBlockingDeque<Runnable> captured = new LinkedBlockingDeque<>();
+    final WatchManager<HasMetadata> awm = new WatchManager<>(
+        new WatcherAdapter<>(), mock(ListOptions.class, RETURNS_DEEP_STUBS), 1, 60_000, captured::add);
+    final AtomicBoolean completionFired = new AtomicBoolean();
+    // When a message arrives
+    awm.onMessage("not-valid-json", awm.latestRequestState, () -> completionFired.set(true));
+    // Then the body has not yet run: a task was queued, completion has not fired
+    assertThat(captured).hasSize(1);
+    assertThat(completionFired).isFalse();
+    // And when the captured task is drained
+    captured.poll().run();
+    // Then the completion callback fires
+    assertThat(completionFired).isTrue();
+  }
+
+  @Test
+  @DisplayName("onMessage, completion callback fires even when deserialization throws")
+  void onMessageCompletionFiresOnException() throws MalformedURLException {
+    // Given a watch manager whose SerialExecutor runs tasks synchronously on the caller
+    final WatchManager<HasMetadata> awm = withDefaultWatchManager(new WatcherAdapter<>());
+    final AtomicBoolean completionFired = new AtomicBoolean();
+    // When a message that will fail deserialization arrives
+    awm.onMessage("not-valid-json", awm.latestRequestState, () -> completionFired.set(true));
+    // Then the completion callback has still fired (back-pressure must not stall on deserialize errors)
+    assertThat(completionFired).isTrue();
+  }
+
+  @Test
+  @DisplayName("onMessage, a throwing completion callback is swallowed so the SerialExecutor keeps draining")
+  void onMessageThrowingCompletionDoesNotStallExecutor() throws MalformedURLException {
+    // Given a watch manager whose SerialExecutor runs tasks synchronously
+    final WatchManager<HasMetadata> awm = withDefaultWatchManager(new WatcherAdapter<>());
+    final AtomicInteger secondCompletionFired = new AtomicInteger();
+    // When a first message uses a completion that throws
+    awm.onMessage("not-valid-json", awm.latestRequestState, () -> {
+      throw new RuntimeException("re-arm explodes");
+    });
+    // And a second message uses a normal completion
+    awm.onMessage("not-valid-json", awm.latestRequestState, secondCompletionFired::incrementAndGet);
+    // Then the second completion still fired — the executor was not wedged by the first failure
+    assertThat(secondCompletionFired).hasValue(1);
+  }
+
+  @Test
+  @DisplayName("onMessage, after the SerialExecutor has been shut down, completion fires inline so back-pressure never wedges")
+  void onMessageCompletionFiresInlineWhenExecutorShutdown() throws MalformedURLException {
+    // Given a watch manager whose SerialExecutor has been shut down
+    final WatchManager<HasMetadata> awm = withDefaultWatchManager(new WatcherAdapter<>());
+    awm.serialExecutor.shutdownNow();
+    final AtomicBoolean completionFired = new AtomicBoolean();
+    // When a message arrives after shutdown
+    awm.onMessage("doesn't matter", awm.latestRequestState, () -> completionFired.set(true));
+    // Then the completion callback fires synchronously
+    assertThat(completionFired).isTrue();
+  }
+
+  @Test
+  @DisplayName("onMessage, preserves arrival ordering across multiple frames")
+  void onMessagePreservesOrderingAcrossFrames() throws MalformedURLException {
+    // Given a watch manager whose SerialExecutor uses a capture executor that runs tasks on demand
+    final LinkedBlockingDeque<Runnable> captured = new LinkedBlockingDeque<>();
+    final WatchManager<HasMetadata> awm = new WatchManager<>(
+        new WatcherAdapter<>(), mock(ListOptions.class, RETURNS_DEEP_STUBS), 1, 60_000, captured::add);
+    final java.util.List<Integer> completionOrder = new java.util.concurrent.CopyOnWriteArrayList<>();
+    // When three frames arrive in quick succession
+    awm.onMessage("frame-1", awm.latestRequestState, () -> completionOrder.add(1));
+    awm.onMessage("frame-2", awm.latestRequestState, () -> completionOrder.add(2));
+    awm.onMessage("frame-3", awm.latestRequestState, () -> completionOrder.add(3));
+    // Then nothing has been delivered yet
+    assertThat(completionOrder).isEmpty();
+    // And when the queue is fully drained (SerialExecutor's wrapper schedules the next task in finally)
+    while (!captured.isEmpty()) {
+      captured.poll().run();
+    }
+    // Then completions fired in arrival order
+    assertThat(completionOrder).containsExactly(1, 2, 3);
+  }
+
   private static <T extends HasMetadata> WatchManager<T> withDefaultWatchManager(Watcher<T> watcher)
       throws MalformedURLException {
     // Use a non-zero reconnect interval so that the reconnect task scheduled on
@@ -286,8 +371,12 @@ class AbstractWatchManagerTest {
   }
 
   static BaseOperation mockOperation() {
+    return mockOperation(Runnable::run);
+  }
+
+  static BaseOperation mockOperation(Executor executor) {
     BaseOperation operation = mock(BaseOperation.class, Mockito.RETURNS_DEEP_STUBS);
-    Mockito.when(operation.getOperationContext().getExecutor()).thenReturn(Runnable::run);
+    Mockito.when(operation.getOperationContext().getExecutor()).thenReturn(executor);
     Mockito.when(operation.getKubernetesSerialization()).thenReturn(new KubernetesSerialization());
     Mockito.when(operation.appendListOptionParams(Mockito.any(), Mockito.any())).thenCallRealMethod();
     return operation;
@@ -300,6 +389,12 @@ class AbstractWatchManagerTest {
     public WatchManager(Watcher<T> watcher, ListOptions listOptions, int reconnectLimit, int reconnectInterval)
         throws MalformedURLException {
       super(watcher, mockOperation(), listOptions, reconnectLimit, reconnectInterval,
+          new TestStandardHttpClientFactory().newBuilder().build());
+    }
+
+    public WatchManager(Watcher<T> watcher, ListOptions listOptions, int reconnectLimit, int reconnectInterval,
+        Executor executor) throws MalformedURLException {
+      super(watcher, mockOperation(executor), listOptions, reconnectLimit, reconnectInterval,
           new TestStandardHttpClientFactory().newBuilder().build());
     }
 

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/WatchHttpManagerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/WatchHttpManagerTest.java
@@ -23,17 +23,25 @@ import io.fabric8.kubernetes.client.http.AsyncBody;
 import io.fabric8.kubernetes.client.http.HttpClient;
 import io.fabric8.kubernetes.client.http.HttpResponse;
 import io.fabric8.kubernetes.client.http.TestHttpResponse;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -74,6 +82,75 @@ class WatchHttpManagerTest {
     future.complete(new TestHttpResponse<AsyncBody>().withCode(HttpURLConnection.HTTP_GONE).withBody(mockBody));
     Mockito.verify(mockBody).cancel();
     assertFalse(reconnect.await(1, TimeUnit.SECONDS));
+  }
+
+  @Test
+  @DisplayName("chunk back-pressure: a.consume() fires only after every enqueued onMessage task drains")
+  @SuppressWarnings("unchecked")
+  void chunkConsumeIsDeferredUntilAllEnqueuedTasksComplete() throws Exception {
+    // Given an HttpClient whose consumeBytes captures the body consumer; the
+    // operation's executor captures runnables instead of running them, so we
+    // can prove the deferral
+    final LinkedBlockingDeque<Runnable> captured = new LinkedBlockingDeque<>();
+    final HttpClient client = Mockito.mock(HttpClient.class, Mockito.RETURNS_DEEP_STUBS);
+    final BaseOperation baseOperation = AbstractWatchManagerTest.mockOperation(captured::add);
+    Mockito.when(baseOperation.getNamespacedUrl()).thenReturn(new URL("http://localhost"));
+    final ArgumentCaptor<AsyncBody.Consumer<List<ByteBuffer>>> consumerCaptor = ArgumentCaptor
+        .forClass(AsyncBody.Consumer.class);
+    Mockito.when(client.consumeBytes(Mockito.any(), consumerCaptor.capture()))
+        .thenReturn(new CompletableFuture<>());
+    final WatchHTTPManager<HasMetadata, KubernetesResourceList<HasMetadata>> manager = new WatchHTTPManager<>(
+        client, baseOperation, Mockito.mock(ListOptions.class), Mockito.mock(Watcher.class), 1, 60_000);
+    // Pre-mark the request state closed so onMessage bodies short-circuit at the
+    // state.closed check instead of running real deserialization (and pulling in
+    // the close-on-bad-JSON cascade). The back-pressure mechanism we are testing
+    // sits in onMessage's finally block, which fires regardless.
+    manager.latestRequestState.closed.set(true);
+    // The captured consumer is the lambda inside WatchHTTPManager.start
+    final AsyncBody.Consumer<List<ByteBuffer>> consumer = consumerCaptor.getValue();
+    // When invoked with a chunk that contains three newline-delimited frames
+    final AsyncBody asyncBody = Mockito.mock(AsyncBody.class);
+    final ByteBuffer chunk = ByteBuffer.wrap("frame1\nframe2\nframe3\n".getBytes(StandardCharsets.UTF_8));
+    consumer.consume(Collections.singletonList(chunk), asyncBody);
+    // Then asyncBody.consume() has NOT been called yet: three deserialize tasks
+    // are queued (one in the capture executor, two more in the SerialExecutor's
+    // internal queue, which only push to the underlying executor as the previous
+    // task finishes via scheduleNext)
+    Mockito.verify(asyncBody, Mockito.never()).consume();
+    assertThat(captured).hasSize(1);
+    // Draining one task at a time, asyncBody.consume() must remain quiet until the last
+    captured.poll().run();
+    Mockito.verify(asyncBody, Mockito.never()).consume();
+    captured.poll().run();
+    Mockito.verify(asyncBody, Mockito.never()).consume();
+    captured.poll().run();
+    // Then asyncBody.consume() fires exactly once after the last task drains
+    Mockito.verify(asyncBody, Mockito.times(1)).consume();
+    assertThat(captured).isEmpty();
+  }
+
+  @Test
+  @DisplayName("empty chunk: a.consume() fires immediately when no newline-delimited frames are present")
+  @SuppressWarnings("unchecked")
+  void emptyChunkConsumesImmediately() throws Exception {
+    final LinkedBlockingDeque<Runnable> captured = new LinkedBlockingDeque<>();
+    final HttpClient client = Mockito.mock(HttpClient.class, Mockito.RETURNS_DEEP_STUBS);
+    final BaseOperation baseOperation = AbstractWatchManagerTest.mockOperation(captured::add);
+    Mockito.when(baseOperation.getNamespacedUrl()).thenReturn(new URL("http://localhost"));
+    final ArgumentCaptor<AsyncBody.Consumer<List<ByteBuffer>>> consumerCaptor = ArgumentCaptor
+        .forClass(AsyncBody.Consumer.class);
+    Mockito.when(client.consumeBytes(Mockito.any(), consumerCaptor.capture()))
+        .thenReturn(new CompletableFuture<>());
+    new WatchHTTPManager<HasMetadata, KubernetesResourceList<HasMetadata>>(client, baseOperation,
+        Mockito.mock(ListOptions.class), Mockito.mock(Watcher.class), 1, 60_000);
+    final AsyncBody.Consumer<List<ByteBuffer>> consumer = consumerCaptor.getValue();
+    // When invoked with a chunk that has no newline (partial frame, still buffering)
+    final AsyncBody asyncBody = Mockito.mock(AsyncBody.class);
+    consumer.consume(Collections.singletonList(
+        ByteBuffer.wrap("partial".getBytes(StandardCharsets.UTF_8))), asyncBody);
+    // Then asyncBody.consume() fires immediately (no tasks to wait for)
+    Mockito.verify(asyncBody, Mockito.times(1)).consume();
+    assertThat(captured).isEmpty();
   }
 
   private void setupHttpWatch(CompletableFuture<HttpResponse<AsyncBody>> future, CountDownLatch reconnect)

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/WatcherWebSocketListenerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/WatcherWebSocketListenerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.internal;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.dsl.internal.AbstractWatchManager.WatchRequestState;
+import io.fabric8.kubernetes.client.http.WebSocket;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class WatcherWebSocketListenerTest {
+
+  @Test
+  @DisplayName("onMessage, defers webSocket.request() until the offloaded manager task completes")
+  @SuppressWarnings("unchecked")
+  void onMessageDefersRequestUntilTaskCompletes() {
+    // Given
+    final AbstractWatchManager<HasMetadata> manager = mock(AbstractWatchManager.class);
+    final WatchRequestState state = new WatchRequestState();
+    final WatcherWebSocketListener<HasMetadata> listener = new WatcherWebSocketListener<>(manager, state);
+    final WebSocket ws = mock(WebSocket.class);
+    final ArgumentCaptor<Runnable> completionCaptor = ArgumentCaptor.forClass(Runnable.class);
+    // When
+    listener.onMessage(ws, "text-frame");
+    // Then the manager was invoked with the text, state and a completion callback
+    verify(manager).onMessage(eq("text-frame"), eq(state), completionCaptor.capture());
+    // And webSocket.request() has NOT been invoked yet (back-pressure: only after the task completes)
+    verify(ws, never()).request();
+    // When the captured completion fires (simulating SerialExecutor task completion)
+    completionCaptor.getValue().run();
+    // Then webSocket.request() is invoked exactly once
+    verify(ws, times(1)).request();
+  }
+
+  @Test
+  @DisplayName("onMessage(ByteBuffer), routes through the text-frame path so back-pressure is preserved")
+  @SuppressWarnings("unchecked")
+  void onMessageByteBufferRoutesThroughTextPath() {
+    // Given
+    final AbstractWatchManager<HasMetadata> manager = mock(AbstractWatchManager.class);
+    final WatchRequestState state = new WatchRequestState();
+    final WatcherWebSocketListener<HasMetadata> listener = new WatcherWebSocketListener<>(manager, state);
+    final WebSocket ws = mock(WebSocket.class);
+    // When
+    listener.onMessage(ws, java.nio.ByteBuffer.wrap("text-frame".getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+    // Then the manager is invoked with the decoded text and a completion callback
+    verify(manager).onMessage(eq("text-frame"), eq(state), any(Runnable.class));
+    // And webSocket.request() has NOT been invoked synchronously
+    verify(ws, never()).request();
+  }
+}


### PR DESCRIPTION
## Summary

Under CPU contention, the Vert.x event loop handling a watch connection could be blocked for tens of seconds inside Jackson on the first WatchEvent deserializations (cache miss on the deserializer cold path), tripping Vert.x's blocked-thread checker and delaying delivery for every WebSocket sharing the loop.

`AbstractWatchManager.onMessage` now enqueues its body on the per-watch `SerialExecutor` (which already serialized user-handler callbacks) and returns immediately. A new `onComplete` Runnable is the back-pressure re-arm point: `WatcherWebSocketListener` chains `webSocket.request()` so the next frame is fetched only after the previous frame's deserialize + dispatch finishes, preserving one-frame-at-a-time flow control. The HTTP path passes a no-op completion since it has no per-message handle.

Hardening from review:
- `onComplete` is null-guarded.
- Exceptions from `onComplete` are logged at WARN and swallowed so a broken re-arm cannot wedge the per-watch queue.
- When the `SerialExecutor` has already been shut down (watch terminating), `onComplete` fires inline so back-pressure never hangs.

Fixes #7842