### PR TITLE
fix(sonar): pin third-party GitHub Actions to full commit SHAs (S7637)

### DIFF
--- a/.github/workflows/e2e-chaos-tests.yml
+++ b/.github/workflows/e2e-chaos-tests.yml
@@ -62,7 +62,7 @@ jobs:
           distribution: "temurin"
           cache: maven
       - name: Setup Kubectl # Chaos-Mesh setup requires a functional kubectl version for all cluster versiones
-        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5
+        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
         with:
           version: ${{ matrix.kubernetes }}
       - name: Install Chaos Mesh

--- a/.github/workflows/e2e-chaos-tests.yml
+++ b/.github/workflows/e2e-chaos-tests.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.18.0
+        uses: manusa/actions-setup-minikube@b65276017fdec6f1e6498129fb740e34e260dc55 # v2.18.0
         with:
           minikube version: v1.38.1
           kubernetes version: ${{ matrix.kubernetes }}
@@ -62,7 +62,7 @@ jobs:
           distribution: "temurin"
           cache: maven
       - name: Setup Kubectl # Chaos-Mesh setup requires a functional kubectl version for all cluster versiones
-        uses: azure/setup-kubectl@v5
+        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5
         with:
           version: ${{ matrix.kubernetes }}
       - name: Install Chaos Mesh

--- a/.github/workflows/e2e-httpclient-tests.yml
+++ b/.github/workflows/e2e-httpclient-tests.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.18.0
+        uses: manusa/actions-setup-minikube@b65276017fdec6f1e6498129fb740e34e260dc55 # v2.18.0
         with:
           minikube version: v1.38.1
           kubernetes version: ${{ matrix.kubernetes }}

--- a/.github/workflows/e2e-osci-tests.yml
+++ b/.github/workflows/e2e-osci-tests.yml
@@ -44,7 +44,7 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
       - name: Install oc
-        uses: redhat-actions/oc-installer@v1
+        uses: redhat-actions/oc-installer@35b60c3f9757ae4301521556e1b75ff6f59f8d7c # v1
       - name: Login to OpenShift
         run: |
           oc login --server=${{ secrets.OSCI_SERVER }} --token=${{ secrets.OSCI_TOKEN }}

--- a/.github/workflows/e2e-osci-tests.yml
+++ b/.github/workflows/e2e-osci-tests.yml
@@ -44,7 +44,7 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
       - name: Install oc
-        uses: redhat-actions/oc-installer@35b60c3f9757ae4301521556e1b75ff6f59f8d7c # v1
+        uses: redhat-actions/oc-installer@35b60c3f9757ae4301521556e1b75ff6f59f8d7c # v1.2
       - name: Login to OpenShift
         run: |
           oc login --server=${{ secrets.OSCI_SERVER }} --token=${{ secrets.OSCI_TOKEN }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.18.0
+        uses: manusa/actions-setup-minikube@b65276017fdec6f1e6498129fb740e34e260dc55 # v2.18.0
         with:
           minikube version: v1.38.1
           kubernetes version: ${{ matrix.kubernetes }}

--- a/.github/workflows/revapi-report.yml
+++ b/.github/workflows/revapi-report.yml
@@ -65,7 +65,7 @@ jobs:
           cache: 'maven'
 
       - name: Setup JBang
-        uses: jbangdev/setup-jbang@main
+        uses: jbangdev/setup-jbang@cc28889678db839e29433f42f9ff25f148b6d8de # main
 
       - name: Generate Revapi Reports
         env:


### PR DESCRIPTION
## Summary
- Pin 6 third-party GitHub Actions `uses:` entries to full 40-character commit SHAs, resolving SonarCloud S7637 security hotspots
- Each SHA includes a trailing version comment for readability (e.g., `# v2.18.0`)
- Dependabot `github-actions` ecosystem already configured — no changes needed

### Actions pinned
| Action | SHA | Version |
|--------|-----|---------|
| `manusa/actions-setup-minikube` | `b65276017fdec6f1e6498129fb740e34e260dc55` | v2.18.0 |
| `azure/setup-kubectl` | `829323503d1be3d00ca8346e5391ca0b07a9ab0d` | v5.1.0 |
| `redhat-actions/oc-installer` | `35b60c3f9757ae4301521556e1b75ff6f59f8d7c` | v1.2 |
| `jbangdev/setup-jbang` | `cc28889678db839e29433f42f9ff25f148b6d8de` | main |

Fixes #7844

## Test plan
- [x] All YAML files parse successfully
- [x] No remaining unpinned third-party actions in workflows
- [x] All SHAs verified as commit SHAs (not tag objects) via `git ls-remote`
- [ ] CI workflows execute successfully with pinned SHAs

🤖 Generated with [Claude Code](https://claude.com/claude-code)