### PR TITLE
fix(sonar): suppress S3077 false positives on volatile fields

### DIFF
--- a/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkWebSocketImpl.java
+++ b/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkWebSocketImpl.java
@@ -35,6 +35,7 @@ class JdkWebSocketImpl implements WebSocket, java.net.http.WebSocket.Listener {
 
   private static final Logger logger = LoggerFactory.getLogger(JdkWebSocketImpl.class);
 
+  @SuppressWarnings("java:S3077") // volatile ensures cross-thread visibility; JDK WebSocket is thread-safe
   private volatile java.net.http.WebSocket webSocket;
   private final AtomicLong queueSize = new AtomicLong();
   private final Listener listener;

--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyWebSocket.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyWebSocket.java
@@ -53,6 +53,7 @@ public class JettyWebSocket implements WebSocket, WebSocketListener {
   private final CompletableFuture<Void> terminated = new CompletableFuture<>();
   private final AtomicBoolean outputClosed = new AtomicBoolean();
   private boolean moreMessages;
+  @SuppressWarnings("java:S3077") // volatile publishes the session reference; Jetty Session is thread-safe
   private volatile Session webSocketSession;
 
   public JettyWebSocket(WebSocket.Listener listener) {

--- a/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/process/EtcdProcess.java
+++ b/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/process/EtcdProcess.java
@@ -35,6 +35,7 @@ public class EtcdProcess {
 
   private final BinaryManager binaryManager;
 
+  @SuppressWarnings("java:S3077") // volatile ensures cross-thread visibility; Process methods are thread-safe
   private volatile Process etcdProcess;
   private volatile boolean stopped = false;
   private final UnexpectedProcessStopHandler processStopHandler;

--- a/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/process/KubeAPIServerProcess.java
+++ b/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/process/KubeAPIServerProcess.java
@@ -40,6 +40,7 @@ public class KubeAPIServerProcess {
   private final CertManager certManager;
   private final BinaryManager binaryManager;
   private final KubeAPIServerConfig config;
+  @SuppressWarnings("java:S3077") // volatile ensures cross-thread visibility; Process methods are thread-safe
   private volatile Process apiServerProcess;
   private volatile boolean stopped = false;
   private final UnexpectedProcessStopHandler processStopHandler;

--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/MockWebServer.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/MockWebServer.java
@@ -87,6 +87,7 @@ public class MockWebServer implements Closeable {
   private final BlockingQueue<RecordedRequest> requestQueue;
   private final AtomicInteger requestCount;
   private final List<MockWebServerListener> listeners;
+  @SuppressWarnings("java:S3077") // volatile reference-swap; Dispatcher implementations are thread-safe
   private volatile Dispatcher dispatcher;
   private ClientAuth clientAuth;
   private final List<String> enabledSecuredTransportProtocols;

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
@@ -45,6 +45,7 @@ public class Serialization {
   public static final UnmatchedFieldTypeModule UNMATCHED_FIELD_TYPE_MODULE = kubernetesSerialization
       .getUnmatchedFieldTypeModule();
 
+  @SuppressWarnings("java:S3077") // double-checked locking; volatile ensures safe publication
   private static volatile ObjectMapper YAML_MAPPER;
 
   /**

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManager.java
@@ -124,6 +124,7 @@ public abstract class AbstractWatchManager<T extends HasMetadata> implements Wat
 
   private final boolean receiveBookmarks;
 
+  @SuppressWarnings("java:S3077") // inner fields (AtomicBoolean, CompletableFuture) are thread-safe
   volatile WatchRequestState latestRequestState;
   private final Map<Class<?>, Integer> endErrors = new ConcurrentHashMap<>();
   private AtomicInteger retryAfterSeconds = new AtomicInteger();

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/LogWatchCallback.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/LogWatchCallback.java
@@ -41,6 +41,7 @@ public class LogWatchCallback implements LogWatch, AutoCloseable {
 
   private final OutputStream out;
   private WritableByteChannel outChannel;
+  @SuppressWarnings("java:S3077") // volatile provides safe publication of the InputStream reference
   private volatile InputStream output;
 
   private final AtomicBoolean closed = new AtomicBoolean(false);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
@@ -43,6 +43,7 @@ public class WatchConnectionManager<T extends HasMetadata, L extends KubernetesR
 
   private final long connectTimeoutMillis;
   protected WatcherWebSocketListener<T> listener;
+  @SuppressWarnings("java:S3077") // CompletableFuture is thread-safe; volatile ensures reference visibility
   private volatile CompletableFuture<WebSocket> websocketFuture;
 
   volatile boolean ready;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchHTTPManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchHTTPManager.java
@@ -37,6 +37,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class WatchHTTPManager<T extends HasMetadata, L extends KubernetesResourceList<T>> extends AbstractWatchManager<T> {
   private CompletableFuture<HttpResponse<AsyncBody>> call;
+  @SuppressWarnings("java:S3077") // volatile reference-swap; AsyncBody is designed for concurrent use
   private volatile AsyncBody body;
 
   public WatchHTTPManager(final HttpClient client,

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/Reflector.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/Reflector.java
@@ -50,13 +50,16 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
   private final ProcessorStore<T> store;
   private final ReflectorWatcher watcher;
   private volatile boolean watching;
+  @SuppressWarnings("java:S3077") // CompletableFuture is thread-safe; volatile ensures reference visibility
   private volatile CompletableFuture<AbstractWatchManager<T>> watchFuture;
+  @SuppressWarnings("java:S3077") // CompletableFuture is thread-safe; volatile ensures reference visibility
   private volatile CompletableFuture<?> reconnectFuture;
   private final CompletableFuture<Void> startFuture = new CompletableFuture<>();
   private final CompletableFuture<Void> stopFuture = new CompletableFuture<>();
   private final ExponentialBackoffIntervalCalculator retryIntervalCalculator;
   private final Executor executor;
   //default behavior - retry if started and it's not a watcherexception
+  @SuppressWarnings("java:S3077") // volatile reference-swap; the handler lambda is stateless
   private volatile ExceptionHandler handler = (b, t) -> b && !(t instanceof WatcherException);
   private long minTimeout = MIN_TIMEOUT;
 
@@ -70,6 +73,7 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
   }
 
   private boolean watchList;
+  @SuppressWarnings("java:S3077") // inner fields (ConcurrentSkipListSet, CompletableFuture) are thread-safe
   private volatile WatchListState watchListState;
 
   public Reflector(ListerWatcher<T, L> listerWatcher, ProcessorStore<T> store) {


### PR DESCRIPTION
## Summary

Resolves #7831

- Added `@SuppressWarnings("java:S3077")` with justification comments to all 14 volatile fields flagged by SonarCloud rule S3077 across 11 files in 6 modules
- Each field was analyzed and confirmed to be a false positive — either a reference-swap pattern where `volatile` correctly ensures visibility, or wrapping a type that is itself thread-safe (`CompletableFuture`, `AtomicBoolean`, `ConcurrentSkipListSet`, JDK `Process`/`WebSocket`)
- No behavior changes — annotation-only suppression

### Classification

| Category | Fields | Count |
|----------|--------|-------|
| Thread-safe inner type | `watchFuture`, `reconnectFuture`, `websocketFuture` (CompletableFuture); `etcdProcess`, `apiServerProcess` (Process); `webSocket` (JDK WebSocket) | 6 |
| Thread-safe inner fields | `latestRequestState` (AtomicBoolean + CompletableFuture); `watchListState` (ConcurrentSkipListSet + CompletableFuture) | 2 |
| Reference-swap | `dispatcher`, `handler`, `body`, `output`, `webSocketSession` | 5 |
| Double-checked locking | `YAML_MAPPER` | 1 |

## Test plan

- [x] `make quickly` — BUILD SUCCESS
- [x] `mvn spotless:check` — formatting clean
- [x] Tests for affected modules pass (315/316; sole failure `UploadTest.bigNumbersSupported` is pre-existing on `main`)
- [x] No API or behavior changes — annotation-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)