### PR TITLE
test(mockwebserver): treat connect-future failure as close observation (#7806)

### DIFF
--- a/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/DefaultMockServerWebSocketTest.groovy
+++ b/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/DefaultMockServerWebSocketTest.groovy
@@ -125,6 +125,15 @@ class DefaultMockServerWebSocketTest extends Specification {
 		wsReq.onComplete { ws ->
 			if (ws.failed() || ws.result() == null) {
 				System.err.println("$DIAG_PREFIX onComplete failed: " + ws.cause())
+				// Any connect-Future failure on the close-immediately server is itself
+				// evidence the client observed the close. Vert.x 4.5 surfaces it as ISE
+				// ("WebSocket is closed") when checkClosed() fires inside the post-connect
+				// handler-setup andThen block, and as WebSocketHandshakeException when
+				// channelInactive fires mid-handshake. Both are valid observations
+				// (#7806 follow-up to #7811).
+				if (ws.failed()) {
+					closeObserved.set(true)
+				}
 				return
 			}
 			def w = ws.result()


### PR DESCRIPTION
Follow-up to #7811. CI diagnostic logging from #7811 showed the residual Windows flake hits a 4th close-observation path that the split missed.

## What the diagnostic logs revealed

From the failed run (job [76963726565](https://github.com/fabric8io/kubernetes-client/actions/runs/26164204996/job/76963726565)):

```
[7806/Windows Server 2025] onComplete failed: java.lang.IllegalStateException: WebSocket is closed
```

The `wsReq` connect Future itself failed before `result()` was observable: the server completed the upgrade and closed before the client's `onComplete` ran. The test currently `return`s on that branch without setting `closeObserved`, so polling times out.

## Why this happens

Vert.x 4.5 wires post-connect handler setup through `ClientWebSocketImpl.andThen`, which calls several `WebSocketImplBase` setters that invoke `checkClosed()` unconditionally. When the server closes between the success-promise resolution and the `andThen` dispatch, `checkClosed()` throws `ISE("WebSocket is closed")` and that propagates out as the Future cause.

A rarer 5th path: `channelInactive` firing mid-handshake fails the same Future with `WebSocketHandshakeException` instead.

## What this changes

When `ws.failed()` is true, mark `closeObserved` set. Any post-server-accept connect-Future failure on the close-immediately mock is itself evidence of the close, since the test's contract is "client observes close." Diagnostic logging from #7811 is preserved so the cause prints to surefire before the flag flips, keeping any future surprise triageable.

No CHANGELOG entry, internal test stabilization.

Closes #7806