### PR TITLE
chore(deps): bump istio.io/client-go from 1.29.2 to 1.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * Fix #7837: (kubernetes-client) Follow-ups on shard selector
 
 #### Dependency Upgrade
-* Fix #PLACEHOLDER: bump istio.io/client-go from 1.29.2 to 1.30.0
+* Fix #7849: bump istio.io/client-go from 1.29.2 to 1.30.0
 
 #### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix #7837: (kubernetes-client) Follow-ups on shard selector
 
 #### Dependency Upgrade
+* Fix #PLACEHOLDER: bump istio.io/client-go from 1.29.2 to 1.30.0
 
 #### New Features
 

--- a/extensions/istio/model/src/generated/java/io/fabric8/istio/api/api/extensions/v1alpha1/IsTrafficExtensionFilterConfig.java
+++ b/extensions/istio/model/src/generated/java/io/fabric8/istio/api/api/extensions/v1alpha1/IsTrafficExtensionFilterConfig.java
@@ -1,0 +1,26 @@
+
+package io.fabric8.istio.api.api.extensions.v1alpha1;
+
+import javax.annotation.processing.Generated;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonTypeResolver;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonTypeResolver(io.fabric8.kubernetes.model.jackson.UnwrappedTypeResolverBuilder.class)
+@JsonSubTypes({
+    @JsonSubTypes.Type(TrafficExtensionLua.class),
+    @JsonSubTypes.Type(TrafficExtensionWasm.class),
+})
+@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
+@Generated("io.fabric8.kubernetes.schema.generator.model.ModelGenerator")
+public interface IsTrafficExtensionFilterConfig extends KubernetesResource
+{
+
+
+
+}

--- a/extensions/istio/model/src/generated/java/io/fabric8/istio/api/api/extensions/v1alpha1/LuaConfig.java
+++ b/extensions/istio/model/src/generated/java/io/fabric8/istio/api/api/extensions/v1alpha1/LuaConfig.java
@@ -1,9 +1,7 @@
 
-package io.fabric8.istio.api.api.meta.v1alpha1;
+package io.fabric8.istio.api.api.extensions.v1alpha1;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import javax.annotation.processing.Generated;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
@@ -13,11 +11,9 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import io.fabric8.istio.api.api.analysis.v1alpha1.AnalysisMessageBase;
 import io.fabric8.kubernetes.api.builder.Editable;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerPort;
-import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -35,12 +31,13 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.Accessors;
 
+/**
+ * LuaConfig configures a Lua filter.<br><p> <br><p> Lua filters provide a lightweight alternative to WebAssembly for simple request/response transformations. The Lua code is executed inline within the Envoy proxy.<br><p> <br><p> Example: Simple header manipulation<br><p> <br><p> ```yaml lua:<br><p> <br><p> 	inlineCode: |<br><p> 	  function envoy_on_request(request_handle)<br><p> 	    request_handle:headers():add("x-custom-header", "custom-value")<br><p> 	  end<br><p> <br><p> ```<br><p> <br><p> The Lua script must define one or both of the following functions: - `envoy_on_request(request_handle)`: Called when a request is received - `envoy_on_response(response_handle)`: Called when a response is received<br><p> <br><p> The request_handle and response_handle provide access to headers, body, metadata, and other request/response attributes. See the Envoy Lua filter documentation for the complete API: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/lua_filter
+ */
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "conditions",
-    "observedGeneration",
-    "validationMessages"
+    "inlineCode"
 })
 @ToString
 @EqualsAndHashCode
@@ -58,96 +55,54 @@ import lombok.experimental.Accessors;
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
-    @BuildableReference(EnvVar.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
     @BuildableReference(ContainerPort.class),
     @BuildableReference(Volume.class),
     @BuildableReference(VolumeMount.class)
 })
 @Generated("io.fabric8.kubernetes.schema.generator.model.ModelGenerator")
