### PR TITLE
feat(informers): callback before re-list for Informers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Fix #7675: (mockwebserver) `MockWebServer.dispatcher` field marked `volatile` so a `setDispatcher(...)` call is reliably visible to the Vert.x request handler thread without further synchronization. `MockWebServer.reset()` Javadoc tightened to make its non-destructive contract explicit (no change to the running server, dispatcher, listeners, SSL/TLS state, port, or protocols)
 * Fix #7809: (kubernetes-client) Support for shard selectors for list and watch - including informers
 * Fix #7837: (kubernetes-client) Follow-ups on shard selector
+* Fix #7899: (kubernetes-client) Callback before re-list for Informers
 
 #### Dependency Upgrade
 * Fix #7849: bump istio.io/client-go from 1.29.2 to 1.30.0

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/ResourceEventHandler.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/ResourceEventHandler.java
@@ -39,10 +39,22 @@ public interface ResourceEventHandler<T> {
   }
 
   /**
+   * Called before a list operation is started, including the initial list and any subsequent re-list
+   * (for example after an HTTP GONE).
+   * <p>
+   * Should not be implemented with long-running logic as that may lead to memory issues.
+   *
+   * @param lastSyncResourceVersion the latest resource version known prior to the list operation, or
+   *        {@code null} if no list has completed yet
+   */
+  default void onBeforeList(String lastSyncResourceVersion) {
+  }
+
+  /**
    * Called after a listing is completed. By default calls {@link #onNothing()} when remainedEmpty is true.
    * <p>
    * Should not be implemented with long-running logic as that may lead to memory issues.
-   * 
+   *
    * @param resourceVersion the latest resource version known to the list operation
    * @param remainedEmpty will be true if the cache remained empty prior to and after the list operation meaning no
    *        other events would have been emitted as part of the relist

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/ResourceEventHandler.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/ResourceEventHandler.java
@@ -56,6 +56,8 @@ public interface ResourceEventHandler<T> {
    *
    * <p>
    * Should not be implemented with long-running logic as that may lead to memory issues.
+   * <p>
+   * This method is not called for re-sync.
    *
    * @param lastSyncResourceVersion the latest resource version known prior to the list operation, or
    *        {@code null} if no list has completed yet
@@ -67,6 +69,8 @@ public interface ResourceEventHandler<T> {
    * Called after a listing is completed. By default calls {@link #onNothing()} when remainedEmpty is true.
    * <p>
    * Should not be implemented with long-running logic as that may lead to memory issues.
+   * <p>
+   * This method is not called for re-sync.
    *
    * @param resourceVersion the latest resource version known to the list operation
    * @param remainedEmpty will be true if the cache remained empty prior to and after the list operation meaning no

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/ResourceEventHandler.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/ResourceEventHandler.java
@@ -40,8 +40,10 @@ public interface ResourceEventHandler<T> {
 
   /**
    * Called once per list/watch cycle, before the list operation is initiated. This fires for the
-   * initial list and for each fresh re-list (for example after an HTTP GONE), but not for retry
-   * attempts that follow a transient failure within the same cycle.
+   * initial list and for every fresh re-list — whether triggered by an HTTP GONE or by any other
+   * watch failure that goes through the reconnect path — but not for retry attempts that follow a
+   * transient failure within the same cycle (i.e. before the matching {@link #onList(String, boolean)}
+   * has been delivered).
    *
    * <p>
    * In the window between this callback and the matching {@link #onList(String, boolean)}:

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/ResourceEventHandler.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/ResourceEventHandler.java
@@ -39,8 +39,9 @@ public interface ResourceEventHandler<T> {
   }
 
   /**
-   * Called before a list operation is started, including the initial list and any subsequent re-list
-   * (for example after an HTTP GONE).
+   * Called once per list/watch cycle, before the list operation is initiated. This fires for the
+   * initial list and for each fresh re-list (for example after an HTTP GONE), but not for retry
+   * attempts that follow a transient failure within the same cycle.
    * <p>
    * Should not be implemented with long-running logic as that may lead to memory issues.
    *

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/ResourceEventHandler.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/ResourceEventHandler.java
@@ -42,6 +42,18 @@ public interface ResourceEventHandler<T> {
    * Called once per list/watch cycle, before the list operation is initiated. This fires for the
    * initial list and for each fresh re-list (for example after an HTTP GONE), but not for retry
    * attempts that follow a transient failure within the same cycle.
+   *
+   * <p>
+   * In the window between this callback and the matching {@link #onList(String, boolean)}:
+   * <ul>
+   * <li>resources already deleted on the server may still be present in the cache — deletions
+   * detected by the list are not reconciled into the cache until just before {@code onList} is
+   * called.</li>
+   * <li>the last sync resource version reported here remains frozen for the duration of the
+   * list, but {@code onAdd} / {@code onUpdate} events can still be emitted from the in-flight
+   * list pages with resource versions newer than {@code lastSyncResourceVersion}.</li>
+   * </ul>
+   *
    * <p>
    * Should not be implemented with long-running logic as that may lead to memory issues.
    *

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/ProcessorStore.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/ProcessorStore.java
@@ -120,6 +120,18 @@ public class ProcessorStore<T extends HasMetadata> {
   }
 
   /**
+   * Distributes the onBeforeList event to all registered handlers. Called prior to each list
+   * operation (initial list and re-lists), so handlers can observe the last known resource version
+   * before the cache is updated.
+   *
+   * @param lastSyncResourceVersion the latest resource version known prior to the list operation,
+   *        or {@code null} if no list has completed yet
+   */
+  public void onBeforeList(String lastSyncResourceVersion) {
+    this.processor.distribute(l -> l.getHandler().onBeforeList(lastSyncResourceVersion), false);
+  }
+
+  /**
    * Distributes the onList event to all registered handlers and returns the serial executor
    * used for event processing. Callers can use the returned executor to schedule work that
    * must run after all handler notifications have been processed.

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/Reflector.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/Reflector.java
@@ -135,6 +135,8 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
       return CompletableFuture.completedFuture(null);
     }
 
+    store.onBeforeList(lastSyncResourceVersion);
+
     CompletableFuture<Void> theFuture = null;
     if (watchList) {
       watchListState = new WatchListState();

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/Reflector.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/Reflector.java
@@ -50,6 +50,9 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
   private final ProcessorStore<T> store;
   private final ReflectorWatcher watcher;
   private volatile boolean watching;
+  // re-armed on initial start and HTTP GONE; cleared once the per-cycle onBeforeList has fired,
+  // so subsequent retries within the same list/watch cycle stay silent
+  private volatile boolean pendingBeforeListNotification = true;
   @SuppressWarnings("java:S3077") // CompletableFuture is thread-safe; volatile ensures reference visibility
   private volatile CompletableFuture<AbstractWatchManager<T>> watchFuture;
   @SuppressWarnings("java:S3077") // CompletableFuture is thread-safe; volatile ensures reference visibility
@@ -135,7 +138,10 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
       return CompletableFuture.completedFuture(null);
     }
 
-    store.onBeforeList(lastSyncResourceVersion);
+    if (pendingBeforeListNotification) {
+      pendingBeforeListNotification = false;
+      store.onBeforeList(lastSyncResourceVersion);
+    }
 
     CompletableFuture<Void> theFuture = null;
     if (watchList) {
@@ -376,6 +382,7 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
           logger.debug("Watch restarting due to http gone for {}", Reflector.this);
         }
         // start a whole new list/watch cycle
+        pendingBeforeListNotification = true;
         reconnect();
       } else {
         onException("watch", exception);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/Reflector.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/Reflector.java
@@ -50,8 +50,6 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
   private final ProcessorStore<T> store;
   private final ReflectorWatcher watcher;
   private volatile boolean watching;
-  // re-armed on initial start and HTTP GONE; cleared once the per-cycle onBeforeList has fired,
-  // so subsequent retries within the same list/watch cycle stay silent
   private volatile boolean pendingBeforeListNotification = true;
   @SuppressWarnings("java:S3077") // CompletableFuture is thread-safe; volatile ensures reference visibility
   private volatile CompletableFuture<AbstractWatchManager<T>> watchFuture;
@@ -185,6 +183,8 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
     boolean startWatchImmediately = cachedListing && lastSyncResourceVersion == null;
     lastSyncResourceVersion = latestResourceVersion;
     Executor executor = store.onList(latestResourceVersion, wasEmpty && nextKeys.isEmpty());
+    // re-arm so the next list/watch cycle (HTTP GONE or onException reconnect) fires onBeforeList
+    pendingBeforeListNotification = true;
     if (startWatchImmediately) {
       cf.complete(null);
     } else {
@@ -382,7 +382,6 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
           logger.debug("Watch restarting due to http gone for {}", Reflector.this);
         }
         // start a whole new list/watch cycle
-        pendingBeforeListNotification = true;
         reconnect();
       } else {
         onException("watch", exception);

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/impl/cache/ProcessorStoreTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/impl/cache/ProcessorStoreTest.java
@@ -17,6 +17,7 @@ package io.fabric8.kubernetes.client.informers.impl.cache;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
 import io.fabric8.kubernetes.client.informers.cache.Cache;
 import io.fabric8.kubernetes.client.informers.impl.cache.ProcessorListener.AddNotification;
 import io.fabric8.kubernetes.client.informers.impl.cache.ProcessorListener.DeleteNotification;
@@ -26,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -137,6 +139,38 @@ class ProcessorStoreTest {
     processorStore.resync();
 
     Mockito.verify(processor).distribute(Mockito.any(ProcessorListener.Notification.class), Mockito.anyBoolean());
+  }
+
+  @Test
+  void onBeforeListPropagatesLastSyncResourceVersionToHandlers() {
+    CacheImpl<Pod> podCache = new CacheImpl<>();
+    SharedProcessor<Pod> processor = new SharedProcessor<>();
+    ProcessorStore<Pod> processorStore = new ProcessorStore<>(podCache, processor);
+
+    List<String> received = new ArrayList<>();
+    processor.addProcessorListener(new ResourceEventHandler<Pod>() {
+      @Override
+      public void onBeforeList(String lastSyncResourceVersion) {
+        received.add(lastSyncResourceVersion);
+      }
+
+      @Override
+      public void onAdd(Pod obj) {
+      }
+
+      @Override
+      public void onUpdate(Pod oldObj, Pod newObj) {
+      }
+
+      @Override
+      public void onDelete(Pod obj, boolean deletedFinalStateUnknown) {
+      }
+    }, 0L, Collections::emptyList);
+
+    processorStore.onBeforeList(null);
+    processorStore.onBeforeList("42");
+
+    assertThat(received).containsExactly(null, "42");
   }
 
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/impl/cache/ReflectorTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/impl/cache/ReflectorTest.java
@@ -252,7 +252,7 @@ class ReflectorTest {
   }
 
   @Test
-  void onBeforeListInvokedWithNullOnInitialListAndLastSyncedRvOnRelist() {
+  void onBeforeListInvokedWithNullOnInitialListAndLastSyncedRvOnHttpGoneRelist() {
     ListerWatcher<Pod, PodList> mock = Mockito.mock(ListerWatcher.class);
     PodList list = new PodListBuilder().withNewMetadata().withResourceVersion("100").endMetadata().build();
     Mockito.when(mock.submitList(Mockito.any())).thenReturn(CompletableFuture.completedFuture(list));
@@ -268,9 +268,38 @@ class ReflectorTest {
     reflector.start().join();
     Mockito.verify(mockStore).onBeforeList(null);
 
-    // re-list -> last sync resource version observed during the previous list
-    reflector.listSyncAndWatch().join();
+    // HTTP GONE re-arms the cycle; reconnect runs listSyncAndWatch again with the
+    // resource version observed during the previous list
+    reflector.getWatcher().onClose(new WatcherException(null, new KubernetesClientException("gone", 410, null)));
     Mockito.verify(mockStore).onBeforeList("100");
+  }
+
+  @Test
+  void onBeforeListNotInvokedOnRetryWithinTheSameCycle() {
+    ListerWatcher<Pod, PodList> mock = Mockito.mock(ListerWatcher.class);
+    PodList list = new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().build();
+    Mockito.when(mock.submitList(Mockito.any())).thenReturn(CompletableFuture.completedFuture(list));
+
+    AbstractWatchManager manager = Mockito.mock(AbstractWatchManager.class);
+    Mockito.when(manager.isWatching()).thenReturn(true);
+    // first watch attempt fails (retry-after-failure), second succeeds
+    Mockito.when(mock.submitWatch(Mockito.any(), Mockito.any()))
+        .thenThrow(new KubernetesClientException("error"))
+        .thenReturn(CompletableFuture.completedFuture(manager));
+
+    Reflector<Pod, PodList> reflector = new Reflector<Pod, PodList>(mock, mockStore) {
+      @Override
+      protected void reconnect() {
+        // drive the retry inline so the test stays deterministic
+        listSyncAndWatch();
+      }
+    };
+    reflector.setExceptionHandler((b, t) -> true);
+
+    reflector.start().join();
+
+    // exactly one onBeforeList for the whole cycle, despite the failure + retry
+    Mockito.verify(mockStore, Mockito.times(1)).onBeforeList(Mockito.any());
   }
 
   @Test
@@ -286,7 +315,7 @@ class ReflectorTest {
 
     Reflector<Pod, PodList> reflector = new Reflector<>(mock, mockStore);
     reflector.start().join();
-    reflector.listSyncAndWatch().join();
+    reflector.getWatcher().onClose(new WatcherException(null, new KubernetesClientException("gone", 410, null)));
 
     InOrder inOrder = Mockito.inOrder(mockStore, mock);
     inOrder.verify(mockStore).onBeforeList(null);

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/impl/cache/ReflectorTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/impl/cache/ReflectorTest.java
@@ -275,8 +275,8 @@ class ReflectorTest {
     reflector.start().join();
     Mockito.verify(mockStore).onBeforeList(null);
 
-    // HTTP GONE re-arms the cycle; reconnect runs listSyncAndWatch again with the
-    // resource version observed during the previous list
+    // HTTP GONE goes through the reconnect path; the previous cycle's onList re-armed the flag,
+    // so listSyncAndWatch fires onBeforeList with the resource version observed during that list
     reflector.getWatcher().onClose(new WatcherException(null, new KubernetesClientException("gone", 410, null)));
     Mockito.verify(mockStore).onBeforeList("100");
   }
@@ -285,13 +285,17 @@ class ReflectorTest {
   void onBeforeListNotInvokedOnRetryWithinTheSameCycle() {
     ListerWatcher<Pod, PodList> mock = Mockito.mock(ListerWatcher.class);
     PodList list = new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().build();
-    Mockito.when(mock.submitList(Mockito.any())).thenReturn(CompletableFuture.completedFuture(list));
+    // first list attempt fails before onList — second one succeeds. The failure is therefore
+    // strictly within the same cycle (no onList delivered yet), so no fresh onBeforeList is due.
+    CompletableFuture<PodList> failedList = new CompletableFuture<>();
+    failedList.completeExceptionally(new KubernetesClientException("error"));
+    Mockito.when(mock.submitList(Mockito.any()))
+        .thenReturn(failedList)
+        .thenReturn(CompletableFuture.completedFuture(list));
 
     AbstractWatchManager manager = Mockito.mock(AbstractWatchManager.class);
     Mockito.when(manager.isWatching()).thenReturn(true);
-    // first watch attempt fails (retry-after-failure), second succeeds
     Mockito.when(mock.submitWatch(Mockito.any(), Mockito.any()))
-        .thenThrow(new KubernetesClientException("error"))
         .thenReturn(CompletableFuture.completedFuture(manager));
 
     Reflector<Pod, PodList> reflector = new Reflector<Pod, PodList>(mock, mockStore) {
@@ -307,6 +311,38 @@ class ReflectorTest {
 
     // exactly one onBeforeList for the whole cycle, despite the failure + retry
     Mockito.verify(mockStore, Mockito.times(1)).onBeforeList(Mockito.any());
+  }
+
+  @Test
+  void onBeforeListInvokedAgainAfterWatchFailureFollowingSuccessfulList() {
+    ListerWatcher<Pod, PodList> mock = Mockito.mock(ListerWatcher.class);
+    PodList list = new PodListBuilder().withNewMetadata().withResourceVersion("5").endMetadata().build();
+    Mockito.when(mock.submitList(Mockito.any())).thenReturn(CompletableFuture.completedFuture(list));
+
+    AbstractWatchManager manager = Mockito.mock(AbstractWatchManager.class);
+    Mockito.when(manager.isWatching()).thenReturn(true);
+    // first watch attempt fails post-onList (non-GONE — i.e. the onException reconnect path),
+    // second attempt succeeds. onList for the first cycle re-arms the next onBeforeList.
+    Mockito.when(mock.submitWatch(Mockito.any(), Mockito.any()))
+        .thenThrow(new KubernetesClientException("error"))
+        .thenReturn(CompletableFuture.completedFuture(manager));
+
+    Reflector<Pod, PodList> reflector = new Reflector<Pod, PodList>(mock, mockStore) {
+      @Override
+      protected void reconnect() {
+        listSyncAndWatch();
+      }
+    };
+    reflector.setExceptionHandler((b, t) -> true);
+
+    reflector.start().join();
+
+    InOrder inOrder = Mockito.inOrder(mockStore);
+    inOrder.verify(mockStore).onBeforeList(null);
+    inOrder.verify(mockStore).onList(Mockito.eq("5"), Mockito.anyBoolean());
+    inOrder.verify(mockStore).onBeforeList("5");
+    inOrder.verify(mockStore).onList(Mockito.eq("5"), Mockito.anyBoolean());
+    Mockito.verify(mockStore, Mockito.times(2)).onBeforeList(Mockito.any());
   }
 
   @Test

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/impl/cache/ReflectorTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/impl/cache/ReflectorTest.java
@@ -262,7 +262,14 @@ class ReflectorTest {
     Mockito.when(mock.submitWatch(Mockito.any(), Mockito.any()))
         .thenReturn(CompletableFuture.completedFuture(manager));
 
-    Reflector<Pod, PodList> reflector = new Reflector<>(mock, mockStore);
+    // override reconnect so the HTTP GONE path runs the relist synchronously instead of via the
+    // scheduled executor
+    Reflector<Pod, PodList> reflector = new Reflector<Pod, PodList>(mock, mockStore) {
+      @Override
+      protected void reconnect() {
+        listSyncAndWatch();
+      }
+    };
 
     // initial list -> no last sync resource version yet
     reflector.start().join();
@@ -313,7 +320,12 @@ class ReflectorTest {
     Mockito.when(mock.submitWatch(Mockito.any(), Mockito.any()))
         .thenReturn(CompletableFuture.completedFuture(manager));
 
-    Reflector<Pod, PodList> reflector = new Reflector<>(mock, mockStore);
+    Reflector<Pod, PodList> reflector = new Reflector<Pod, PodList>(mock, mockStore) {
+      @Override
+      protected void reconnect() {
+        listSyncAndWatch();
+      }
+    };
     reflector.start().join();
     reflector.getWatcher().onClose(new WatcherException(null, new KubernetesClientException("gone", 410, null)));
 

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/impl/cache/ReflectorTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/impl/cache/ReflectorTest.java
@@ -27,6 +27,7 @@ import io.fabric8.kubernetes.client.informers.impl.ListerWatcher;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 import org.mockito.Mockito;
 import org.mockito.exceptions.verification.TooFewActualInvocations;
 
@@ -248,6 +249,51 @@ class ReflectorTest {
     // In normal mode, the ADDED event should add to the store
     Mockito.verify(mockStore).add(laterPod);
     assertEquals("50", reflector.getLastSyncResourceVersion());
+  }
+
+  @Test
+  void onBeforeListInvokedWithNullOnInitialListAndLastSyncedRvOnRelist() {
+    ListerWatcher<Pod, PodList> mock = Mockito.mock(ListerWatcher.class);
+    PodList list = new PodListBuilder().withNewMetadata().withResourceVersion("100").endMetadata().build();
+    Mockito.when(mock.submitList(Mockito.any())).thenReturn(CompletableFuture.completedFuture(list));
+
+    AbstractWatchManager manager = Mockito.mock(AbstractWatchManager.class);
+    Mockito.when(manager.isWatching()).thenReturn(true);
+    Mockito.when(mock.submitWatch(Mockito.any(), Mockito.any()))
+        .thenReturn(CompletableFuture.completedFuture(manager));
+
+    Reflector<Pod, PodList> reflector = new Reflector<>(mock, mockStore);
+
+    // initial list -> no last sync resource version yet
+    reflector.start().join();
+    Mockito.verify(mockStore).onBeforeList(null);
+
+    // re-list -> last sync resource version observed during the previous list
+    reflector.listSyncAndWatch().join();
+    Mockito.verify(mockStore).onBeforeList("100");
+  }
+
+  @Test
+  void onBeforeListInvokedBeforeSubmitListSoHandlersSeePreviousResourceVersion() {
+    ListerWatcher<Pod, PodList> mock = Mockito.mock(ListerWatcher.class);
+    PodList list = new PodListBuilder().withNewMetadata().withResourceVersion("7").endMetadata().build();
+    Mockito.when(mock.submitList(Mockito.any())).thenReturn(CompletableFuture.completedFuture(list));
+
+    AbstractWatchManager manager = Mockito.mock(AbstractWatchManager.class);
+    Mockito.when(manager.isWatching()).thenReturn(true);
+    Mockito.when(mock.submitWatch(Mockito.any(), Mockito.any()))
+        .thenReturn(CompletableFuture.completedFuture(manager));
+
+    Reflector<Pod, PodList> reflector = new Reflector<>(mock, mockStore);
+    reflector.start().join();
+    reflector.listSyncAndWatch().join();
+
+    InOrder inOrder = Mockito.inOrder(mockStore, mock);
+    inOrder.verify(mockStore).onBeforeList(null);
+    inOrder.verify(mock).submitList(Mockito.any());
+    inOrder.verify(mockStore).onList(Mockito.eq("7"), Mockito.anyBoolean());
+    inOrder.verify(mockStore).onBeforeList("7");
+    inOrder.verify(mock).submitList(Mockito.any());
   }
 
   @Test


### PR DESCRIPTION


## Description

Introducing a callback before re-list happens in Informers. Note that we have already a callback when a list is finished:

```java
   
  // before list happening
  default void onBeforeList(String lastSyncResourceVersion) {
  
  }

  // after list finished
  default void onList(String resourceVersion, boolean remainedEmpty) {
    // ...
  }

```

This is both for the WatchList and former pure list approach.

The rational behind this that, if a list happens in informers there might be events lost. So let's say we have a resource  in already in the caches in the informer, if we start to do a re-list because watch connection broke (and cannot continue continue watch from the last resource version). If we just make multiple updates on our resource before re-list while watch is down, after re-list we will see only the final state of the resource.

In Java Operator SDK we are currently doing improvements regarding read-after-write-consistency; there this would help to cover some corner cases.

See: https://github.com/operator-framework/java-operator-sdk/issues/3398

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->

Signed-off-by: Attila Mészáros <a_meszaros@apple.com>