### PR TITLE
fix(kube-api-test): fail fast on unexpected child-process exit

### DIFF
--- a/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/process/EtcdProcess.java
+++ b/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/process/EtcdProcess.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.function.BooleanSupplier;
 
 import static io.fabric8.kubeapitest.Utils.deleteDirectory;
 
@@ -80,7 +81,7 @@ public class EtcdProcess {
       etcdProcess.onExit().thenApply(p -> {
         if (!stopped) {
           stopped = true;
-          logger.error("etcd process stopped unexpectedly");
+          logger.error("etcd process stopped unexpectedly with exit code {}", p.exitValue());
           processStopHandler.processStopped(p);
         }
         return null;
@@ -96,7 +97,11 @@ public class EtcdProcess {
   }
 
   private void waitUntilEtcdHealthy(int port) {
-    new ProcessReadinessChecker().waitUntilReady(port, "health", "etcd", false, startupTimeout);
+    // Abort the readiness wait promptly if etcd exits unexpectedly during startup, instead of
+    // running out the full startupTimeout on a dead process (see #7807).
+    BooleanSupplier abortCheck = () -> etcdProcess != null && !etcdProcess.isAlive();
+    new ProcessReadinessChecker().waitUntilReady(port, "health", "etcd", false, startupTimeout,
+        null, abortCheck);
   }
 
   public void cleanEtcdData() {

--- a/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/process/KubeAPIServerProcess.java
+++ b/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/process/KubeAPIServerProcess.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.BooleanSupplier;
 
 public class KubeAPIServerProcess {
 
@@ -69,7 +70,7 @@ public class KubeAPIServerProcess {
       apiServerProcess.onExit().thenApply(p -> {
         if (!stopped) {
           stopped = true;
-          logger.error("API Server process stopped unexpectedly");
+          logger.error("API Server process stopped unexpectedly with exit code {}", p.exitValue());
           this.processStopHandler.processStopped(p);
         }
         return null;
@@ -106,10 +107,14 @@ public class KubeAPIServerProcess {
     var readinessChecker = new ProcessReadinessChecker();
     var timeout = config.getStartupTimeout();
     var startTime = System.currentTimeMillis();
-    readinessChecker.waitUntilReady(apiServerPort, "readyz", KUBE_API_SERVER, true, timeout, certManager);
+    // Abort the readiness wait promptly if the apiserver process exits unexpectedly during
+    // startup, instead of running out the full startupTimeout on a dead process (see #7807).
+    BooleanSupplier abortCheck = () -> apiServerProcess != null && !apiServerProcess.isAlive();
+    readinessChecker.waitUntilReady(apiServerPort, "readyz", KUBE_API_SERVER, true, timeout,
+        certManager, abortCheck);
     var newTimout = (int) (timeout - (System.currentTimeMillis() - startTime));
     readinessChecker.waitUntilDefaultNamespaceAvailable(apiServerPort, binaryManager, certManager,
-        config, newTimout);
+        config, newTimout, abortCheck);
   }
 
   public void stopApiServer() {

--- a/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/process/ProcessReadinessChecker.java
+++ b/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/process/ProcessReadinessChecker.java
@@ -72,8 +72,15 @@ public class ProcessReadinessChecker {
 
   public void waitUntilDefaultNamespaceAvailable(int apiServerPort, BinaryManager binaryManager,
       CertManager certManager, KubeAPIServerConfig config, int timeoutMillis) {
+    waitUntilDefaultNamespaceAvailable(apiServerPort, binaryManager, certManager, config,
+        timeoutMillis, null);
+  }
+
+  public void waitUntilDefaultNamespaceAvailable(int apiServerPort, BinaryManager binaryManager,
+      CertManager certManager, KubeAPIServerConfig config, int timeoutMillis,
+      BooleanSupplier abortCheck) {
     pollWithTimeout(() -> defaultNamespaceExists(apiServerPort, binaryManager, certManager, config),
-        KUBE_API_SERVER, timeoutMillis);
+        KUBE_API_SERVER, timeoutMillis, abortCheck);
   }
 
   private boolean defaultNamespaceExists(int apiServerPort, BinaryManager binaryManager,
@@ -111,7 +118,7 @@ public class ProcessReadinessChecker {
 
   public void waitUntilReady(int port, String readyCheckPath, String processName,
       boolean useTLS, int timeoutMillis) {
-    waitUntilReady(port, readyCheckPath, processName, useTLS, timeoutMillis, null);
+    waitUntilReady(port, readyCheckPath, processName, useTLS, timeoutMillis, null, null);
   }
 
   /**
@@ -124,16 +131,34 @@ public class ProcessReadinessChecker {
    */
   public void waitUntilReady(int port, String readyCheckPath, String processName,
       boolean useTLS, int timeoutMillis, CertManager certManager) {
+    waitUntilReady(port, readyCheckPath, processName, useTLS, timeoutMillis, certManager, null);
+  }
+
+  /**
+   * Same as {@link #waitUntilReady(int, String, String, boolean, int, CertManager)}, but accepts
+   * an {@code abortCheck} supplier consulted between polls. When the supplier returns {@code true}
+   * (e.g. the underlying child process has exited unexpectedly) the wait is aborted immediately
+   * instead of running out the full timeout. This keeps a failed startup from stalling the main
+   * thread the entire {@code startupTimeout} window (see #7807).
+   */
+  public void waitUntilReady(int port, String readyCheckPath, String processName,
+      boolean useTLS, int timeoutMillis, CertManager certManager, BooleanSupplier abortCheck) {
     HttpClient client = getHttpClient(certManager);
     HttpRequest request = getHttpRequest(useTLS, readyCheckPath, port);
-    pollWithTimeout(() -> ready(client, request, processName, port), processName, timeoutMillis);
+    pollWithTimeout(() -> ready(client, request, processName, port), processName, timeoutMillis,
+        abortCheck);
   }
 
   private static void pollWithTimeout(BooleanSupplier predicate, String processName,
-      int timeoutMillis) {
+      int timeoutMillis, BooleanSupplier abortCheck) {
     try {
       LocalTime startedAt = LocalTime.now();
       while (true) {
+        // abortCheck is consulted before the (potentially slow, network-bound) predicate so an
+        // already-dead child process does not burn another HTTP-timeout window before throwing.
+        if (abortCheck != null && abortCheck.getAsBoolean()) {
+          throw new KubeAPITestException(processName + " exited before becoming ready");
+        }
         if (predicate.getAsBoolean()) {
           return;
         }

--- a/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/process/ProcessReadinessCheckerTest.java
+++ b/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/process/ProcessReadinessCheckerTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubeapitest.process;
+
+import com.sun.net.httpserver.HttpServer;
+import io.fabric8.kubeapitest.KubeAPITestException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+
+class ProcessReadinessCheckerTest {
+
+  private HttpServer httpServer;
+  private int port;
+  private ProcessReadinessChecker checker;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    httpServer = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    httpServer.createContext("/readyz-ok", exchange -> {
+      exchange.sendResponseHeaders(200, -1);
+      exchange.close();
+    });
+    httpServer.createContext("/readyz-not-ready", exchange -> {
+      exchange.sendResponseHeaders(503, -1);
+      exchange.close();
+    });
+    httpServer.start();
+    port = httpServer.getAddress().getPort();
+    checker = new ProcessReadinessChecker();
+  }
+
+  @AfterEach
+  void tearDown() {
+    httpServer.stop(0);
+  }
+
+  @Test
+  void waitUntilReadyAbortsPromptlyWhenAbortCheckFlips() throws InterruptedException {
+    AtomicBoolean aborted = new AtomicBoolean(false);
+    Thread flipper = new Thread(() -> {
+      try {
+        Thread.sleep(ProcessReadinessChecker.POLLING_INTERVAL * 2L);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      aborted.set(true);
+    });
+    flipper.start();
+
+    long start = System.currentTimeMillis();
+    KubeAPITestException ex = catchThrowableOfType(() -> checker.waitUntilReady(
+        port, "readyz-not-ready", "test-process", false, 60_000, null, aborted::get),
+        KubeAPITestException.class);
+    long elapsed = System.currentTimeMillis() - start;
+    flipper.join();
+
+    assertThat(ex).isNotNull();
+    assertThat(ex).hasMessageContaining("test-process").hasMessageContaining("exited");
+    // Generous upper bound — the assertion is that the wait aborts well before the 60s
+    // startupTimeout, not that it returns in microseconds. HttpClient/JSSE cold start on a
+    // contended 2-vCPU CI runner can chew several seconds.
+    assertThat(elapsed).isLessThan(15_000L);
+  }
+
+  @Test
+  void waitUntilReadyReturnsNormallyOnHealthyResponse() {
+    AtomicBoolean aborted = new AtomicBoolean(false);
+    checker.waitUntilReady(port, "readyz-ok", "test-process", false, 10_000, null, aborted::get);
+  }
+
+  @Test
+  void waitUntilReadyTimesOutWhenAbortCheckNullAndNotReady() {
+    long start = System.currentTimeMillis();
+    KubeAPITestException ex = catchThrowableOfType(() -> checker.waitUntilReady(
+        port, "readyz-not-ready", "test-process", false, 500, null, null),
+        KubeAPITestException.class);
+    long elapsed = System.currentTimeMillis() - start;
+
+    assertThat(ex).isNotNull();
+    assertThat(ex).hasMessageContaining("test-process").hasMessageContaining("did not start properly");
+    assertThat(elapsed).isGreaterThanOrEqualTo(500L);
+  }
+}

--- a/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/process/ProcessReadinessCheckerTest.java
+++ b/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/process/ProcessReadinessCheckerTest.java
@@ -75,9 +75,10 @@ class ProcessReadinessCheckerTest {
     long elapsed = System.currentTimeMillis() - start;
     flipper.join();
 
-    assertThat(ex).isNotNull();
-    assertThat(ex).hasMessageContaining("test-process").hasMessageContaining("exited");
-    // Generous upper bound — the assertion is that the wait aborts well before the 60s
+    assertThat(ex).isNotNull()
+        .hasMessageContaining("test-process")
+        .hasMessageContaining("exited");
+    // Generous upper bound. The assertion is that the wait aborts well before the 60s
     // startupTimeout, not that it returns in microseconds. HttpClient/JSSE cold start on a
     // contended 2-vCPU CI runner can chew several seconds.
     assertThat(elapsed).isLessThan(15_000L);
@@ -97,8 +98,11 @@ class ProcessReadinessCheckerTest {
         KubeAPITestException.class);
     long elapsed = System.currentTimeMillis() - start;
 
-    assertThat(ex).isNotNull();
-    assertThat(ex).hasMessageContaining("test-process").hasMessageContaining("did not start properly");
-    assertThat(elapsed).isGreaterThanOrEqualTo(500L);
+    assertThat(ex).isNotNull()
+        .hasMessageContaining("test-process")
+        .hasMessageContaining("did not start properly");
+    // Lower bound proves the timeout actually fired; upper bound guards against a hypothetical
+    // regression that drops out of the polling loop into an unbounded wait.
+    assertThat(elapsed).isGreaterThanOrEqualTo(500L).isLessThan(30_000L);
   }
 }


### PR DESCRIPTION
Implements open question #2 from the investigation in #7807.

`ProcessReadinessChecker.pollWithTimeout` previously polled obliviously
to child-process state, so when kube-apiserver or etcd exited
unexpectedly during startup the main thread stalled the full
`startupTimeout` (120s post-#7836) before throwing.

A new `BooleanSupplier abortCheck` is consulted between polls (and
before the slow predicate, so an already-dead process does not burn
another HTTP-timeout window). `KubeAPIServerProcess` and `EtcdProcess`
pass `() -> !process.isAlive()` so the loop bails out promptly on
unexpected child exit. The thrown message is `"<processName> exited
before becoming ready"`, distinct from the existing `"did not start
properly"` timeout message so CI logs disambiguate the two failure
modes.

`onExit` handlers also now log the exit code at ERROR level so the
failure is triageable from surefire output without enabling DEBUG.

Refs #7807