-public class IstioStatus implements Editable<IstioStatusBuilder>, KubernetesResource
+public class LuaConfig implements Editable<LuaConfigBuilder>, KubernetesResource
 {
 
-    @JsonProperty("conditions")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<IstioCondition> conditions = new ArrayList<>();
-    @JsonProperty("observedGeneration")
-    private Long observedGeneration;
-    @JsonProperty("validationMessages")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<AnalysisMessageBase> validationMessages = new ArrayList<>();
+    @JsonProperty("inlineCode")
+    private String inlineCode;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
      */
-    public IstioStatus() {
+    public LuaConfig() {
     }
 
-    public IstioStatus(List<IstioCondition> conditions, Long observedGeneration, List<AnalysisMessageBase> validationMessages) {
+    public LuaConfig(String inlineCode) {
         super();
-        this.conditions = conditions;
-        this.observedGeneration = observedGeneration;
-        this.validationMessages = validationMessages;
+        this.inlineCode = inlineCode;
     }
 
     /**
-     * Current service state of the resource.
+     * The inline Lua code to be executed. The code must be a valid Lua script that defines the appropriate callback functions (`envoy_on_request` and/or `envoy_on_response`).<br><p> <br><p> The maximum size is 64KB. For larger or more complex filters, use a WebAssembly filter instead.
      */
-    @JsonProperty("conditions")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<IstioCondition> getConditions() {
-        return conditions;
+    @JsonProperty("inlineCode")
+    public String getInlineCode() {
+        return inlineCode;
     }
 
     /**
-     * Current service state of the resource.
+     * The inline Lua code to be executed. The code must be a valid Lua script that defines the appropriate callback functions (`envoy_on_request` and/or `envoy_on_response`).<br><p> <br><p> The maximum size is 64KB. For larger or more complex filters, use a WebAssembly filter instead.
      */
-    @JsonProperty("conditions")
-    public void setConditions(List<IstioCondition> conditions) {
-        this.conditions = conditions;
-    }
-
-    /**
-     * $hide_from_docs Deprecated. IstioCondition observed_generation will show the resource generation for which the condition was generated. Resource Generation to which the Reconciled Condition refers. When this value is not equal to the object's metadata generation, reconciled condition  calculation for the current generation is still in progress.
-     */
-    @JsonProperty("observedGeneration")
-    public Long getObservedGeneration() {
-        return observedGeneration;
-    }
-
-    /**
-     * $hide_from_docs Deprecated. IstioCondition observed_generation will show the resource generation for which the condition was generated. Resource Generation to which the Reconciled Condition refers. When this value is not equal to the object's metadata generation, reconciled condition  calculation for the current generation is still in progress.
-     */
-    @JsonProperty("observedGeneration")
-    public void setObservedGeneration(Long observedGeneration) {
-        this.observedGeneration = observedGeneration;
-    }
-
-    /**
-     * Includes any errors or warnings detected by Istio's analyzers.
-     */
-    @JsonProperty("validationMessages")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<AnalysisMessageBase> getValidationMessages() {
-        return validationMessages;
-    }
-
-    /**
-     * Includes any errors or warnings detected by Istio's analyzers.
-     */
-    @JsonProperty("validationMessages")
-    public void setValidationMessages(List<AnalysisMessageBase> validationMessages) {
-        this.validationMessages = validationMessages;
+    @JsonProperty("inlineCode")
+    public void setInlineCode(String inlineCode) {
+        this.inlineCode = inlineCode;
     }
 
     @JsonIgnore
-    public IstioStatusBuilder edit() {
-        return new IstioStatusBuilder(this);
+    public LuaConfigBuilder edit() {
+        return new LuaConfigBuilder(this);
     }
 
     @JsonIgnore
-    public IstioStatusBuilder toBuilder() {
+    public LuaConfigBuilder toBuilder() {
         return edit();
     }
 

--- a/extensions/istio/model/src/generated/java/io/fabric8/istio/api/api/extensions/v1alpha1/TrafficExtension.java
+++ b/extensions/istio/model/src/generated/java/io/fabric8/istio/api/api/extensions/v1alpha1/TrafficExtension.java
@@ -1,0 +1,240 @@
+
+package io.fabric8.istio.api.api.extensions.v1alpha1;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.processing.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.istio.api.api.type.v1beta1.PolicyTargetReference;
+import io.fabric8.istio.api.api.type.v1beta1.WorkloadSelector;
+import io.fabric8.kubernetes.api.builder.Editable;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerPort;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+/**
+ * &lt;!-- crd generation tags --&gt;<br><p> <br><p> &lt;!-- go code generation tags --&gt;
+ */
+@JsonDeserialize(using = io.fabric8.kubernetes.model.jackson.JsonUnwrappedDeserializer.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "FilterConfig",
+    "match",
+    "phase",
+    "priority",
+    "selector",
+    "targetRefs"
+})
+@ToString
+@EqualsAndHashCode
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @BuildableReference(ContainerPort.class),
+    @BuildableReference(Volume.class),
+    @BuildableReference(VolumeMount.class)
+})
+@Version("v1alpha1")
+@Group("")
+@Generated("io.fabric8.kubernetes.schema.generator.model.ModelGenerator")
+public class TrafficExtension implements Editable<TrafficExtensionBuilder>, KubernetesResource, Namespaced
+{
+
+    @JsonProperty("FilterConfig")
+    @JsonUnwrapped
+    private IsTrafficExtensionFilterConfig filterConfig;
+    @JsonProperty("match")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<TrafficSelector> match = new ArrayList<>();
+    @JsonProperty("phase")
+    private TrafficExtensionExecutionPhase phase;
+    @JsonProperty("priority")
+    private Integer priority;
+    @JsonProperty("selector")
+    private WorkloadSelector selector;
+    @JsonProperty("targetRefs")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<PolicyTargetReference> targetRefs = new ArrayList<>();
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     */
+    public TrafficExtension() {
+    }
+
+    public TrafficExtension(IsTrafficExtensionFilterConfig filterConfig, List<TrafficSelector> match, TrafficExtensionExecutionPhase phase, Integer priority, WorkloadSelector selector, List<PolicyTargetReference> targetRefs) {
+        super();
+        this.filterConfig = filterConfig;
+        this.match = match;
+        this.phase = phase;
+        this.priority = priority;
+        this.selector = selector;
+        this.targetRefs = targetRefs;
+    }
+
+    /**
+     * &lt;!-- crd generation tags --&gt;<br><p> <br><p> &lt;!-- go code generation tags --&gt;
+     */
+    @JsonProperty("FilterConfig")
+    @JsonUnwrapped
+    public IsTrafficExtensionFilterConfig getFilterConfig() {
+        return filterConfig;
+    }
+
+    /**
+     * &lt;!-- crd generation tags --&gt;<br><p> <br><p> &lt;!-- go code generation tags --&gt;
+     */
+    @JsonProperty("FilterConfig")
+    public void setFilterConfig(IsTrafficExtensionFilterConfig filterConfig) {
+        this.filterConfig = filterConfig;
+    }
+
+    /**
+     * Specifies the criteria to determine which traffic is passed to TrafficExtension. If a traffic satisfies any of TrafficSelectors, the traffic passes the TrafficExtension.
+     */
+    @JsonProperty("match")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<TrafficSelector> getMatch() {
+        return match;
+    }
+
+    /**
+     * Specifies the criteria to determine which traffic is passed to TrafficExtension. If a traffic satisfies any of TrafficSelectors, the traffic passes the TrafficExtension.
+     */
+    @JsonProperty("match")
+    public void setMatch(List<TrafficSelector> match) {
+        this.match = match;
+    }
+
+    /**
+     * &lt;!-- crd generation tags --&gt;<br><p> <br><p> &lt;!-- go code generation tags --&gt;
+     */
+    @JsonProperty("phase")
+    public TrafficExtensionExecutionPhase getPhase() {
+        return phase;
+    }
+
+    /**
+     * &lt;!-- crd generation tags --&gt;<br><p> <br><p> &lt;!-- go code generation tags --&gt;
+     */
+    @JsonProperty("phase")
+    public void setPhase(TrafficExtensionExecutionPhase phase) {
+        this.phase = phase;
+    }
+
+    /**
+     * &lt;!-- crd generation tags --&gt;<br><p> <br><p> &lt;!-- go code generation tags --&gt;
+     */
+    @JsonProperty("priority")
+    public Integer getPriority() {
+        return priority;
+    }
+
+    /**
+     * &lt;!-- crd generation tags --&gt;<br><p> <br><p> &lt;!-- go code generation tags --&gt;
+     */
+    @JsonProperty("priority")
+    public void setPriority(Integer priority) {
+        this.priority = priority;
+    }
+
+    /**
+     * &lt;!-- crd generation tags --&gt;<br><p> <br><p> &lt;!-- go code generation tags --&gt;
+     */
+    @JsonProperty("selector")
+    public WorkloadSelector getSelector() {
+        return selector;
+    }
+
+    /**
+     * &lt;!-- crd generation tags --&gt;<br><p> <br><p> &lt;!-- go code generation tags --&gt;
+     */
+    @JsonProperty("selector")
+    public void setSelector(WorkloadSelector selector) {
+        this.selector = selector;
+    }
+
+    /**
+     * Optional. The targetRefs specifies a list of resources the policy should be applied to. The targeted resources specified will determine which workloads the policy applies to.<br><p> <br><p> Currently, the following resource attachment types are supported: &#42; `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace. &#42; `kind: GatewayClass` with `group: gateway.networking.k8s.io` in the root namespace. &#42; `kind: Service` with `group: ""` or `group: "core"` in the same namespace. This type is only supported for waypoints. &#42; `kind: ServiceEntry` with `group: networking.istio.io` in the same namespace.<br><p> <br><p> If not set, the policy is applied as defined by the selector. At most one of the selector and targetRefs can be set.<br><p> <br><p> NOTE: Waypoint proxies are required to use this field for policies to apply; `selector` policies will be ignored.
+     */
+    @JsonProperty("targetRefs")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<PolicyTargetReference> getTargetRefs() {
+        return targetRefs;
+    }
+
+    /**
+     * Optional. The targetRefs specifies a list of resources the policy should be applied to. The targeted resources specified will determine which workloads the policy applies to.<br><p> <br><p> Currently, the following resource attachment types are supported: &#42; `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace. &#42; `kind: GatewayClass` with `group: gateway.networking.k8s.io` in the root namespace. &#42; `kind: Service` with `group: ""` or `group: "core"` in the same namespace. This type is only supported for waypoints. &#42; `kind: ServiceEntry` with `group: networking.istio.io` in the same namespace.<br><p> <br><p> If not set, the policy is applied as defined by the selector. At most one of the selector and targetRefs can be set.<br><p> <br><p> NOTE: Waypoint proxies are required to use this field for policies to apply; `selector` policies will be ignored.
+     */
+    @JsonProperty("targetRefs")
+    public void setTargetRefs(List<PolicyTargetReference> targetRefs) {
+        this.targetRefs = targetRefs;
+    }
+
+    @JsonIgnore
+    public TrafficExtensionBuilder edit() {
+        return new TrafficExtensionBuilder(this);
+    }
+
+    @JsonIgnore
+    public TrafficExtensionBuilder toBuilder() {
+        return edit();
+    }
+
+    @JsonAnyGetter
+    @JsonIgnore
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public void setAdditionalProperties(Map<String, Object> additionalProperties) {
+        this.additionalProperties = additionalProperties;
+    }
+
+}

--- a/extensions/istio/model/src/generated/java/io/fabric8/istio/api/api/extensions/v1alpha1/TrafficExtensionExecutionPhase.java
+++ b/extensions/istio/model/src/generated/java/io/fabric8/istio/api/api/extensions/v1alpha1/TrafficExtensionExecutionPhase.java
@@ -1,0 +1,42 @@
+
+package io.fabric8.istio.api.api.extensions.v1alpha1;
+
+import javax.annotation.processing.Generated;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+/**
+ * ExecutionPhase specifies where in the filter chain a `TrafficExtension` is injected.
+ */
+@Generated("io.fabric8.kubernetes.schema.generator.model.ModelGenerator")
+public enum TrafficExtensionExecutionPhase 
+{
+    AUTHN(1),
+    AUTHZ(2),
+    STATS(3),
+    UNSPECIFIED(0);
+    private final int value;
+    private TrafficExtensionExecutionPhase(int value) {
+        this.value = value;
+    }
+
+    @JsonCreator
+    public static TrafficExtensionExecutionPhase fromValue(Object value) {
+        if (value instanceof String) {
+            for (TrafficExtensionExecutionPhase e : TrafficExtensionExecutionPhase.values()) {
+                if (e.name().equalsIgnoreCase(value.toString())) {
+                    return e;
+                }
+            }
+        } else if (value instanceof Integer) {
+            for (TrafficExtensionExecutionPhase e : TrafficExtensionExecutionPhase.values()) {
+                if (value.equals(e.value)) {
+                    return e;
+                }
+            }
+        }
+        return null;
+    }
+
+
+
+}

--- a/extensions/istio/model/src/generated/java/io/fabric8/istio/api/api/extensions/v1alpha1/TrafficExtensionLua.java
+++ b/extensions/istio/model/src/generated/java/io/fabric8/istio/api/api/extensions/v1alpha1/TrafficExtensionLua.java
@@ -1,9 +1,7 @@
 
-package io.fabric8.istio.api.api.meta.v1alpha1;
+package io.fabric8.istio.api.api.extensions.v1alpha1;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import javax.annotation.processing.Generated;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
@@ -13,11 +11,9 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import io.fabric8.istio.api.api.analysis.v1alpha1.AnalysisMessageBase;
 import io.fabric8.kubernetes.api.builder.Editable;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerPort;
-import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -38,9 +34,7 @@ import lombok.experimental.Accessors;
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "conditions",
-    "observedGeneration",
-    "validationMessages"
+    "lua"
 })
 @ToString
 @EqualsAndHashCode
@@ -58,96 +52,48 @@ import lombok.experimental.Accessors;
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
-    @BuildableReference(EnvVar.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
     @BuildableReference(ContainerPort.class),
     @BuildableReference(Volume.class),
     @BuildableReference(VolumeMount.class)
 })
 @Generated("io.fabric8.kubernetes.schema.generator.model.ModelGenerator")
-public class IstioStatus implements Editable<IstioStatusBuilder>, KubernetesResource
+public class TrafficExtensionLua implements IsTrafficExtensionFilterConfig, Editable<TrafficExtensionLuaBuilder>, KubernetesResource
 {
 
-    @JsonProperty("conditions")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<IstioCondition> conditions = new ArrayList<>();
-    @JsonProperty("observedGeneration")
-    private Long observedGeneration;
-    @JsonProperty("validationMessages")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<AnalysisMessageBase> validationMessages = new ArrayList<>();
+    @JsonProperty("lua")
+    private LuaConfig lua;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
      */
-    public IstioStatus() {
+    public TrafficExtensionLua() {
     }
 
-    public IstioStatus(List<IstioCondition> conditions, Long observedGeneration, List<AnalysisMessageBase> validationMessages) {
+    public TrafficExtensionLua(LuaConfig lua) {
         super();
-        this.conditions = conditions;
-        this.observedGeneration = observedGeneration;
-        this.validationMessages = validationMessages;
+        this.lua = lua;
     }
 
-    /**
-     * Current service state of the resource.
-     */
-    @JsonProperty("conditions")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<IstioCondition> getConditions() {
-        return conditions;
+    @JsonProperty("lua")
+    public LuaConfig getLua() {
+        return lua;
     }
 
-    /**
-     * Current service state of the resource.
-     */
-    @JsonProperty("conditions")
-    public void setConditions(List<IstioCondition> conditions) {
-        this.conditions = conditions;
-    }
-
-    /**
-     * $hide_from_docs Deprecated. IstioCondition observed_generation will show the resource generation for which the condition was generated. Resource Generation to which the Reconciled Condition refers. When this value is not equal to the object's metadata generation, reconciled condition  calculation for the current generation is still in progress.
-     */
-    @JsonProperty("observedGeneration")
-    public Long getObservedGeneration() {
-        return observedGeneration;
-    }
-
-    /**
-     * $hide_from_docs Deprecated. IstioCondition observed_generation will show the resource generation for which the condition was generated. Resource Generation to which the Reconciled Condition refers. When this value is not equal to the object's metadata generation, reconciled condition  calculation for the current generation is still in progress.
-     */
-    @JsonProperty("observedGeneration")
-    public void setObservedGeneration(Long observedGeneration) {
-        this.observedGeneration = observedGeneration;
-    }
-
-    /**
-     * Includes any errors or warnings detected by Istio's analyzers.
-     */
-    @JsonProperty("validationMessages")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<AnalysisMessageBase> getValidationMessages() {
-        return validationMessages;
-    }
-
-    /**
-     * Includes any errors or warnings detected by Istio's analyzers.
-     */
-    @JsonProperty("validationMessages")
-    public void setValidationMessages(List<AnalysisMessageBase> validationMessages) {
-        this.validationMessages = validationMessages;
+    @JsonProperty("lua")
+    public void setLua(LuaConfig lua) {
+        this.lua = lua;
     }
 
     @JsonIgnore
-    public IstioStatusBuilder edit() {
-        return new IstioStatusBuilder(this);
+    public TrafficExtensionLuaBuilder edit() {
+        return new TrafficExtensionLuaBuilder(this);
     }
 
     @JsonIgnore
-    public IstioStatusBuilder toBuilder() {
+    public TrafficExtensionLuaBuilder toBuilder() {
         return edit();
     }
 

--- a/extensions/istio/model/src/generated/java/io/fabric8/istio/api/api/extensions/v1alpha1/TrafficExtensionWasm.java
+++ b/extensions/istio/model/src/generated/java/io/fabric8/istio/api/api/extensions/v1alpha1/TrafficExtensionWasm.java
@@ -1,9 +1,7 @@
 
-package io.fabric8.istio.api.api.meta.v1alpha1;
+package io.fabric8.istio.api.api.extensions.v1alpha1;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import javax.annotation.processing.Generated;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
@@ -13,11 +11,9 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import io.fabric8.istio.api.api.analysis.v1alpha1.AnalysisMessageBase;
 import io.fabric8.kubernetes.api.builder.Editable;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerPort;
-import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -38,9 +34,7 @@ import lombok.experimental.Accessors;
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "conditions",
-    "observedGeneration",
-    "validationMessages"
+    "wasm"
 })
 @ToString
 @EqualsAndHashCode
@@ -58,96 +52,48 @@ import lombok.experimental.Accessors;
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
-    @BuildableReference(EnvVar.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
     @BuildableReference(ContainerPort.class),
     @BuildableReference(Volume.class),
     @BuildableReference(VolumeMount.class)
 })
 @Generated("io.fabric8.kubernetes.schema.generator.model.ModelGenerator")
-public class IstioStatus implements Editable<IstioStatusBuilder>, KubernetesResource
+public class TrafficExtensionWasm implements IsTrafficExtensionFilterConfig, Editable<TrafficExtensionWasmBuilder>, KubernetesResource
 {
 
-    @JsonProperty("conditions")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<IstioCondition> conditions = new ArrayList<>();
-    @JsonProperty("observedGeneration")
-    private Long observedGeneration;
-    @JsonProperty("validationMessages")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<AnalysisMessageBase> validationMessages = new ArrayList<>();
+    @JsonProperty("wasm")
+    private WasmConfig wasm;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
      */
-    public IstioStatus() {
+    public TrafficExtensionWasm() {
     }
 
-    public IstioStatus(List<IstioCondition> conditions, Long observedGeneration, List<AnalysisMessageBase> validationMessages) {
+    public TrafficExtensionWasm(WasmConfig wasm) {
         super();
-        this.conditions = conditions;
-        this.observedGeneration = observedGeneration;
-        this.validationMessages = validationMessages;
+        this.wasm = wasm;
     }
 
-    /**
-     * Current service state of the resource.
-     */
-    @JsonProperty("conditions")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<IstioCondition> getConditions() {
-        return conditions;
+    @JsonProperty("wasm")
+    public WasmConfig getWasm() {
+        return wasm;
     }
 
-    /**
-     * Current service state of the resource.
-     */
-    @JsonProperty("conditions")
-    public void setConditions(List<IstioCondition> conditions) {
-        this.conditions = conditions;
-    }
-
-    /**
-     * $hide_from_docs Deprecated. IstioCondition observed_generation will show the resource generation for which the condition was generated. Resource Generation to which the Reconciled Condition refers. When this value is not equal to the object's metadata generation, reconciled condition  calculation for the current generation is still in progress.
-     */
-    @JsonProperty("observedGeneration")
-    public Long getObservedGeneration() {
-        return observedGeneration;
-    }
-
-    /**
-     * $hide_from_docs Deprecated. IstioCondition observed_generation will show the resource generation for which the condition was generated. Resource Generation to which the Reconciled Condition refers. When this value is not equal to the object's metadata generation, reconciled condition  calculation for the current generation is still in progress.
-     */
-    @JsonProperty("observedGeneration")
-    public void setObservedGeneration(Long observedGeneration) {
-        this.observedGeneration = observedGeneration;
-    }
-
-    /**
-     * Includes any errors or warnings detected by Istio's analyzers.
-     */
-    @JsonProperty("validationMessages")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<AnalysisMessageBase> getValidationMessages() {
-        return validationMessages;
-    }
-
-    /**
-     * Includes any errors or warnings detected by Istio's analyzers.
-     */
-    @JsonProperty("validationMessages")
-    public void setValidationMessages(List<AnalysisMessageBase> validationMessages) {
-        this.validationMessages = validationMessages;
+    @JsonProperty("wasm")
+    public void setWasm(WasmConfig wasm) {
+        this.wasm = wasm;
     }
 
     @JsonIgnore
-    public IstioStatusBuilder edit() {
-        return new IstioStatusBuilder(this);
+    public TrafficExtensionWasmBuilder edit() {
+        return new TrafficExtensionWasmBuilder(this);
     }
 
     @JsonIgnore
-    public IstioStatusBuilder toBuilder() {
+    public TrafficExtensionWasmBuilder toBuilder() {
         return edit();
     }
 

--- a/extensions/istio/model/src/generated/java/io/fabric8/istio/api/api/extensions/v1alpha1/TrafficSelector.java
+++ b/extensions/istio/model/src/generated/java/io/fabric8/istio/api/api/extensions/v1alpha1/TrafficSelector.java
@@ -1,5 +1,5 @@
 
-package io.fabric8.istio.api.api.meta.v1alpha1;
+package io.fabric8.istio.api.api.extensions.v1alpha1;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -13,11 +13,10 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import io.fabric8.istio.api.api.analysis.v1alpha1.AnalysisMessageBase;
+import io.fabric8.istio.api.api.type.v1beta1.PortSelector;
 import io.fabric8.kubernetes.api.builder.Editable;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerPort;
-import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -35,12 +34,14 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.Accessors;
 
+/**
+ * TrafficSelector provides a mechanism to select a specific traffic flow for which a TrafficExtension will be enabled. When all the sub conditions in the TrafficSelector are satisfied, the traffic will be selected.
+ */
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "conditions",
-    "observedGeneration",
-    "validationMessages"
+    "mode",
+    "ports"
 })
 @ToString
 @EqualsAndHashCode
@@ -58,96 +59,75 @@ import lombok.experimental.Accessors;
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
-    @BuildableReference(EnvVar.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
     @BuildableReference(ContainerPort.class),
     @BuildableReference(Volume.class),
     @BuildableReference(VolumeMount.class)
 })
 @Generated("io.fabric8.kubernetes.schema.generator.model.ModelGenerator")
-public class IstioStatus implements Editable<IstioStatusBuilder>, KubernetesResource
+public class TrafficSelector implements Editable<TrafficSelectorBuilder>, KubernetesResource
 {
 
-    @JsonProperty("conditions")
+    @JsonProperty("mode")
+    private Integer mode;
+    @JsonProperty("ports")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<IstioCondition> conditions = new ArrayList<>();
-    @JsonProperty("observedGeneration")
-    private Long observedGeneration;
-    @JsonProperty("validationMessages")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<AnalysisMessageBase> validationMessages = new ArrayList<>();
+    private List<PortSelector> ports = new ArrayList<>();
     @JsonIgnore
     private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
      */
-    public IstioStatus() {
+    public TrafficSelector() {
     }
 
-    public IstioStatus(List<IstioCondition> conditions, Long observedGeneration, List<AnalysisMessageBase> validationMessages) {
+    public TrafficSelector(Integer mode, List<PortSelector> ports) {
         super();
-        this.conditions = conditions;
-        this.observedGeneration = observedGeneration;
-        this.validationMessages = validationMessages;
+        this.mode = mode;
+        this.ports = ports;
     }
 
     /**
-     * Current service state of the resource.
+     * Criteria for selecting traffic by their direction. Note that `CLIENT` and `SERVER` are analogous to OUTBOUND and INBOUND, respectively. For the gateway, the field should be `CLIENT` or `CLIENT_AND_SERVER`. If not specified, the default value is `CLIENT_AND_SERVER`.
      */
-    @JsonProperty("conditions")
+    @JsonProperty("mode")
+    public Integer getMode() {
+        return mode;
+    }
+
+    /**
+     * Criteria for selecting traffic by their direction. Note that `CLIENT` and `SERVER` are analogous to OUTBOUND and INBOUND, respectively. For the gateway, the field should be `CLIENT` or `CLIENT_AND_SERVER`. If not specified, the default value is `CLIENT_AND_SERVER`.
+     */
+    @JsonProperty("mode")
+    public void setMode(Integer mode) {
+        this.mode = mode;
+    }
+
+    /**
+     * Criteria for selecting traffic by their destination port. More specifically, for the outbound traffic, the destination port would be the port of the target service. On the other hand, for the inbound traffic, the destination port is the port bound by the server process in the same Pod.<br><p> <br><p> If one of the given `ports` is matched, this condition is evaluated to true. If not specified, this condition is evaluated to true for any port.
+     */
+    @JsonProperty("ports")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<IstioCondition> getConditions() {
-        return conditions;
+    public List<PortSelector> getPorts() {
+        return ports;
     }
 
     /**
-     * Current service state of the resource.
+     * Criteria for selecting traffic by their destination port. More specifically, for the outbound traffic, the destination port would be the port of the target service. On the other hand, for the inbound traffic, the destination port is the port bound by the server process in the same Pod.<br><p> <br><p> If one of the given `ports` is matched, this condition is evaluated to true. If not specified, this condition is evaluated to true for any port.
      */
-    @JsonProperty("conditions")
-    public void setConditions(List<IstioCondition> conditions) {
-        this.conditions = conditions;
-    }
-
-    /**
-     * $hide_from_docs Deprecated. IstioCondition observed_generation will show the resource generation for which the condition was generated. Resource Generation to which the Reconciled Condition refers. When this value is not equal to the object's metadata generation, reconciled condition  calculation for the current generation is still in progress.
-     */
-    @JsonProperty("observedGeneration")
-    public Long getObservedGeneration() {
-        return observedGeneration;
-    }
-
-    /**
-     * $hide_from_docs Deprecated. IstioCondition observed_generation will show the resource generation for which the condition was generated. Resource Generation to which the Reconciled Condition refers. When this value is not equal to the object's metadata generation, reconciled condition  calculation for the current generation is still in progress.
-     */
-    @JsonProperty("observedGeneration")
-    public void setObservedGeneration(Long observedGeneration) {
-        this.observedGeneration = observedGeneration;
-    }
-
-    /**
-     * Includes any errors or warnings detected by Istio's analyzers.
-     */
-    @JsonProperty("validationMessages")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<AnalysisMessageBase> getValidationMessages() {
-        return validationMessages;
-    }
-
-    /**
-     * Includes any errors or warnings detected by Istio's analyzers.
-     */
-    @JsonProperty("validationMessages")
-    public void setValidationMessages(List<AnalysisMessageBase> validationMessages) {
-        this.validationMessages = validationMessages;
+    @JsonProperty("ports")
+    public void setPorts(List<PortSelector> ports) {
+        this.ports = ports;
     }
 
     @JsonIgnore
-    public IstioStatusBuilder edit() {
-        return new IstioStatusBuilder(this);
+    public TrafficSelectorBuilder edit() {
+        return new TrafficSelectorBuilder(this);
     }
 
     @JsonIgnore
-    public IstioStatusBuilder toBuilder() {
+    public TrafficSelectorBuilder toBuilder() {
         return edit();
     }
 

--- a/extensions/istio/model/src/generated/java/io/fabric8/istio/api/api/extensions/v1alpha1/WasmConfig.java
+++ b/extensions/istio/model/src/generated/java/io/fabric8/istio/api/api/extensions/v1alpha1/WasmConfig.java
@@ -1,0 +1,306 @@
+
+package io.fabric8.istio.api.api.extensions.v1alpha1;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.processing.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.builder.Editable;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerPort;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+/**
+ * WasmConfig configures a WebAssembly filter.<br><p> <br><p> Example:<br><p> <br><p> ```yaml wasm:<br><p> <br><p> 	url: oci://gcr.io/myproject/filter:v1.0.0<br><p> 	sha256: abc123...<br><p> 	imagePullPolicy: IfNotPresent<br><p> 	imagePullSecret: gcr-secret<br><p> 	pluginName: my-filter<br><p> 	pluginConfig:<br><p> 	  key1: value1<br><p> 	  key2: value2<br><p> 	failStrategy: FAIL_CLOSE<br><p> 	vmConfig:<br><p> 	  env:<br><p> 	  - name: SOME_ENV_VAR<br><p> 	    value: some_value<br><p> 	type: HTTP<br><p> <br><p> ```
+ */
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "failStrategy",
+    "imagePullPolicy",
+    "imagePullSecret",
+    "pluginConfig",
+    "pluginName",
+    "sha256",
+    "type",
+    "url",
+    "verificationKey",
+    "vmConfig"
+})
+@ToString
+@EqualsAndHashCode
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @BuildableReference(ContainerPort.class),
+    @BuildableReference(Volume.class),
+    @BuildableReference(VolumeMount.class)
+})
+@Generated("io.fabric8.kubernetes.schema.generator.model.ModelGenerator")
+public class WasmConfig implements Editable<WasmConfigBuilder>, KubernetesResource
+{
+
+    @JsonProperty("failStrategy")
+    private FailStrategy failStrategy;
+    @JsonProperty("imagePullPolicy")
+    private PullPolicy imagePullPolicy;
+    @JsonProperty("imagePullSecret")
+    private String imagePullSecret;
+    @JsonProperty("pluginConfig")
+    @JsonDeserialize(using = io.fabric8.kubernetes.internal.KubernetesDeserializer.class)
+    private Object pluginConfig;
+    @JsonProperty("pluginName")
+    private String pluginName;
+    @JsonProperty("sha256")
+    private String sha256;
+    @JsonProperty("type")
+    private PluginType type;
+    @JsonProperty("url")
+    private String url;
+    @JsonProperty("verificationKey")
+    private String verificationKey;
+    @JsonProperty("vmConfig")
+    private VmConfig vmConfig;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     */
+    public WasmConfig() {
+    }
+
+    public WasmConfig(FailStrategy failStrategy, PullPolicy imagePullPolicy, String imagePullSecret, Object pluginConfig, String pluginName, String sha256, PluginType type, String url, String verificationKey, VmConfig vmConfig) {
+        super();
+        this.failStrategy = failStrategy;
+        this.imagePullPolicy = imagePullPolicy;
+        this.imagePullSecret = imagePullSecret;
+        this.pluginConfig = pluginConfig;
+        this.pluginName = pluginName;
+        this.sha256 = sha256;
+        this.type = type;
+        this.url = url;
+        this.verificationKey = verificationKey;
+        this.vmConfig = vmConfig;
+    }
+
+    /**
+     * WasmConfig configures a WebAssembly filter.<br><p> <br><p> Example:<br><p> <br><p> ```yaml wasm:<br><p> <br><p> 	url: oci://gcr.io/myproject/filter:v1.0.0<br><p> 	sha256: abc123...<br><p> 	imagePullPolicy: IfNotPresent<br><p> 	imagePullSecret: gcr-secret<br><p> 	pluginName: my-filter<br><p> 	pluginConfig:<br><p> 	  key1: value1<br><p> 	  key2: value2<br><p> 	failStrategy: FAIL_CLOSE<br><p> 	vmConfig:<br><p> 	  env:<br><p> 	  - name: SOME_ENV_VAR<br><p> 	    value: some_value<br><p> 	type: HTTP<br><p> <br><p> ```
+     */
+    @JsonProperty("failStrategy")
+    public FailStrategy getFailStrategy() {
+        return failStrategy;
+    }
+
+    /**
+     * WasmConfig configures a WebAssembly filter.<br><p> <br><p> Example:<br><p> <br><p> ```yaml wasm:<br><p> <br><p> 	url: oci://gcr.io/myproject/filter:v1.0.0<br><p> 	sha256: abc123...<br><p> 	imagePullPolicy: IfNotPresent<br><p> 	imagePullSecret: gcr-secret<br><p> 	pluginName: my-filter<br><p> 	pluginConfig:<br><p> 	  key1: value1<br><p> 	  key2: value2<br><p> 	failStrategy: FAIL_CLOSE<br><p> 	vmConfig:<br><p> 	  env:<br><p> 	  - name: SOME_ENV_VAR<br><p> 	    value: some_value<br><p> 	type: HTTP<br><p> <br><p> ```
+     */
+    @JsonProperty("failStrategy")
+    public void setFailStrategy(FailStrategy failStrategy) {
+        this.failStrategy = failStrategy;
+    }
+
+    /**
+     * WasmConfig configures a WebAssembly filter.<br><p> <br><p> Example:<br><p> <br><p> ```yaml wasm:<br><p> <br><p> 	url: oci://gcr.io/myproject/filter:v1.0.0<br><p> 	sha256: abc123...<br><p> 	imagePullPolicy: IfNotPresent<br><p> 	imagePullSecret: gcr-secret<br><p> 	pluginName: my-filter<br><p> 	pluginConfig:<br><p> 	  key1: value1<br><p> 	  key2: value2<br><p> 	failStrategy: FAIL_CLOSE<br><p> 	vmConfig:<br><p> 	  env:<br><p> 	  - name: SOME_ENV_VAR<br><p> 	    value: some_value<br><p> 	type: HTTP<br><p> <br><p> ```
+     */
+    @JsonProperty("imagePullPolicy")
+    public PullPolicy getImagePullPolicy() {
+        return imagePullPolicy;
+    }
+
+    /**
+     * WasmConfig configures a WebAssembly filter.<br><p> <br><p> Example:<br><p> <br><p> ```yaml wasm:<br><p> <br><p> 	url: oci://gcr.io/myproject/filter:v1.0.0<br><p> 	sha256: abc123...<br><p> 	imagePullPolicy: IfNotPresent<br><p> 	imagePullSecret: gcr-secret<br><p> 	pluginName: my-filter<br><p> 	pluginConfig:<br><p> 	  key1: value1<br><p> 	  key2: value2<br><p> 	failStrategy: FAIL_CLOSE<br><p> 	vmConfig:<br><p> 	  env:<br><p> 	  - name: SOME_ENV_VAR<br><p> 	    value: some_value<br><p> 	type: HTTP<br><p> <br><p> ```
+     */
+    @JsonProperty("imagePullPolicy")
+    public void setImagePullPolicy(PullPolicy imagePullPolicy) {
+        this.imagePullPolicy = imagePullPolicy;
+    }
+
+    /**
+     * Credentials to use for OCI image pulling. Name of a Kubernetes Secret in the same namespace as the `TrafficExtension` that contains a Docker pull secret which is to be used to authenticate against the registry when pulling the image.
+     */
+    @JsonProperty("imagePullSecret")
+    public String getImagePullSecret() {
+        return imagePullSecret;
+    }
+
+    /**
+     * Credentials to use for OCI image pulling. Name of a Kubernetes Secret in the same namespace as the `TrafficExtension` that contains a Docker pull secret which is to be used to authenticate against the registry when pulling the image.
+     */
+    @JsonProperty("imagePullSecret")
+    public void setImagePullSecret(String imagePullSecret) {
+        this.imagePullSecret = imagePullSecret;
+    }
+
+    /**
+     * WasmConfig configures a WebAssembly filter.<br><p> <br><p> Example:<br><p> <br><p> ```yaml wasm:<br><p> <br><p> 	url: oci://gcr.io/myproject/filter:v1.0.0<br><p> 	sha256: abc123...<br><p> 	imagePullPolicy: IfNotPresent<br><p> 	imagePullSecret: gcr-secret<br><p> 	pluginName: my-filter<br><p> 	pluginConfig:<br><p> 	  key1: value1<br><p> 	  key2: value2<br><p> 	failStrategy: FAIL_CLOSE<br><p> 	vmConfig:<br><p> 	  env:<br><p> 	  - name: SOME_ENV_VAR<br><p> 	    value: some_value<br><p> 	type: HTTP<br><p> <br><p> ```
+     */
+    @JsonProperty("pluginConfig")
+    public Object getPluginConfig() {
+        return pluginConfig;
+    }
+
+    /**
+     * WasmConfig configures a WebAssembly filter.<br><p> <br><p> Example:<br><p> <br><p> ```yaml wasm:<br><p> <br><p> 	url: oci://gcr.io/myproject/filter:v1.0.0<br><p> 	sha256: abc123...<br><p> 	imagePullPolicy: IfNotPresent<br><p> 	imagePullSecret: gcr-secret<br><p> 	pluginName: my-filter<br><p> 	pluginConfig:<br><p> 	  key1: value1<br><p> 	  key2: value2<br><p> 	failStrategy: FAIL_CLOSE<br><p> 	vmConfig:<br><p> 	  env:<br><p> 	  - name: SOME_ENV_VAR<br><p> 	    value: some_value<br><p> 	type: HTTP<br><p> <br><p> ```
+     */
+    @JsonProperty("pluginConfig")
+    @JsonDeserialize(using = io.fabric8.kubernetes.internal.KubernetesDeserializer.class)
+    public void setPluginConfig(Object pluginConfig) {
+        this.pluginConfig = pluginConfig;
+    }
+
+    /**
+     * The plugin name to be used in the Envoy configuration (used to be called `rootID`). Some .wasm modules might require this value to select the Wasm plugin to execute.
+     */
+    @JsonProperty("pluginName")
+    public String getPluginName() {
+        return pluginName;
+    }
+
+    /**
+     * The plugin name to be used in the Envoy configuration (used to be called `rootID`). Some .wasm modules might require this value to select the Wasm plugin to execute.
+     */
+    @JsonProperty("pluginName")
+    public void setPluginName(String pluginName) {
+        this.pluginName = pluginName;
+    }
+
+    /**
+     * SHA256 checksum that will be used to verify Wasm module or OCI container. If the `url` field already references a SHA256 (using the `@sha256:` notation), it must match the value of this field. If an OCI image is referenced by tag and this field is set, its checksum will be verified against the contents of this field after pulling.
+     */
+    @JsonProperty("sha256")
+    public String getSha256() {
+        return sha256;
+    }
+
+    /**
+     * SHA256 checksum that will be used to verify Wasm module or OCI container. If the `url` field already references a SHA256 (using the `@sha256:` notation), it must match the value of this field. If an OCI image is referenced by tag and this field is set, its checksum will be verified against the contents of this field after pulling.
+     */
+    @JsonProperty("sha256")
+    public void setSha256(String sha256) {
+        this.sha256 = sha256;
+    }
+
+    /**
+     * WasmConfig configures a WebAssembly filter.<br><p> <br><p> Example:<br><p> <br><p> ```yaml wasm:<br><p> <br><p> 	url: oci://gcr.io/myproject/filter:v1.0.0<br><p> 	sha256: abc123...<br><p> 	imagePullPolicy: IfNotPresent<br><p> 	imagePullSecret: gcr-secret<br><p> 	pluginName: my-filter<br><p> 	pluginConfig:<br><p> 	  key1: value1<br><p> 	  key2: value2<br><p> 	failStrategy: FAIL_CLOSE<br><p> 	vmConfig:<br><p> 	  env:<br><p> 	  - name: SOME_ENV_VAR<br><p> 	    value: some_value<br><p> 	type: HTTP<br><p> <br><p> ```
+     */
+    @JsonProperty("type")
+    public PluginType getType() {
+        return type;
+    }
+
+    /**
+     * WasmConfig configures a WebAssembly filter.<br><p> <br><p> Example:<br><p> <br><p> ```yaml wasm:<br><p> <br><p> 	url: oci://gcr.io/myproject/filter:v1.0.0<br><p> 	sha256: abc123...<br><p> 	imagePullPolicy: IfNotPresent<br><p> 	imagePullSecret: gcr-secret<br><p> 	pluginName: my-filter<br><p> 	pluginConfig:<br><p> 	  key1: value1<br><p> 	  key2: value2<br><p> 	failStrategy: FAIL_CLOSE<br><p> 	vmConfig:<br><p> 	  env:<br><p> 	  - name: SOME_ENV_VAR<br><p> 	    value: some_value<br><p> 	type: HTTP<br><p> <br><p> ```
+     */
+    @JsonProperty("type")
+    public void setType(PluginType type) {
+        this.type = type;
+    }
+
+    /**
+     * URL of a Wasm module or OCI container. If no scheme is present, defaults to `oci://`, referencing an OCI image. Other valid schemes are `file://` for referencing .wasm module files present locally within the proxy container, and `http[s]://` for .wasm module files hosted remotely.
+     */
+    @JsonProperty("url")
+    public String getUrl() {
+        return url;
+    }
+
+    /**
+     * URL of a Wasm module or OCI container. If no scheme is present, defaults to `oci://`, referencing an OCI image. Other valid schemes are `file://` for referencing .wasm module files present locally within the proxy container, and `http[s]://` for .wasm module files hosted remotely.
+     */
+    @JsonProperty("url")
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    /**
+     * $hide_from_docs Public key that will be used to verify signatures of signed OCI images or Wasm modules.<br><p> <br><p> At this moment, various ways for signing/verifying are emerging and being proposed. We can observe two major streams for signing OCI images: Cosign from Sigstore and Notary, which is used in Docker Content Trust. In case of Wasm module, multiple approaches are still in discussion.<br><p>   - https://github.com/WebAssembly/design/issues/1413<br><p>   - https://github.com/wasm-signatures/design (various signing tools are enumerated)<br><p> <br><p> In addition, for each method for signing&amp;verifying, we may need to consider to provide additional data or configuration (e.g., key rolling, KMS, root certs, ...) as well.<br><p> <br><p> To deal with this situation, we need to elaborate more generic way to describe how to sign and verify the image or wasm binary, and how to specify relevant data, including this `verification_key`.<br><p> <br><p> Therefore, this field will not be implemented until the detailed design is established. For the future use, just keep this field in proto and hide from documentation.
+     */
+    @JsonProperty("verificationKey")
+    public String getVerificationKey() {
+        return verificationKey;
+    }
+
+    /**
+     * $hide_from_docs Public key that will be used to verify signatures of signed OCI images or Wasm modules.<br><p> <br><p> At this moment, various ways for signing/verifying are emerging and being proposed. We can observe two major streams for signing OCI images: Cosign from Sigstore and Notary, which is used in Docker Content Trust. In case of Wasm module, multiple approaches are still in discussion.<br><p>   - https://github.com/WebAssembly/design/issues/1413<br><p>   - https://github.com/wasm-signatures/design (various signing tools are enumerated)<br><p> <br><p> In addition, for each method for signing&amp;verifying, we may need to consider to provide additional data or configuration (e.g., key rolling, KMS, root certs, ...) as well.<br><p> <br><p> To deal with this situation, we need to elaborate more generic way to describe how to sign and verify the image or wasm binary, and how to specify relevant data, including this `verification_key`.<br><p> <br><p> Therefore, this field will not be implemented until the detailed design is established. For the future use, just keep this field in proto and hide from documentation.
+     */
+    @JsonProperty("verificationKey")
+    public void setVerificationKey(String verificationKey) {
+        this.verificationKey = verificationKey;
+    }
+
+    /**
+     * WasmConfig configures a WebAssembly filter.<br><p> <br><p> Example:<br><p> <br><p> ```yaml wasm:<br><p> <br><p> 	url: oci://gcr.io/myproject/filter:v1.0.0<br><p> 	sha256: abc123...<br><p> 	imagePullPolicy: IfNotPresent<br><p> 	imagePullSecret: gcr-secret<br><p> 	pluginName: my-filter<br><p> 	pluginConfig:<br><p> 	  key1: value1<br><p> 	  key2: value2<br><p> 	failStrategy: FAIL_CLOSE<br><p> 	vmConfig:<br><p> 	  env:<br><p> 	  - name: SOME_ENV_VAR<br><p> 	    value: some_value<br><p> 	type: HTTP<br><p> <br><p> ```
+     */
+    @JsonProperty("vmConfig")
+    public VmConfig getVmConfig() {
+        return vmConfig;
+    }
+
+    /**
+     * WasmConfig configures a WebAssembly filter.<br><p> <br><p> Example:<br><p> <br><p> ```yaml wasm:<br><p> <br><p> 	url: oci://gcr.io/myproject/filter:v1.0.0<br><p> 	sha256: abc123...<br><p> 	imagePullPolicy: IfNotPresent<br><p> 	imagePullSecret: gcr-secret<br><p> 	pluginName: my-filter<br><p> 	pluginConfig:<br><p> 	  key1: value1<br><p> 	  key2: value2<br><p> 	failStrategy: FAIL_CLOSE<br><p> 	vmConfig:<br><p> 	  env:<br><p> 	  - name: SOME_ENV_VAR<br><p> 	    value: some_value<br><p> 	type: HTTP<br><p> <br><p> ```
+     */
+    @JsonProperty("vmConfig")
+    public void setVmConfig(VmConfig vmConfig) {
+        this.vmConfig = vmConfig;
+    }
+
+    @JsonIgnore
+    public WasmConfigBuilder edit() {
+        return new WasmConfigBuilder(this);
+    }
+
+    @JsonIgnore
+    public WasmConfigBuilder toBuilder() {
+        return edit();
+    }
+
+    @JsonAnyGetter
+    @JsonIgnore
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public void setAdditionalProperties(Map<String, Object> additionalProperties) {
+        this.additionalProperties = additionalProperties;
+    }
+
+}

--- a/extensions/istio/model/src/generated/java/io/fabric8/istio/api/api/networking/v1alpha3/ServiceEntryStatus.java
+++ b/extensions/istio/model/src/generated/java/io/fabric8/istio/api/api/networking/v1alpha3/ServiceEntryStatus.java
@@ -115,7 +115,7 @@ public class ServiceEntryStatus implements Editable<ServiceEntryStatusBuilder>, 
     }
 
     /**
-     * Current service state of ServiceEntry. More info: https://istio.io/docs/reference/config/config-status/
+     * Current service state of ServiceEntry.
      */
     @JsonProperty("conditions")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -124,7 +124,7 @@ public class ServiceEntryStatus implements Editable<ServiceEntryStatusBuilder>, 
     }
 
     /**
-     * Current service state of ServiceEntry. More info: https://istio.io/docs/reference/config/config-status/
+     * Current service state of ServiceEntry.
      */
     @JsonProperty("conditions")
     public void setConditions(List<IstioCondition> conditions) {
@@ -132,7 +132,7 @@ public class ServiceEntryStatus implements Editable<ServiceEntryStatusBuilder>, 
     }
 
     /**
-     * Resource Generation to which the Reconciled Condition refers. When this value is not equal to the object's metadata generation, reconciled condition  calculation for the current generation is still in progress.  See https://istio.io/latest/docs/reference/config/config-status/ for more info.
+     * Resource Generation to which the Reconciled Condition refers. When this value is not equal to the object's metadata generation, reconciled condition  calculation for the current generation is still in progress.
      */
     @JsonProperty("observedGeneration")
     public Long getObservedGeneration() {
@@ -140,7 +140,7 @@ public class ServiceEntryStatus implements Editable<ServiceEntryStatusBuilder>, 
     }
 
     /**
-     * Resource Generation to which the Reconciled Condition refers. When this value is not equal to the object's metadata generation, reconciled condition  calculation for the current generation is still in progress.  See https://istio.io/latest/docs/reference/config/config-status/ for more info.
+     * Resource Generation to which the Reconciled Condition refers. When this value is not equal to the object's metadata generation, reconciled condition  calculation for the current generation is still in progress.
      */
     @JsonProperty("observedGeneration")
     public void setObservedGeneration(Long observedGeneration) {

--- a/extensions/istio/model/src/generated/java/io/fabric8/istio/api/api/security/v1beta1/Source.java
+++ b/extensions/istio/model/src/generated/java/io/fabric8/istio/api/api/security/v1beta1/Source.java
@@ -48,10 +48,12 @@ import lombok.experimental.Accessors;
     "notRemoteIpBlocks",
     "notRequestPrincipals",
     "notServiceAccounts",
+    "notTrustDomains",
     "principals",
     "remoteIpBlocks",
     "requestPrincipals",
-    "serviceAccounts"
+    "serviceAccounts",
+    "trustDomains"
 })
 @ToString
 @EqualsAndHashCode
@@ -102,6 +104,9 @@ public class Source implements Editable<SourceBuilder>, KubernetesResource
     @JsonProperty("notServiceAccounts")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<String> notServiceAccounts = new ArrayList<>();
+    @JsonProperty("notTrustDomains")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<String> notTrustDomains = new ArrayList<>();
     @JsonProperty("principals")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<String> principals = new ArrayList<>();
@@ -114,6 +119,9 @@ public class Source implements Editable<SourceBuilder>, KubernetesResource
     @JsonProperty("serviceAccounts")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<String> serviceAccounts = new ArrayList<>();
+    @JsonProperty("trustDomains")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<String> trustDomains = new ArrayList<>();
     @JsonIgnore
     private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
@@ -123,7 +131,7 @@ public class Source implements Editable<SourceBuilder>, KubernetesResource
     public Source() {
     }
 
-    public Source(List<String> ipBlocks, List<String> namespaces, List<String> notIpBlocks, List<String> notNamespaces, List<String> notPrincipals, List<String> notRemoteIpBlocks, List<String> notRequestPrincipals, List<String> notServiceAccounts, List<String> principals, List<String> remoteIpBlocks, List<String> requestPrincipals, List<String> serviceAccounts) {
+    public Source(List<String> ipBlocks, List<String> namespaces, List<String> notIpBlocks, List<String> notNamespaces, List<String> notPrincipals, List<String> notRemoteIpBlocks, List<String> notRequestPrincipals, List<String> notServiceAccounts, List<String> notTrustDomains, List<String> principals, List<String> remoteIpBlocks, List<String> requestPrincipals, List<String> serviceAccounts, List<String> trustDomains) {
         super();
         this.ipBlocks = ipBlocks;
         this.namespaces = namespaces;
@@ -133,10 +141,12 @@ public class Source implements Editable<SourceBuilder>, KubernetesResource
         this.notRemoteIpBlocks = notRemoteIpBlocks;
         this.notRequestPrincipals = notRequestPrincipals;
         this.notServiceAccounts = notServiceAccounts;
+        this.notTrustDomains = notTrustDomains;
         this.principals = principals;
         this.remoteIpBlocks = remoteIpBlocks;
         this.requestPrincipals = requestPrincipals;
         this.serviceAccounts = serviceAccounts;
+        this.trustDomains = trustDomains;
     }
 
     /**
@@ -276,6 +286,23 @@ public class Source implements Editable<SourceBuilder>, KubernetesResource
     }
 
     /**
+     * Optional. A list of negative match of trust domains. Can be exact, prefix, suffix and presence.
+     */
+    @JsonProperty("notTrustDomains")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<String> getNotTrustDomains() {
+        return notTrustDomains;
+    }
+
+    /**
+     * Optional. A list of negative match of trust domains. Can be exact, prefix, suffix and presence.
+     */
+    @JsonProperty("notTrustDomains")
+    public void setNotTrustDomains(List<String> notTrustDomains) {
+        this.notTrustDomains = notTrustDomains;
+    }
+
+    /**
      * Optional. A list of peer identities derived from the peer certificate. The peer identity is in the format of `"&lt;TRUST_DOMAIN&gt;/ns/&lt;NAMESPACE&gt;/sa/&lt;SERVICE_ACCOUNT&gt;"`, for example, `"cluster.local/ns/default/sa/productpage"`. This field requires mTLS enabled and is the same as the `source.principal` attribute.<br><p> <br><p> Usage of `serviceAccounts` is typically simpler and offers the same functionality.<br><p> <br><p> If not set, any principal is allowed.
      */
     @JsonProperty("principals")
@@ -341,6 +368,23 @@ public class Source implements Editable<SourceBuilder>, KubernetesResource
     @JsonProperty("serviceAccounts")
     public void setServiceAccounts(List<String> serviceAccounts) {
         this.serviceAccounts = serviceAccounts;
+    }
+
+    /**
+     * Optional. A list of trust domains derived from the peer certificate. Can be exact, prefix, suffix and presence. This field requires mTLS enabled and is the same as the `source.trustDomain` attribute.<br><p> <br><p> If not set, any trust domain is allowed.
+     */
+    @JsonProperty("trustDomains")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<String> getTrustDomains() {
+        return trustDomains;
+    }
+
+    /**
+     * Optional. A list of trust domains derived from the peer certificate. Can be exact, prefix, suffix and presence. This field requires mTLS enabled and is the same as the `source.trustDomain` attribute.<br><p> <br><p> If not set, any trust domain is allowed.
+     */
+    @JsonProperty("trustDomains")
+    public void setTrustDomains(List<String> trustDomains) {
+        this.trustDomains = trustDomains;
     }
 
     @JsonIgnore

--- a/extensions/istio/model/src/generated/java/io/fabric8/istio/api/api/telemetry/v1alpha1/Tracing.java
+++ b/extensions/istio/model/src/generated/java/io/fabric8/istio/api/api/telemetry/v1alpha1/Tracing.java
@@ -41,6 +41,7 @@ import lombok.experimental.Accessors;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
     "customTags",
+    "disableContextPropagation",
     "disableSpanReporting",
     "enableIstioTags",
     "match",
@@ -76,6 +77,8 @@ public class Tracing implements Editable<TracingBuilder>, KubernetesResource
     @JsonProperty("customTags")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, TracingCustomTag> customTags = new LinkedHashMap<>();
+    @JsonProperty("disableContextPropagation")
+    private Boolean disableContextPropagation;
     @JsonProperty("disableSpanReporting")
     private Boolean disableSpanReporting;
     @JsonProperty("enableIstioTags")
@@ -98,9 +101,10 @@ public class Tracing implements Editable<TracingBuilder>, KubernetesResource
     public Tracing() {
     }
 
-    public Tracing(Map<String, TracingCustomTag> customTags, Boolean disableSpanReporting, Boolean enableIstioTags, TracingTracingSelector match, List<ProviderRef> providers, Double randomSamplingPercentage, Boolean useRequestIdForTraceSampling) {
+    public Tracing(Map<String, TracingCustomTag> customTags, Boolean disableContextPropagation, Boolean disableSpanReporting, Boolean enableIstioTags, TracingTracingSelector match, List<ProviderRef> providers, Double randomSamplingPercentage, Boolean useRequestIdForTraceSampling) {
         super();
         this.customTags = customTags;
+        this.disableContextPropagation = disableContextPropagation;
         this.disableSpanReporting = disableSpanReporting;
         this.enableIstioTags = enableIstioTags;
         this.match = match;
@@ -124,6 +128,22 @@ public class Tracing implements Editable<TracingBuilder>, KubernetesResource
     @JsonProperty("customTags")
     public void setCustomTags(Map<String, TracingCustomTag> customTags) {
         this.customTags = customTags;
+    }
+
+    /**
+     * Tracing configures tracing behavior for workloads within a mesh. It can be used to enable/disable tracing, as well as to set sampling rates and custom tag extraction.<br><p> <br><p> Tracing configuration support overrides of the fields `providers`, `random_sampling_percentage`, `disable_span_reporting`, and `custom_tags` at each level in the configuration hierarchy, with missing values filled in from parent resources. However, when specified, `custom_tags` will fully replace any values provided by parent configuration.
+     */
+    @JsonProperty("disableContextPropagation")
+    public Boolean getDisableContextPropagation() {
+        return disableContextPropagation;
+    }
+
+    /**
+     * Tracing configures tracing behavior for workloads within a mesh. It can be used to enable/disable tracing, as well as to set sampling rates and custom tag extraction.<br><p> <br><p> Tracing configuration support overrides of the fields `providers`, `random_sampling_percentage`, `disable_span_reporting`, and `custom_tags` at each level in the configuration hierarchy, with missing values filled in from parent resources. However, when specified, `custom_tags` will fully replace any values provided by parent configuration.
+     */
+    @JsonProperty("disableContextPropagation")
+    public void setDisableContextPropagation(Boolean disableContextPropagation) {
+        this.disableContextPropagation = disableContextPropagation;
     }
 
     /**

--- a/extensions/istio/model/src/generated/java/io/fabric8/istio/api/extensions/v1alpha1/TrafficExtension.java
+++ b/extensions/istio/model/src/generated/java/io/fabric8/istio/api/extensions/v1alpha1/TrafficExtension.java
@@ -1,0 +1,211 @@
+
+package io.fabric8.istio.api.extensions.v1alpha1;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.processing.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.istio.api.api.meta.v1alpha1.IstioStatus;
+import io.fabric8.kubernetes.api.builder.Editable;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerPort;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+/**
+ * &lt;!-- crd generation tags --&gt;<br><p> <br><p> &lt;!-- go code generation tags --&gt;
+ */
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "spec",
+    "status"
+})
+@ToString
+@EqualsAndHashCode
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(EnvVar.class),
+    @BuildableReference(ContainerPort.class),
+    @BuildableReference(Volume.class),
+    @BuildableReference(VolumeMount.class)
+})
+@Version("v1alpha1")
+@Group("extensions.istio.io")
+@Generated("io.fabric8.kubernetes.schema.generator.model.ModelGenerator")
+public class TrafficExtension implements Editable<TrafficExtensionBuilder>, HasMetadata, Namespaced
+{
+
+    @JsonProperty("apiVersion")
+    private String apiVersion = "extensions.istio.io/v1alpha1";
+    @JsonProperty("kind")
+    private String kind = "TrafficExtension";
+    @JsonProperty("metadata")
+    private ObjectMeta metadata;
+    @JsonProperty("spec")
+    private io.fabric8.istio.api.api.extensions.v1alpha1.TrafficExtension spec;
+    @JsonProperty("status")
+    private IstioStatus status;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     */
+    public TrafficExtension() {
+    }
+
+    public TrafficExtension(String apiVersion, String kind, ObjectMeta metadata, io.fabric8.istio.api.api.extensions.v1alpha1.TrafficExtension spec, IstioStatus status) {
+        super();
+        this.apiVersion = apiVersion;
+        this.kind = kind;
+        this.metadata = metadata;
+        this.spec = spec;
+        this.status = status;
+    }
+
+    /**
+     * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+     */
+    @JsonProperty("apiVersion")
+    public String getApiVersion() {
+        return apiVersion;
+    }
+
+    /**
+     * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+     */
+    @JsonProperty("apiVersion")
+    public void setApiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
+    }
+
+    /**
+     * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+     */
+    @JsonProperty("kind")
+    public String getKind() {
+        return kind;
+    }
+
+    /**
+     * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+     */
+    @JsonProperty("kind")
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    /**
+     * &lt;!-- crd generation tags --&gt;<br><p> <br><p> &lt;!-- go code generation tags --&gt;
+     */
+    @JsonProperty("metadata")
+    public ObjectMeta getMetadata() {
+        return metadata;
+    }
+
+    /**
+     * &lt;!-- crd generation tags --&gt;<br><p> <br><p> &lt;!-- go code generation tags --&gt;
+     */
+    @JsonProperty("metadata")
+    public void setMetadata(ObjectMeta metadata) {
+        this.metadata = metadata;
+    }
+
+    /**
+     * &lt;!-- crd generation tags --&gt;<br><p> <br><p> &lt;!-- go code generation tags --&gt;
+     */
+    @JsonProperty("spec")
+    public io.fabric8.istio.api.api.extensions.v1alpha1.TrafficExtension getSpec() {
+        return spec;
+    }
+
+    /**
+     * &lt;!-- crd generation tags --&gt;<br><p> <br><p> &lt;!-- go code generation tags --&gt;
+     */
+    @JsonProperty("spec")
+    public void setSpec(io.fabric8.istio.api.api.extensions.v1alpha1.TrafficExtension spec) {
+        this.spec = spec;
+    }
+
+    /**
+     * &lt;!-- crd generation tags --&gt;<br><p> <br><p> &lt;!-- go code generation tags --&gt;
+     */
+    @JsonProperty("status")
+    public IstioStatus getStatus() {
+        return status;
+    }
+
+    /**
+     * &lt;!-- crd generation tags --&gt;<br><p> <br><p> &lt;!-- go code generation tags --&gt;
+     */
+    @JsonProperty("status")
+    public void setStatus(IstioStatus status) {
+        this.status = status;
+    }
+
+    @JsonIgnore
+    public TrafficExtensionBuilder edit() {
+        return new TrafficExtensionBuilder(this);
+    }
+
+    @JsonIgnore
+    public TrafficExtensionBuilder toBuilder() {
+        return edit();
+    }
+
+    @JsonAnyGetter
+    @JsonIgnore
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public void setAdditionalProperties(Map<String, Object> additionalProperties) {
+        this.additionalProperties = additionalProperties;
+    }
+
+}

--- a/extensions/istio/model/src/generated/java/io/fabric8/istio/api/extensions/v1alpha1/TrafficExtensionList.java
+++ b/extensions/istio/model/src/generated/java/io/fabric8/istio/api/extensions/v1alpha1/TrafficExtensionList.java
@@ -1,0 +1,195 @@
+
+package io.fabric8.istio.api.extensions.v1alpha1;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.processing.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.builder.Editable;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerPort;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.ListMeta;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+/**
+ * TrafficExtensionList is a collection of TrafficExtensions.
+ */
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "items"
+})
+@ToString
+@EqualsAndHashCode
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(EnvVar.class),
+    @BuildableReference(ContainerPort.class),
+    @BuildableReference(Volume.class),
+    @BuildableReference(VolumeMount.class)
+})
+@Version("v1alpha1")
+@Group("extensions.istio.io")
+@Generated("io.fabric8.kubernetes.schema.generator.model.ModelGenerator")
+public class TrafficExtensionList implements Editable<TrafficExtensionListBuilder>, KubernetesResource, KubernetesResourceList<io.fabric8.istio.api.extensions.v1alpha1.TrafficExtension>
+{
+
+    @JsonProperty("apiVersion")
+    private String apiVersion = "extensions.istio.io/v1alpha1";
+    @JsonProperty("items")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<io.fabric8.istio.api.extensions.v1alpha1.TrafficExtension> items = new ArrayList<>();
+    @JsonProperty("kind")
+    private String kind = "TrafficExtensionList";
+    @JsonProperty("metadata")
+    private ListMeta metadata;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     */
+    public TrafficExtensionList() {
+    }
+
+    public TrafficExtensionList(String apiVersion, List<io.fabric8.istio.api.extensions.v1alpha1.TrafficExtension> items, String kind, ListMeta metadata) {
+        super();
+        this.apiVersion = apiVersion;
+        this.items = items;
+        this.kind = kind;
+        this.metadata = metadata;
+    }
+
+    /**
+     * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+     */
+    @JsonProperty("apiVersion")
+    public String getApiVersion() {
+        return apiVersion;
+    }
+
+    /**
+     * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+     */
+    @JsonProperty("apiVersion")
+    public void setApiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
+    }
+
+    /**
+     * TrafficExtensionList is a collection of TrafficExtensions.
+     */
+    @JsonProperty("items")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<io.fabric8.istio.api.extensions.v1alpha1.TrafficExtension> getItems() {
+        return items;
+    }
+
+    /**
+     * TrafficExtensionList is a collection of TrafficExtensions.
+     */
+    @JsonProperty("items")
+    public void setItems(List<io.fabric8.istio.api.extensions.v1alpha1.TrafficExtension> items) {
+        this.items = items;
+    }
+
+    /**
+     * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+     */
+    @JsonProperty("kind")
+    public String getKind() {
+        return kind;
+    }
+
+    /**
+     * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+     */
+    @JsonProperty("kind")
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    /**
+     * TrafficExtensionList is a collection of TrafficExtensions.
+     */
+    @JsonProperty("metadata")
+    public ListMeta getMetadata() {
+        return metadata;
+    }
+
+    /**
+     * TrafficExtensionList is a collection of TrafficExtensions.
+     */
+    @JsonProperty("metadata")
+    public void setMetadata(ListMeta metadata) {
+        this.metadata = metadata;
+    }
+
+    @JsonIgnore
+    public TrafficExtensionListBuilder edit() {
+        return new TrafficExtensionListBuilder(this);
+    }
+
+    @JsonIgnore
+    public TrafficExtensionListBuilder toBuilder() {
+        return edit();
+    }
+
+    @JsonAnyGetter
+    @JsonIgnore
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public void setAdditionalProperties(Map<String, Object> additionalProperties) {
+        this.additionalProperties = additionalProperties;
+    }
+
+}

--- a/extensions/istio/model/src/generated/resources/META-INF/services/io.fabric8.kubernetes.api.model.KubernetesResource
+++ b/extensions/istio/model/src/generated/resources/META-INF/services/io.fabric8.kubernetes.api.model.KubernetesResource
@@ -1,3 +1,4 @@
+io.fabric8.istio.api.api.extensions.v1alpha1.TrafficExtension
 io.fabric8.istio.api.api.extensions.v1alpha1.WasmPlugin
 io.fabric8.istio.api.api.networking.v1alpha3.DestinationRule
 io.fabric8.istio.api.api.networking.v1alpha3.EnvoyFilter
@@ -13,6 +14,8 @@ io.fabric8.istio.api.api.security.v1beta1.AuthorizationPolicyExtensionProvider
 io.fabric8.istio.api.api.security.v1beta1.PeerAuthentication
 io.fabric8.istio.api.api.security.v1beta1.RequestAuthentication
 io.fabric8.istio.api.api.telemetry.v1alpha1.Telemetry
+io.fabric8.istio.api.extensions.v1alpha1.TrafficExtension
+io.fabric8.istio.api.extensions.v1alpha1.TrafficExtensionList
 io.fabric8.istio.api.extensions.v1alpha1.WasmPlugin
 io.fabric8.istio.api.extensions.v1alpha1.WasmPluginList
 io.fabric8.istio.api.networking.v1.DestinationRule

--- a/kubernetes-model-generator/openapi/generator/go.mod
+++ b/kubernetes-model-generator/openapi/generator/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/stolostron/search-v2-operator v0.0.0-20250609200037-030a382461f4
 	github.com/tektoncd/pipeline v1.12.0
 	github.com/tektoncd/triggers v0.35.0
-	istio.io/client-go v1.29.2
+	istio.io/client-go v1.30.0
 	k8s.io/api v0.36.1
 	k8s.io/apiextensions-apiserver v0.36.1
 	k8s.io/apimachinery v0.36.1
@@ -239,7 +239,7 @@ require (
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	istio.io/api v1.29.2-0.20260408155000-a0e4e1cbfcc5 // indirect
+	istio.io/api v1.30.0-rc.0.0.20260508191950-a283232d9647 // indirect
 	k8s.io/component-base v0.36.1 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect

--- a/kubernetes-model-generator/openapi/generator/go.sum
+++ b/kubernetes-model-generator/openapi/generator/go.sum
@@ -6469,10 +6469,10 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.1.3/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
-istio.io/api v1.29.2-0.20260408155000-a0e4e1cbfcc5 h1:Siz0rsGpJbx8ug/6e4GeKjgPBpMi7jJvzNvzkkg6H6U=
-istio.io/api v1.29.2-0.20260408155000-a0e4e1cbfcc5/go.mod h1:+brQWcBHoROuyA6fv8rbgg8Kfn0RCGuqoY0duCMuSLA=
-istio.io/client-go v1.29.2 h1:aljV/qXcEGgRYisPTJ7L0Nx8GXWbM8rZgr1eEAC3bCw=
-istio.io/client-go v1.29.2/go.mod h1:RazwM5KR3FzhWXrvjCq1o85ReFNrHcG3cF2lcs5anzg=
+istio.io/api v1.30.0-rc.0.0.20260508191950-a283232d9647 h1:q5krBszeiQAZ8YBGQN3Drkkz4ovPSzSclYENcMwgBhE=
+istio.io/api v1.30.0-rc.0.0.20260508191950-a283232d9647/go.mod h1:+brQWcBHoROuyA6fv8rbgg8Kfn0RCGuqoY0duCMuSLA=
+istio.io/client-go v1.30.0 h1:8EejecI8rBSR1/7HXOd45RVsTT+IscumgUSY1LOZzCA=
+istio.io/client-go v1.30.0/go.mod h1:5i1cRYbIUvGJdE5UIGdDfkXvRTZinNIUhQe+AXTJQl8=
 k8s.io/api v0.35.2 h1:tW7mWc2RpxW7HS4CoRXhtYHSzme1PN1UjGHJ1bdrtdw=
 k8s.io/api v0.35.2/go.mod h1:7AJfqGoAZcwSFhOjcGM7WV05QxMMgUaChNfLTXDRE60=
 k8s.io/apiextensions-apiserver v0.21.4/go.mod h1:OoC8LhI9LnV+wKjZkXIBbLUwtnOGJiTRE33qctH5CIk=

--- a/kubernetes-model-generator/openapi/schemas/io.istio.json
+++ b/kubernetes-model-generator/openapi/schemas/io.istio.json
@@ -216,6 +216,35 @@
       "x-kubernetes-fabric8-enum-values": "FAIL_CLOSE(0),FAIL_OPEN(1),FAIL_RELOAD(2)",
       "x-kubernetes-fabric8-type": "enum"
     },
+    "io.istio.api.extensions.v1alpha1.IsTrafficExtension_FilterConfig": {
+      "type": "object",
+      "x-fabric8-info": {
+        "Type": "nested",
+        "Group": "",
+        "Version": "v1alpha1",
+        "Kind": "IsTrafficExtension_FilterConfig",
+        "Scope": "Namespaced"
+      },
+      "x-kubernetes-fabric8-implementation": "TrafficExtension_Lua,TrafficExtension_Wasm",
+      "x-kubernetes-fabric8-type": "interface"
+    },
+    "io.istio.api.extensions.v1alpha1.LuaConfig": {
+      "description": "LuaConfig configures a Lua filter.\n\nLua filters provide a lightweight alternative to WebAssembly for simple request/response transformations. The Lua code is executed inline within the Envoy proxy.\n\nExample: Simple header manipulation\n\n```yaml lua:\n\n\tinlineCode: |\n\t  function envoy_on_request(request_handle)\n\t    request_handle:headers():add(\"x-custom-header\", \"custom-value\")\n\t  end\n\n```\n\nThe Lua script must define one or both of the following functions: - `envoy_on_request(request_handle)`: Called when a request is received - `envoy_on_response(response_handle)`: Called when a response is received\n\nThe request_handle and response_handle provide access to headers, body, metadata, and other request/response attributes. See the Envoy Lua filter documentation for the complete API: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/lua_filter",
+      "type": "object",
+      "properties": {
+        "inlineCode": {
+          "description": "The inline Lua code to be executed. The code must be a valid Lua script that defines the appropriate callback functions (`envoy_on_request` and/or `envoy_on_response`).\n\nThe maximum size is 64KB. For larger or more complex filters, use a WebAssembly filter instead.",
+          "type": "string"
+        }
+      },
+      "x-fabric8-info": {
+        "Type": "nested",
+        "Group": "",
+        "Version": "v1alpha1",
+        "Kind": "LuaConfig",
+        "Scope": "Namespaced"
+      }
+    },
     "io.istio.api.extensions.v1alpha1.PluginPhase": {
       "description": "The phase in the filter chain where the plugin will be injected.",
       "type": "object",
@@ -255,6 +284,137 @@
       "x-kubernetes-fabric8-enum-values": "Always(2),IfNotPresent(1),UNSPECIFIED_POLICY(0)",
       "x-kubernetes-fabric8-type": "enum"
     },
+    "io.istio.api.extensions.v1alpha1.TrafficExtension": {
+      "description": "\u003c!-- crd generation tags --\u003e\n\n\u003c!-- go code generation tags --\u003e",
+      "type": "object",
+      "required": [
+        "FilterConfig"
+      ],
+      "properties": {
+        "FilterConfig": {
+          "description": "Exactly one of `wasm` or `lua` must be set.\n\nTypes that are valid to be assigned to FilterConfig:\n\n\t*TrafficExtension_Wasm\n\t*TrafficExtension_Lua",
+          "default": {},
+          "$ref": "#/definitions/io.istio.api.extensions.v1alpha1.IsTrafficExtension_FilterConfig"
+        },
+        "match": {
+          "description": "Specifies the criteria to determine which traffic is passed to TrafficExtension. If a traffic satisfies any of TrafficSelectors, the traffic passes the TrafficExtension.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/io.istio.api.extensions.v1alpha1.TrafficSelector"
+          }
+        },
+        "phase": {
+          "description": "Determines where in the filter chain this `TrafficExtension` is to be injected.",
+          "default": {},
+          "$ref": "#/definitions/io.istio.api.extensions.v1alpha1.TrafficExtension_ExecutionPhase"
+        },
+        "priority": {
+          "description": "Determines ordering of `TrafficExtensions` in the same `phase`. When multiple `TrafficExtensions` are applied to the same workload in the same `phase`, they will be applied by priority, in descending order. If `priority` is not set, or two `TrafficExtensions` exist with the same value, the ordering will be deterministically derived from the `creationTimestamp`, then name and namespace of the `TrafficExtensions`. Defaults to `0`.",
+          "$ref": "#/definitions/org.golang.google.protobuf.types.known.wrapperspb.Int32Value"
+        },
+        "selector": {
+          "description": "Optional. Criteria used to select the specific set of pods/VMs on which this configuration should be applied. If omitted, this configuration will be applied to all workload instances in the same namespace. If the `TrafficExtension` is present in the config root namespace, it will be applied to all applicable workloads in any namespace.\n\nAt most, only one of `selector` or `targetRefs` can be set for a given policy.",
+          "$ref": "#/definitions/io.istio.api.type.v1beta1.WorkloadSelector"
+        },
+        "targetRefs": {
+          "description": "Optional. The targetRefs specifies a list of resources the policy should be applied to. The targeted resources specified will determine which workloads the policy applies to.\n\nCurrently, the following resource attachment types are supported: * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace. * `kind: GatewayClass` with `group: gateway.networking.k8s.io` in the root namespace. * `kind: Service` with `group: \"\"` or `group: \"core\"` in the same namespace. This type is only supported for waypoints. * `kind: ServiceEntry` with `group: networking.istio.io` in the same namespace.\n\nIf not set, the policy is applied as defined by the selector. At most one of the selector and targetRefs can be set.\n\nNOTE: Waypoint proxies are required to use this field for policies to apply; `selector` policies will be ignored.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/io.istio.api.type.v1beta1.PolicyTargetReference"
+          }
+        }
+      },
+      "x-fabric8-info": {
+        "Type": "object",
+        "Group": "",
+        "Version": "v1alpha1",
+        "Kind": "TrafficExtension",
+        "Scope": "Namespaced"
+      },
+      "x-kubernetes-fabric8-interface-fields": "FilterConfig"
+    },
+    "io.istio.api.extensions.v1alpha1.TrafficExtension_ExecutionPhase": {
+      "description": "ExecutionPhase specifies where in the filter chain a `TrafficExtension` is injected.",
+      "type": "object",
+      "x-fabric8-info": {
+        "Type": "nested",
+        "Group": "",
+        "Version": "v1alpha1",
+        "Kind": "TrafficExtension_ExecutionPhase",
+        "Scope": "Namespaced"
+      },
+      "x-kubernetes-fabric8-enum-values": "AUTHN(1),AUTHZ(2),STATS(3),UNSPECIFIED(0)",
+      "x-kubernetes-fabric8-type": "enum"
+    },
+    "io.istio.api.extensions.v1alpha1.TrafficExtension_Lua": {
+      "type": "object",
+      "required": [
+        "lua"
+      ],
+      "properties": {
+        "lua": {
+          "description": "Lua filter configuration.",
+          "$ref": "#/definitions/io.istio.api.extensions.v1alpha1.LuaConfig"
+        }
+      },
+      "x-fabric8-info": {
+        "Type": "nested",
+        "Group": "",
+        "Version": "v1alpha1",
+        "Kind": "TrafficExtension_Lua",
+        "Scope": "Namespaced"
+      },
+      "x-kubernetes-fabric8-implements": "IsTrafficExtension_FilterConfig"
+    },
+    "io.istio.api.extensions.v1alpha1.TrafficExtension_Wasm": {
+      "type": "object",
+      "required": [
+        "wasm"
+      ],
+      "properties": {
+        "wasm": {
+          "description": "WebAssembly filter configuration.",
+          "$ref": "#/definitions/io.istio.api.extensions.v1alpha1.WasmConfig"
+        }
+      },
+      "x-fabric8-info": {
+        "Type": "nested",
+        "Group": "",
+        "Version": "v1alpha1",
+        "Kind": "TrafficExtension_Wasm",
+        "Scope": "Namespaced"
+      },
+      "x-kubernetes-fabric8-implements": "IsTrafficExtension_FilterConfig"
+    },
+    "io.istio.api.extensions.v1alpha1.TrafficSelector": {
+      "description": "TrafficSelector provides a mechanism to select a specific traffic flow for which a TrafficExtension will be enabled. When all the sub conditions in the TrafficSelector are satisfied, the traffic will be selected.",
+      "type": "object",
+      "properties": {
+        "mode": {
+          "description": "Criteria for selecting traffic by their direction. Note that `CLIENT` and `SERVER` are analogous to OUTBOUND and INBOUND, respectively. For the gateway, the field should be `CLIENT` or `CLIENT_AND_SERVER`. If not specified, the default value is `CLIENT_AND_SERVER`.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "ports": {
+          "description": "Criteria for selecting traffic by their destination port. More specifically, for the outbound traffic, the destination port would be the port of the target service. On the other hand, for the inbound traffic, the destination port is the port bound by the server process in the same Pod.\n\nIf one of the given `ports` is matched, this condition is evaluated to true. If not specified, this condition is evaluated to true for any port.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/io.istio.api.type.v1beta1.PortSelector"
+          },
+          "x-kubernetes-list-map-keys": [
+            "number"
+          ],
+          "x-kubernetes-list-type": "map"
+        }
+      },
+      "x-fabric8-info": {
+        "Type": "nested",
+        "Group": "",
+        "Version": "v1alpha1",
+        "Kind": "TrafficSelector",
+        "Scope": "Namespaced"
+      }
+    },
     "io.istio.api.extensions.v1alpha1.VmConfig": {
       "description": "Configuration for a Wasm VM. more details can be found [here](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/wasm/v3/wasm.proto#extensions-wasm-v3-vmconfig).",
       "type": "object",
@@ -276,6 +436,62 @@
         "Group": "",
         "Version": "v1alpha1",
         "Kind": "VmConfig",
+        "Scope": "Namespaced"
+      }
+    },
+    "io.istio.api.extensions.v1alpha1.WasmConfig": {
+      "description": "WasmConfig configures a WebAssembly filter.\n\nExample:\n\n```yaml wasm:\n\n\turl: oci://gcr.io/myproject/filter:v1.0.0\n\tsha256: abc123...\n\timagePullPolicy: IfNotPresent\n\timagePullSecret: gcr-secret\n\tpluginName: my-filter\n\tpluginConfig:\n\t  key1: value1\n\t  key2: value2\n\tfailStrategy: FAIL_CLOSE\n\tvmConfig:\n\t  env:\n\t  - name: SOME_ENV_VAR\n\t    value: some_value\n\ttype: HTTP\n\n```",
+      "type": "object",
+      "properties": {
+        "failStrategy": {
+          "description": "Specifies the failure behavior for the plugin due to fatal errors.",
+          "default": {},
+          "$ref": "#/definitions/io.istio.api.extensions.v1alpha1.FailStrategy"
+        },
+        "imagePullPolicy": {
+          "description": "The pull behaviour to be applied when fetching Wasm module by either OCI image or `http/https`. Only relevant when referencing Wasm module without any digest, including the digest in OCI image URL or `sha256` field in `vm_config`. Defaults to `IfNotPresent`, except when an OCI image is referenced in the `url` and the `latest` tag is used, in which case `Always` is the default, mirroring Kubernetes behaviour.",
+          "default": {},
+          "$ref": "#/definitions/io.istio.api.extensions.v1alpha1.PullPolicy"
+        },
+        "imagePullSecret": {
+          "description": "Credentials to use for OCI image pulling. Name of a Kubernetes Secret in the same namespace as the `TrafficExtension` that contains a Docker pull secret which is to be used to authenticate against the registry when pulling the image.",
+          "type": "string"
+        },
+        "pluginConfig": {
+          "description": "The configuration that will be passed on to the plugin.",
+          "$ref": "#/definitions/org.golang.google.protobuf.types.known.structpb.Struct"
+        },
+        "pluginName": {
+          "description": "The plugin name to be used in the Envoy configuration (used to be called `rootID`). Some .wasm modules might require this value to select the Wasm plugin to execute.",
+          "type": "string"
+        },
+        "sha256": {
+          "description": "SHA256 checksum that will be used to verify Wasm module or OCI container. If the `url` field already references a SHA256 (using the `@sha256:` notation), it must match the value of this field. If an OCI image is referenced by tag and this field is set, its checksum will be verified against the contents of this field after pulling.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Specifies the type of Wasm Extension to be used.",
+          "default": {},
+          "$ref": "#/definitions/io.istio.api.extensions.v1alpha1.PluginType"
+        },
+        "url": {
+          "description": "URL of a Wasm module or OCI container. If no scheme is present, defaults to `oci://`, referencing an OCI image. Other valid schemes are `file://` for referencing .wasm module files present locally within the proxy container, and `http[s]://` for .wasm module files hosted remotely.",
+          "type": "string"
+        },
+        "verificationKey": {
+          "description": "$hide_from_docs Public key that will be used to verify signatures of signed OCI images or Wasm modules.\n\nAt this moment, various ways for signing/verifying are emerging and being proposed. We can observe two major streams for signing OCI images: Cosign from Sigstore and Notary, which is used in Docker Content Trust. In case of Wasm module, multiple approaches are still in discussion.\n  - https://github.com/WebAssembly/design/issues/1413\n  - https://github.com/wasm-signatures/design (various signing tools are enumerated)\n\nIn addition, for each method for signing\u0026verifying, we may need to consider to provide additional data or configuration (e.g., key rolling, KMS, root certs, ...) as well.\n\nTo deal with this situation, we need to elaborate more generic way to describe how to sign and verify the image or wasm binary, and how to specify relevant data, including this `verification_key`.\n\nTherefore, this field will not be implemented until the detailed design is established. For the future use, just keep this field in proto and hide from documentation.",
+          "type": "string"
+        },
+        "vmConfig": {
+          "description": "Configuration for a Wasm VM. More details can be found [here](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/wasm/v3/wasm.proto#extensions-wasm-v3-vmconfig).",
+          "$ref": "#/definitions/io.istio.api.extensions.v1alpha1.VmConfig"
+        }
+      },
+      "x-fabric8-info": {
+        "Type": "nested",
+        "Group": "",
+        "Version": "v1alpha1",
+        "Kind": "WasmConfig",
         "Scope": "Namespaced"
       }
     },
