### PR TITLE
chore(deps): bump vertx5.version from 5.0.12 to 5.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Fix #7894: bump k8s.io/autoscaler/vertical-pod-autoscaler from 1.6.0 to 1.7.0
 * Fix #7894: bump k8s.io/gengo/v2 from 2.0.0-20251215205346-5ee0d033ba5b to 2.0.0-20260408192533-25e2208e0dc3
 * Fix #7894: bump k8s.io/kube-openapi from 0.0.0-20260319004828-5883c5ee87b9 to 0.0.0-20260414162039-ec9c827d403f
+* Fix #7875: bump vertx5.version from 5.0.12 to 5.1.1, adapting httpclient-vertx-5 to Vert.x 5.1 behaviour changes (SSL engine options no longer accept an empty protocol array; request-body stream errors are reset with HTTP/2 CANCEL so they are not retried as transient IOExceptions)
 
 #### New Features
 * Fix #5084: Jbang scripts to generate graalVM metadata

--- a/httpclient-vertx-5/src/main/java/io/fabric8/kubernetes/client/vertx5/InputStreamReadStream.java
+++ b/httpclient-vertx-5/src/main/java/io/fabric8/kubernetes/client/vertx5/InputStreamReadStream.java
@@ -106,18 +106,13 @@ class InputStreamReadStream implements ReadStream<Buffer> {
       return;
     }
     errored = true;
-    // Vert.x 5.1's pipe (used internally by req.send(stream)) treats source failures by calling
-    // dst.end() — for an HTTP request that writes a clean truncated chunked body and leaves the
-    // response future pending forever waiting for a server reply. Reset the request directly so
-    // the failure propagates to the response promise.
+    // Reset instead of relying on the pipe: on source failure the pipe just end()s the request,
+    // sending a truncated-but-valid chunked body and leaving the response pending forever.
     //
