### PR TITLE
chore(ci): speed up Style Checks workflow

### DIFF
--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -17,7 +17,7 @@
 name: Style Checks
 
 env:
-  MAVEN_ARGS: -B -C -V -ntp -Dhttp.keepAlive=false -e -T 1C
+  MAVEN_ARGS: -B -C -V -ntp -Dhttp.keepAlive=false -e -T 1C -Daether.connector.http.connectionTimeout=10000 -Daether.connector.http.requestTimeout=30000
 
 on:
   push:
@@ -47,16 +47,12 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           cache: 'maven'
-      - name: Cache spotless formatter bundles
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.m2/repository/com/diffplug
-            ~/.m2/repository/org/eclipse
-          key: spotless-${{ runner.os }}-3.5.1-${{ hashFiles('ide-config/eclipse-format.xml', 'ide-config/eclipse.importorder') }}
-          restore-keys: |
-            spotless-${{ runner.os }}-3.5.1-
-            spotless-${{ runner.os }}-
+      - name: Strip stale _remote.repositories tracker files
+        # Tracker files left behind by other workflows reference repository
+        # IDs that don't exist in this build's pom, which makes Maven 3.9
+        # re-validate each cached artifact against Maven Central. A slow
+        # Central response can then stall the job for many minutes.
+        run: find ~/.m2/repository -name _remote.repositories -delete 2>/dev/null || true
       - name: Check License Headers
         run: ./mvnw ${MAVEN_ARGS} -Pitests -N license:check
       - name: Check Format

--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -17,7 +17,7 @@
 name: Style Checks
 
 env:
-  MAVEN_ARGS: -B -C -V -ntp -Dhttp.keepAlive=false -e
+  MAVEN_ARGS: -B -C -V -ntp -Dhttp.keepAlive=false -e -T 1C
 
 on:
   push:
@@ -41,16 +41,25 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
       - name: Setup Java 17
         uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
+          cache: 'maven'
+      - name: Cache spotless formatter bundles
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository/com/diffplug
+            ~/.m2/repository/org/eclipse
+          key: spotless-${{ runner.os }}-3.5.1-${{ hashFiles('ide-config/eclipse-format.xml', 'ide-config/eclipse.importorder') }}
+          restore-keys: |
+            spotless-${{ runner.os }}-3.5.1-
+            spotless-${{ runner.os }}-
       - name: Check License Headers
         run: ./mvnw ${MAVEN_ARGS} -Pitests -N license:check
-      - name: Check Format (only on touched files)
+      - name: Check Format
         run: ./mvnw ${MAVEN_ARGS} -Pitests spotless:check
       - name: Cancel PR workflows on failure
         if: ${{ failure() && github.event_name == 'pull_request' }}

--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -17,7 +17,7 @@
 name: Style Checks
 
 env:
-  MAVEN_ARGS: -B -C -V -ntp -Dhttp.keepAlive=false -e -T 1C -Daether.connector.http.connectionTimeout=10000 -Daether.connector.http.requestTimeout=30000
+  MAVEN_ARGS: -B -C -V -ntp -Dhttp.keepAlive=false -e -T 1C -Daether.transport.http.connectTimeout=10000 -Daether.transport.http.requestTimeout=30000
 
 on:
   push:

--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -17,7 +17,16 @@
 name: Style Checks
 
 env:
-  MAVEN_ARGS: -B -C -V -ntp -Dhttp.keepAlive=false -e -T 1C -Daether.connector.connectTimeout=10000 -Daether.connector.requestTimeout=30000 -Daether.connector.http.retryHandler.count=1
+  # Aether timeouts cap Maven Resolver HTTP calls; sun.net.client.* timeouts
+  # cap raw java.net.HttpURLConnection (e.g. URL.openStream in
+  # gradle-api-maven-plugin), which Aether cannot affect.
+  MAVEN_ARGS: >-
+    -B -C -V -ntp -Dhttp.keepAlive=false -e -T 1C
+    -Daether.connector.connectTimeout=10000
+    -Daether.connector.requestTimeout=30000
+    -Daether.connector.http.retryHandler.count=1
+    -Dsun.net.client.defaultConnectTimeout=10000
+    -Dsun.net.client.defaultReadTimeout=30000
 
 on:
   push:

--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -17,7 +17,7 @@
 name: Style Checks
 
 env:
-  MAVEN_ARGS: -B -C -V -ntp -Dhttp.keepAlive=false -e -T 1C -Daether.transport.http.connectTimeout=10000 -Daether.transport.http.requestTimeout=30000
+  MAVEN_ARGS: -B -C -V -ntp -Dhttp.keepAlive=false -e -T 1C -Daether.connector.connectTimeout=10000 -Daether.connector.requestTimeout=30000 -Daether.connector.http.retryHandler.count=1
 
 on:
   push:

--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -62,9 +62,33 @@ jobs:
         # re-validate each cached artifact against Maven Central. A slow
         # Central response can then stall the job for many minutes.
         run: find ~/.m2/repository -name _remote.repositories -delete 2>/dev/null || true
+      - name: Resolve spotless version
+        # Drive the Equo P2 cache key off the actual plugin version in the
+        # root pom, so a spotless bump auto-invalidates the cache.
+        run: |
+          V=$(grep -oE '<spotless-maven-plugin\.version>[^<]+' pom.xml | sed 's/.*>//')
+          echo "SPOTLESS_VERSION=$V" >> "$GITHUB_ENV"
+      - name: Cache spotless Equo P2 data
+        # Pre-populates ~/.m2/repository/dev/equo/p2-data so spotless's
+        # eclipse / greclipse formatters don't have to fetch Eclipse plugin
+        # bundles from download.eclipse.org via OkHttp on every run.
+        # OkHttp is configured without timeouts by Equo, so a P2 fetch that
+        # stalls hangs the job indefinitely — the cache makes this a
+        # cold-key-only risk, contained by the step timeout below.
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository/dev/equo
+          key: spotless-equo-${{ runner.os }}-${{ env.SPOTLESS_VERSION }}-${{ hashFiles('ide-config/eclipse-format.xml', 'ide-config/eclipse.importorder') }}
+          restore-keys: |
+            spotless-equo-${{ runner.os }}-${{ env.SPOTLESS_VERSION }}-
+            spotless-equo-${{ runner.os }}-
       - name: Check License Headers
         run: ./mvnw ${MAVEN_ARGS} -Pitests -N license:check
       - name: Check Format
+        # If OkHttp hangs on a cold Equo cache, fail in 5 min with a clear
+        # timeout instead of stalling for 15+ minutes (Aether/JVM timeouts
+        # don't reach OkHttp; only the cache and this hard cap protect us).
+        timeout-minutes: 5
         run: ./mvnw ${MAVEN_ARGS} -Pitests spotless:check
       - name: Cancel PR workflows on failure
         if: ${{ failure() && github.event_name == 'pull_request' }}


### PR DESCRIPTION
## Summary

The Style Checks workflow has been disproportionately slow (10–25 min typical, up to 42 min stuck) and earlier
investigations attributed it to dependency downloads — an explanation that never matched the data, since `build.yml`
downloads strictly more and consistently ran faster. After several diagnostic rounds, the actual root cause turned out
to be a `SocketTimeoutException` inside OkHttp's HTTP/2 stream during spotless's Equo-based P2 provisioning. The diff
addresses that plus a few smaller orthogonal issues.

## Root cause

The `eclipse` and `greclipse` formatters in spotless 3.5.1 use Equo to fetch Eclipse plugin bundles from
`download.eclipse.org` via OkHttp. Equo's `P2Client` builds the client with `new OkHttpClient.Builder().cache(...).build()`
— no timeouts configured. OkHttp's defaults give a per-stream `readTimeout` of 10 s but `callTimeout=0`, and HTTP/2
keep-alive frames can keep the per-stream timeout from tripping, so a stalled call can hang for hours. There is no `-D`
system property to override OkHttp's timeouts (verified against `square/okhttp` and `equodev/equo-ide` sources). The
actual stack from one stall:

```
java.io.IOException: Failed to provision P2 dependencies:
java.net.SocketTimeoutException: timeout
    at okhttp3.internal.http2.Http2Stream$StreamTimeout...
```

`build.yml`'s cache saved `~/.m2/repository` after `mvn install`, but `mvn install` never runs spotless — so the
`dev/equo/p2-data` directory was never populated when the cache was created. Every style-checks run was effectively a
cold-cache P2 fetch.

## Changes

**Caching & parallelism**
- `-T 1C` on the Maven invocation. Spotless is configured in the root `<build><plugins>` (not `<pluginManagement>`), so
  the goal walks every one of ~150 modules; this was previously sequential.
- Enable `setup-java`'s broad maven cache (`cache: 'maven'`).
- Dedicated `actions/cache` for `~/.m2/repository/dev/equo`, the location Equo uses for P2 data since spotless 2.37.0.
  Cache key is derived from the spotless plugin version (extracted from `pom.xml` at runtime so a bump auto-invalidates)
  plus a hash of `ide-config/eclipse-format.xml` and `ide-config/eclipse.importorder`. After one successful run, the
  bundles are read from disk and OkHttp never reaches `download.eclipse.org`.

**Defensive timeouts** — multiple HTTP stacks are in play; each layer needs its own knob:
- `-Daether.connector.connectTimeout=10000`, `-Daether.connector.requestTimeout=30000`,
  `-Daether.connector.http.retryHandler.count=1` cap Maven Resolver calls. (Default `requestTimeout` is 1 800 000 ms /
  30 min — silent stalls of that length matched it exactly.)
- `-Dsun.net.client.defaultConnectTimeout=10000`, `-Dsun.net.client.defaultReadTimeout=30000` cap any
  `HttpURLConnection`-based code path — notably `gradle-api-maven-plugin`'s `URL.openStream()` for the Gradle
  distribution.
- `timeout-minutes: 5` on the `Check Format` step is the hard cap that catches anything no system property reaches —
  primarily the OkHttp/Equo path. On a cold cache where the Equo fetch hangs, the step now fails clearly in 5 min
  instead of stalling for 15+.

**Other cleanups**
- Strip `_remote.repositories` tracker files after cache restore. Without this, Maven 3.9 re-validates ~188 cached
  artifacts against Maven Central on every run because the cache was populated by a workflow with different repository
  IDs — itself a slow path and a historical source of flakes.
- Rename `Check Format (only on touched files)` → `Check Format`. Spotless was always running on every file
  (`ratchetFrom` was never configured), so the original step name was misleading. `fetch-depth: 0` on the checkout was
  also removed since it only existed to support an unconfigured ratchet.

## Verification

After all changes, the workflow was re-run 6 consecutive times on `553f7fe2d0`:

| Attempt | Duration | Conclusion |
|---|---|---|
| 1 | 1 m 18 s | success |
| 2 | 57 s | success |
| 3 | 57 s | success |
| 4 | 1 m 02 s | success |
| 5 | 1 m 04 s | success |
| 6 | 1 m 04 s | success |

Min 57 s, max 1 m 18 s, mean ~64 s; range 21 s. Versus 10–25 min typical and 42 min worst case on `main`.

## Caveats

- The first run after any future spotless bump invalidates `spotless-equo-*` and has to fetch P2 bundles fresh; if
  OkHttp hangs in that window, the 5-min step timeout fires and a re-run usually succeeds.
- `spotless-maven-plugin` is already at the current latest (3.5.1) — no plugin bump included.
- ARM-64 runners aren't tested here (the workflow uses `ubuntu-latest`); the symptoms suggest they'd benefit similarly,
  but that's unverified.