@@ -440,7 +656,7 @@
       "type": "object",
       "properties": {
         "conditions": {
-          "description": "Current service state of the resource. More info: https://istio.io/docs/reference/config/config-status/",
+          "description": "Current service state of the resource.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/io.istio.api.meta.v1alpha1.IstioCondition"
@@ -449,7 +665,7 @@
           "x-kubernetes-patch-strategy": "merge"
         },
         "observedGeneration": {
-          "description": "$hide_from_docs Deprecated. IstioCondition observed_generation will show the resource generation for which the condition was generated. Resource Generation to which the Reconciled Condition refers. When this value is not equal to the object's metadata generation, reconciled condition  calculation for the current generation is still in progress.  See https://istio.io/latest/docs/reference/config/config-status/ for more info.",
+          "description": "$hide_from_docs Deprecated. IstioCondition observed_generation will show the resource generation for which the condition was generated. Resource Generation to which the Reconciled Condition refers. When this value is not equal to the object's metadata generation, reconciled condition  calculation for the current generation is still in progress.",
           "type": "integer",
           "format": "int64"
         },
@@ -3576,7 +3792,7 @@
           }
         },
         "conditions": {
-          "description": "Current service state of ServiceEntry. More info: https://istio.io/docs/reference/config/config-status/",
+          "description": "Current service state of ServiceEntry.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/io.istio.api.meta.v1alpha1.IstioCondition"
@@ -3585,7 +3801,7 @@
           "x-kubernetes-patch-strategy": "merge"
         },
         "observedGeneration": {
-          "description": "Resource Generation to which the Reconciled Condition refers. When this value is not equal to the object's metadata generation, reconciled condition  calculation for the current generation is still in progress.  See https://istio.io/latest/docs/reference/config/config-status/ for more info.",
+          "description": "Resource Generation to which the Reconciled Condition refers. When this value is not equal to the object's metadata generation, reconciled condition  calculation for the current generation is still in progress.",
           "type": "integer",
           "format": "int64"
         },