-    // We deliberately pass null as the reset cause: HttpClientRequestImpl#mapException in 5.1
-    // unwraps StreamResetException(code, cause) to the original cause, so passing the IOException
-    // here would surface as IOException on the response. StandardHttpClient's retry layer treats
-    // IOException as retryable, but a half-sent request body cannot be replayed — we'd retry
-    // until the user-facing timeout. Passing null cause leaves the response failing with
-    // StreamResetException, which is not retried; the original cause is still forwarded to the
-    // pipe via the exceptionHandler below.
+    // No cause on purpose: since 5.1, HttpClientRequestBase#mapException unwraps the reset cause,
+    // and surfacing our IOException would make StandardHttpClient retry an unreplayable half-sent
+    // body until timeout. A bare StreamResetException is not retried; the cause still reaches the
+    // pipe via the exceptionHandler below. 0x8 = HTTP/2 CANCEL, same as Vert.x's own cancel().
     request.reset(0x8);
     if (exceptionHandler != null) {
       exceptionHandler.handle(cause);

--- a/httpclient-vertx-5/src/main/java/io/fabric8/kubernetes/client/vertx5/InputStreamReadStream.java
+++ b/httpclient-vertx-5/src/main/java/io/fabric8/kubernetes/client/vertx5/InputStreamReadStream.java
@@ -31,6 +31,7 @@ class InputStreamReadStream implements ReadStream<Buffer> {
   private final StreamFlowController flowController;
 
   private Handler<Throwable> exceptionHandler;
+  private boolean errored;
 
   InputStreamReadStream(Vertx5HttpRequest vertxHttpRequest, InputStream inputStream, HttpClientRequest request) {
     this.vertxHttpRequest = vertxHttpRequest;
@@ -64,6 +65,9 @@ class InputStreamReadStream implements ReadStream<Buffer> {
   }
 
   private void readChunk() {
+    if (errored) {
+      return;
+    }
     if (recursionGuard.enter()) {
       try {
         executeBlockingRead();
@@ -98,7 +102,23 @@ class InputStreamReadStream implements ReadStream<Buffer> {
   }
 
   private void handleReadError(final Throwable cause) {
-    request.reset(0, cause);
+    if (errored) {
+      return;
+    }
+    errored = true;
+    // Vert.x 5.1's pipe (used internally by req.send(stream)) treats source failures by calling
+    // dst.end() — for an HTTP request that writes a clean truncated chunked body and leaves the
+    // response future pending forever waiting for a server reply. Reset the request directly so
+    // the failure propagates to the response promise.
+    //
+    // We deliberately pass null as the reset cause: HttpClientRequestImpl#mapException in 5.1
+    // unwraps StreamResetException(code, cause) to the original cause, so passing the IOException
+    // here would surface as IOException on the response. StandardHttpClient's retry layer treats
+    // IOException as retryable, but a half-sent request body cannot be replayed — we'd retry
+    // until the user-facing timeout. Passing null cause leaves the response failing with
+    // StreamResetException, which is not retried; the original cause is still forwarded to the
+    // pipe via the exceptionHandler below.
+    request.reset(0x8);
     if (exceptionHandler != null) {
       exceptionHandler.handle(cause);
     }

--- a/httpclient-vertx-5/src/main/java/io/fabric8/kubernetes/client/vertx5/Vertx5HttpClientBuilder.java
+++ b/httpclient-vertx-5/src/main/java/io/fabric8/kubernetes/client/vertx5/Vertx5HttpClientBuilder.java
@@ -271,6 +271,9 @@ public class Vertx5HttpClientBuilder<F extends HttpClient.Factory>
 
       @Override
       public SslContextFactory sslContextFactory() {
+        // JdkSslContext interprets an empty String[] as "no protocols enabled", which JSSE then
+        // rejects with "No appropriate protocol". Pass null when the caller didn't request a
+        // specific TLS version so the JDK defaults apply.
         return () -> new JdkSslContext(
             sslContext,
             true,
@@ -278,7 +281,7 @@ public class Vertx5HttpClientBuilder<F extends HttpClient.Factory>
             IdentityCipherSuiteFilter.INSTANCE,
             ApplicationProtocolConfig.DISABLED,
             io.netty.handler.ssl.ClientAuth.NONE,
-            protocols,
+            protocols.length > 0 ? protocols : null,
             false);
       }
     };

--- a/httpclient-vertx-5/src/main/java/io/fabric8/kubernetes/client/vertx5/Vertx5HttpClientBuilder.java
+++ b/httpclient-vertx-5/src/main/java/io/fabric8/kubernetes/client/vertx5/Vertx5HttpClientBuilder.java
@@ -271,9 +271,11 @@ public class Vertx5HttpClientBuilder<F extends HttpClient.Factory>
 
       @Override
       public SslContextFactory sslContextFactory() {
-        // JdkSslContext interprets an empty String[] as "no protocols enabled", which JSSE then
-        // rejects with "No appropriate protocol". Pass null when the caller didn't request a
-        // specific TLS version so the JDK defaults apply.
+        // JdkSslContext treats an empty String[] as "no protocols enabled" and JSSE then rejects
+        // the handshake ("No appropriate protocol"). Harmless before Vert.x 5.1, which re-applied
+        // the option-level protocols to each engine (SslContextProvider#configureEngine); now the
+        // SPI's enabledProtocols(Set) — a no-op for this lambda factory — is the only override,
+        // so whatever is passed here is final. Null lets the JDK defaults apply.
         return () -> new JdkSslContext(
             sslContext,
             true,

--- a/httpclient-vertx-5/src/test/java/io/fabric8/kubernetes/client/vertx5/InputStreamReadStreamTest.java
+++ b/httpclient-vertx-5/src/test/java/io/fabric8/kubernetes/client/vertx5/InputStreamReadStreamTest.java
@@ -42,7 +42,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -58,9 +57,6 @@ class InputStreamReadStreamTest {
 
   @Captor
   private ArgumentCaptor<Long> resetCodeCaptor;
-
-  @Captor
-  private ArgumentCaptor<Throwable> resetCauseCaptor;
 
   private AutoCloseable mocks;
 
@@ -160,7 +156,7 @@ class InputStreamReadStreamTest {
     assertThat(exceptionRef.get()).isNotNull();
 
     await().atMost(1, TimeUnit.SECONDS)
-        .untilAsserted(() -> verify(httpRequest, times(1)).reset(anyLong(), any(Throwable.class)));
+        .untilAsserted(() -> verify(httpRequest, times(1)).reset(anyLong()));
   }
 
   @Test
@@ -293,9 +289,11 @@ class InputStreamReadStreamTest {
     assertThat(caughtException.get()).isInstanceOf(IOException.class);
 
     await().atMost(1, TimeUnit.SECONDS)
-        .untilAsserted(() -> verify(httpRequest).reset(resetCodeCaptor.capture(), resetCauseCaptor.capture()));
-    assertThat(resetCodeCaptor.getValue()).isZero();
-    assertThat(resetCauseCaptor.getValue()).isSameAs(caughtException.get());
+        .untilAsserted(() -> verify(httpRequest).reset(resetCodeCaptor.capture()));
+    // Vert.x 5.1: HTTP/2 CANCEL (0x8) rather than NO_ERROR (0x0); no cause arg so the response
+    // future fails with StreamResetException and is not unwrapped by mapException into the
+    // underlying IOException (which would be picked up by StandardHttpClient's retry layer).
+    assertThat(resetCodeCaptor.getValue()).isEqualTo(0x8L);
   }
 
   @Test

--- a/httpclient-vertx-5/src/test/java/io/fabric8/kubernetes/client/vertx5/InputStreamReadStreamTest.java
+++ b/httpclient-vertx-5/src/test/java/io/fabric8/kubernetes/client/vertx5/InputStreamReadStreamTest.java
@@ -290,9 +290,8 @@ class InputStreamReadStreamTest {
 
     await().atMost(1, TimeUnit.SECONDS)
         .untilAsserted(() -> verify(httpRequest).reset(resetCodeCaptor.capture()));
-    // Vert.x 5.1: HTTP/2 CANCEL (0x8) rather than NO_ERROR (0x0); no cause arg so the response
-    // future fails with StreamResetException and is not unwrapped by mapException into the
-    // underlying IOException (which would be picked up by StandardHttpClient's retry layer).
+    // HTTP/2 CANCEL (0x8), no cause: mapException must not unwrap to the IOException, which
+    // StandardHttpClient's retry layer would re-issue (see InputStreamReadStream#handleReadError).
     assertThat(resetCodeCaptor.getValue()).isEqualTo(0x8L);
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     <maven-core.version>3.9.16</maven-core.version>
     <maven-plugin-annotations.version>3.15.2</maven-plugin-annotations.version>
     <vertx.version>4.5.28</vertx.version>
-    <vertx5.version>5.0.12</vertx5.version>
+    <vertx5.version>5.1.1</vertx5.version>
     <jandex.version>3.5.3</jandex.version>
     <snakeyaml.version>3.0.1</snakeyaml.version>
     <snakeyaml.bundle.version>2.5</snakeyaml.bundle.version> <!-- Transitive Jackson -->


### PR DESCRIPTION
## Summary

Bumps `vertx5.version` from 5.0.12 to 5.1.1 and adapts `httpclient-vertx-5` to upstream behaviour changes. Supersedes #7869 (Dependabot's PR for the same bump, whose title was misleading — only `vertx5.version` moves; `vertx.version` stays on 4.5.x).

## Changes

- **SSL handshake fix** (`Vertx5HttpClientBuilder#createSslEngineOptions`): pass `null` instead of `new String[0]` to `JdkSslContext`. The empty array always meant "no protocols enabled" to JSSE, but was harmless before 5.1: Vert.x re-applied the option-level protocols to each engine after creation (`SslContextProvider#configureEngine`). 5.1 removed that override — protocols moved into the `SslContextFactory` SPI (`enabledProtocols(Set)`, a no-op for our lambda factory) — so the empty array now sticks and the handshake fails with `No appropriate protocol`. Fixes `Vertx5SslTest` and `Vertx5HttpClientProxyHttpsTest` against 5.1.
- **Stream-error propagation** (`InputStreamReadStream`): add a re-entry guard and switch `reset(0, cause)` → `reset(0x8)`. In 5.1, `HttpClientRequestBase#mapException` now unwraps the reset cause (and also matches `StreamResetException`, not just `HttpClosedException`), so our `IOException` would surface on the response; `StandardHttpClient`'s retry layer treats `IOException` as retryable, causing a re-issue loop until the user-facing timeout. Code `0x8` (HTTP/2 CANCEL, same as Vert.x's own `cancel()`) with no cause makes the response fail with `StreamResetException` — not retried. The reset itself remains necessary because the pipe (unchanged since 5.0) just `end()`s the request on source failure, sending a truncated-but-valid chunked body and leaving the response pending forever.
- Matching update to `InputStreamReadStreamTest`.
- CHANGELOG entry under *Dependency Upgrade*.

## Notes

This PR originally targeted 5.1.0 and was held in draft because Vert.x 5.1.0's `TcpClientConfig.setConnectTimeout(Duration)` rejected `Duration.ZERO` (eclipse-vertx/vert.x#6131), breaking `Vertx5HttpClientBuilderTest#testZeroTimeouts`. The fix landed in Vert.x 5.1.1, and `testZeroTimeouts` passes again with no local workaround — the bump now goes straight to 5.1.1.

Closes #7869