### PR TITLE
fix(sonar): add explicit assertions to indirect-verification tests

### DIFF
--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/extended/leaderelection/LeaderElectorTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/extended/leaderelection/LeaderElectorTest.java
@@ -44,6 +44,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static io.fabric8.kubernetes.client.extended.leaderelection.LeaderElector.jitter;
 import static io.fabric8.kubernetes.client.extended.leaderelection.LeaderElector.loop;
 import static io.fabric8.kubernetes.client.extended.leaderelection.LeaderElector.now;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -311,7 +312,7 @@ class LeaderElectorTest {
       completion.complete(null);
     }, () -> 1L, CommonThreadPool.get());
     // When
-    cf.get(500, TimeUnit.MILLISECONDS);
+    assertThat(cf).succeedsWithin(Duration.ofMillis(500));
   }
 
   @Test

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/SerializationTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/SerializationTest.java
@@ -297,7 +297,9 @@ class SerializationTest {
   void unmarshalRawResource() {
     InputStream is = SerializationTest.class.getResourceAsStream("/serialization/invalid-resource.yml");
     RawExtension raw = Serialization.unmarshal(is);
-    ((Map) raw.getValue()).get("not-a").equals("resource");
+    @SuppressWarnings("unchecked")
+    Map<String, String> value = (Map<String, String>) raw.getValue();
+    assertThat(value).containsEntry("not-a", "resource");
   }
 
   @Test

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManagerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManagerTest.java
@@ -30,6 +30,7 @@ import org.mockito.Mockito;
 import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.URL;
+import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ForkJoinPool;
@@ -184,7 +185,7 @@ class AbstractWatchManagerTest {
     awm.cancelReconnect();
     // Then
 
-    done.get(5, TimeUnit.SECONDS);
+    assertThat(done).succeedsWithin(Duration.ofSeconds(5));
   }
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/VisitResourcesTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/VisitResourcesTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @EnableKubernetesMockClient(https = false)
@@ -42,14 +43,14 @@ class VisitResourcesTest {
     // api/v1 is missing
     // apis is missing
     // the following should still succeed
-    client.visitResources(new ApiVisitor() {
+    assertDoesNotThrow(() -> client.visitResources(new ApiVisitor() {
 
       @Override
       public ApiVisitResult visitResource(String group, String version, APIResource apiResource,
           MixedOperation<GenericKubernetesResource, GenericKubernetesResourceList, Resource<GenericKubernetesResource>> operation) {
         throw new AssertionError();
       }
-    });
+    }));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- **SerializationTest.unmarshalRawResource** — fixed a real bug where `.equals()` result was discarded; replaced with `assertThat(value).containsEntry("not-a", "resource")`
- **AbstractWatchManagerTest.reconnectRace** — replaced `done.get(5, SECONDS)` with `assertThat(done).succeedsWithin(Duration.ofSeconds(5))`
- **VisitResourcesTest.testMissingApiResourcesAndGroups** — wrapped body in `assertDoesNotThrow(...)`
- **LeaderElectorTest.loopCompletesOk** — replaced `cf.get(500, MILLISECONDS)` with `assertThat(cf).succeedsWithin(Duration.ofMillis(500))`

Fixes #7826

## Test plan
- [x] All 4 modified tests pass individually (`mvn test -Dtest=...`)
- [x] Formatting check passes (`mvn spotless:check`)
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)