@@ -5027,6 +5243,14 @@
             "default": ""
           }
         },
+        "notTrustDomains": {
+          "description": "Optional. A list of negative match of trust domains. Can be exact, prefix, suffix and presence.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "default": ""
+          }
+        },
         "principals": {
           "description": "Optional. A list of peer identities derived from the peer certificate. The peer identity is in the format of `\"\u003cTRUST_DOMAIN\u003e/ns/\u003cNAMESPACE\u003e/sa/\u003cSERVICE_ACCOUNT\u003e\"`, for example, `\"cluster.local/ns/default/sa/productpage\"`. This field requires mTLS enabled and is the same as the `source.principal` attribute.\n\nUsage of `serviceAccounts` is typically simpler and offers the same functionality.\n\nIf not set, any principal is allowed.",
           "type": "array",
@@ -5053,6 +5277,14 @@
         },
         "serviceAccounts": {
           "description": "Optional. A list of Kubernetes service accounts derived from the peer certificate. This field requires mTLS enabled and is the same as the `source.serviceaccount` attribute.\n\nThis takes the format `\u003cnamespace\u003e/\u003cserviceaccount\u003e`. `\u003cserviceaccount\u003e` may also be used to use the same namespace as the `AuthorizationPolicy`.\n\nIf not set, any service account is allowed.\n\nNo form of wildcard (`*`) is allowed. Cannot be set with `principals` or `namespaces`.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "default": ""
+          }
+        },
+        "trustDomains": {
+          "description": "Optional. A list of trust domains derived from the peer certificate. Can be exact, prefix, suffix and presence. This field requires mTLS enabled and is the same as the `source.trustDomain` attribute.\n\nIf not set, any trust domain is allowed.",
           "type": "array",
           "items": {
             "type": "string",
@@ -5413,6 +5645,10 @@
             "$ref": "#/definitions/io.istio.api.telemetry.v1alpha1.Tracing_CustomTag"
           }
         },
