### PR TITLE
chore(ci): route spotless P2 fetches through a mirror

### DIFF
--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -62,32 +62,19 @@ jobs:
         # re-validate each cached artifact against Maven Central. A slow
         # Central response can then stall the job for many minutes.
         run: find ~/.m2/repository -name _remote.repositories -delete 2>/dev/null || true
-      - name: Resolve spotless version
-        # Drive the Equo P2 cache key off the actual plugin version in the
-        # root pom, so a spotless bump auto-invalidates the cache.
-        run: |
-          V=$(grep -oE '<spotless-maven-plugin\.version>[^<]+' pom.xml | sed 's/.*>//')
-          echo "SPOTLESS_VERSION=$V" >> "$GITHUB_ENV"
-      - name: Cache spotless Equo P2 data
-        # Pre-populates ~/.m2/repository/dev/equo/p2-data so spotless's
-        # eclipse / greclipse formatters don't have to fetch Eclipse plugin
-        # bundles from download.eclipse.org via OkHttp on every run.
-        # OkHttp is configured without timeouts by Equo, so a P2 fetch that
-        # stalls hangs the job indefinitely — the cache makes this a
-        # cold-key-only risk, contained by the step timeout below.
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository/dev/equo
-          key: spotless-equo-${{ runner.os }}-${{ env.SPOTLESS_VERSION }}-${{ hashFiles('ide-config/eclipse-format.xml', 'ide-config/eclipse.importorder') }}
-          restore-keys: |
-            spotless-equo-${{ runner.os }}-${{ env.SPOTLESS_VERSION }}-
-            spotless-equo-${{ runner.os }}-
       - name: Check License Headers
         run: ./mvnw ${MAVEN_ARGS} -Pitests -N license:check
       - name: Check Format
-        # If OkHttp hangs on a cold Equo cache, fail in 5 min with a clear
-        # timeout instead of stalling for 15+ minutes (Aether/JVM timeouts
-        # don't reach OkHttp; only the cache and this hard cap protect us).
+        # Spotless's eclipse formatter pulls Eclipse JDT bundles via Equo's P2
+        # client, which uses OkHttp without timeouts and stalls indefinitely on
+        # download.eclipse.org. We work around this by routing those fetches
+        # through a P2 mirror configured in the root pom (<p2Mirrors> on the
+        # spotless plugin's <eclipse> block).
+        #
+        # If this step starts hanging again, the mirror is the most likely
+        # culprit — switch to one of the alternatives listed alongside the
+        # <p2Mirrors> entry in pom.xml. The 5-minute cap is a safety net so a
+        # mirror outage fails fast instead of consuming the full job budget.
         timeout-minutes: 5
         run: ./mvnw ${MAVEN_ARGS} -Pitests spotless:check
       - name: Cancel PR workflows on failure

--- a/pom.xml
+++ b/pom.xml
@@ -1159,6 +1159,26 @@
             </includes>
             <eclipse>
               <file>ide-config/eclipse-format.xml</file>
+              <!--
+                Route Equo's P2 fetches through OSU Open Source Lab. The default
+                https://download.eclipse.org/ origin uses HTTP/2 keep-alive frames
+                that defeat OkHttp's per-stream timeout (Equo builds the client
+                with no callTimeout), so cold-cache CI runs stall indefinitely.
+                The mirror serves the same paths over plain HTTPS and downloads
+                reliably in ~30s.
+
+                If this mirror ever becomes unreliable, alternatives that have
+                been verified to host the same /eclipse/updates/ tree:
+                  https://mirror.umd.edu/eclipse/
+                  https://ftp.halifax.rwth-aachen.de/eclipse/
+                  https://www.mirrorservice.org/sites/download.eclipse.org/eclipseMirror/
+              -->
+              <p2Mirrors>
+                <p2Mirror>
+                  <prefix>https://download.eclipse.org/</prefix>
+                  <url>https://ftp.osuosl.org/pub/eclipse/</url>
+                </p2Mirror>
+              </p2Mirrors>
             </eclipse>
             <importOrder>
               <file>ide-config/eclipse.importorder</file>
@@ -1173,7 +1193,24 @@
               <include>src/it/**/*.groovy</include>
             </includes>
             <importOrder/>
-            <greclipse/>
+            <greclipse>
+              <!--
+                See the rationale in the <eclipse> block above; greclipse also
+                fetches Eclipse 4.x bundles. With <p2Mirrors> present, spotless
+                rejects any P2 URL whose prefix isn't listed here, so we also
+                pass groovy.jfrog.io through (identity mapping = allow as-is).
+              -->
+              <p2Mirrors>
+                <p2Mirror>
+                  <prefix>https://download.eclipse.org/</prefix>
+                  <url>https://ftp.osuosl.org/pub/eclipse/</url>
+                </p2Mirror>
+                <p2Mirror>
+                  <prefix>https://groovy.jfrog.io/</prefix>
+                  <url>https://groovy.jfrog.io/</url>
+                </p2Mirror>
+              </p2Mirrors>
+            </greclipse>
           </groovy>
         </configuration>
       </plugin>


### PR DESCRIPTION
## Summary
- Spotless's Equo P2 client uses OkHttp without callTimeout, so cold-cache fetches from `download.eclipse.org` stall indefinitely on CI.
- The cache mitigation in 3f6319de2a / #7850 couldn't bootstrap (cold download exceeded the 5-min step cap), so the cache never saved.
- Configures `<p2Mirrors>` on `<eclipse>` and `<greclipse>` to route `/eclipse/updates/` traffic through `ftp.osuosl.org`. Since `<p2Mirrors>` is whitelist-mode, `<greclipse>` also identity-maps `groovy.jfrog.io`.
- Drops the now-redundant `Cache spotless Equo P2 data` and `Resolve spotless version` steps from the workflow; keeps the 5-min safety cap and the `_remote.repositories` cleanup.

## Test plan
- [x] Cleared `~/.m2/repository/dev/equo` and ran `./mvnw -N spotless:check` → `BUILD SUCCESS` in ~2 min (vs prior indefinite hangs).
- [x] Confirmed cache populated under `bundle-pool/https-ftp.osuosl.org-pub-eclipse-eclipse-updates-{4.35,4.39}-…`.
- [x] Warm-cache `spotless:check -pl kubernetes-client-api` (344 files) → 6.7s.
- [x] Style Checks workflow passes on this PR's commit.