+        "disableContextPropagation": {
+          "description": "Controls whether trace context headers (e.g., `traceparent`/`tracestate` for W3C, `X-B3-*` for Zipkin) are propagated in forwarded requests. When set to true, trace context headers will not be included in proxied requests, effectively stopping trace context propagation at the selected workloads. This is useful for egress gateways where you want to prevent leaking trace context to external services while still reporting spans for internal observability. Defaults to false (context propagation enabled). NOTE: This does NOT impact span reporting; use `disable_span_reporting` to control that.",
+          "$ref": "#/definitions/org.golang.google.protobuf.types.known.wrapperspb.BoolValue"
+        },
         "disableSpanReporting": {
           "description": "Controls span reporting. If set to true, no spans will be reported for impacted workloads. This does NOT impact context propagation or trace sampling behavior.",
           "$ref": "#/definitions/org.golang.google.protobuf.types.known.wrapperspb.BoolValue"
@@ -5723,6 +5959,72 @@
         "Group": "",
         "Version": "v1beta1",
         "Kind": "WorkloadSelector",
+        "Scope": "Namespaced"
+      }
+    },
+    "io.istio.extensions.v1alpha1.TrafficExtension": {
+      "description": "\u003c!-- crd generation tags --\u003e\n\n\u003c!-- go code generation tags --\u003e",
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string"
+        },
+        "metadata": {
+          "default": {},
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+        },
+        "spec": {
+          "description": "Spec defines the implementation of this definition.",
+          "$ref": "#/definitions/io.istio.api.extensions.v1alpha1.TrafficExtension"
+        },
+        "status": {
+          "$ref": "#/definitions/io.istio.api.meta.v1alpha1.IstioStatus"
+        }
+      },
+      "x-fabric8-info": {
+        "Type": "object",
+        "Group": "extensions.istio.io",
+        "Version": "v1alpha1",
+        "Kind": "TrafficExtension",
+        "Scope": "Namespaced"
+      }
+    },
+    "io.istio.extensions.v1alpha1.TrafficExtensionList": {
+      "description": "TrafficExtensionList is a collection of TrafficExtensions.",
+      "type": "object",
+      "required": [
+        "items"
+      ],
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/io.istio.extensions.v1alpha1.TrafficExtension"
+          }
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string"
+        },
+        "metadata": {
+          "default": {},
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+        }
+      },
+      "x-fabric8-info": {
+        "Type": "list",
+        "Group": "extensions.istio.io",
+        "Version": "v1alpha1",
+        "Kind": "TrafficExtensionList",
         "Scope": "Namespaced"
       }
     },


### PR DESCRIPTION
## Summary
- Bumps `istio.io/client-go` from 1.29.2 to 1.30.0 in `kubernetes-model-generator/openapi/generator`.
- Regenerated istio models: adds new `TrafficExtension` CR (and supporting types under `api.extensions.v1alpha1`), new `trustDomains` / `notTrustDomains` fields on `security.v1beta1.Source`, new `disableContextPropagation` on `telemetry.v1alpha1.Tracing`, plus doc-only tweaks on `IstioStatus` / `ServiceEntryStatus`.

Closes #7840