### PR TITLE
feat: add JPMS module descriptors to all published artifacts (#1996)

### DIFF
--- a/extensions/certmanager/client/pom.xml
+++ b/extensions/certmanager/client/pom.xml
@@ -68,4 +68,29 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.certmanager.client {
+                exports io.fabric8.certmanager.client;
+                exports io.fabric8.certmanager.client.dsl;
+
+                requires transitive io.fabric8.certmanager.model;
+                requires transitive io.fabric8.kubernetes.client;
+                requires transitive io.fabric8.kubernetes.client.api;
+                requires static builder.annotations;
+                provides io.fabric8.kubernetes.client.extension.ExtensionAdapter with
+                    io.fabric8.certmanager.client.CertManagerExtensionAdapter;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/extensions/certmanager/model/pom.xml
+++ b/extensions/certmanager/model/pom.xml
@@ -60,6 +60,33 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.certmanager.model {
+                exports io.fabric8.certmanager.api.model.acme.v1;
+                exports io.fabric8.certmanager.api.model.meta.v1;
+                exports io.fabric8.certmanager.api.model.v1;
+
+                requires transitive io.fabric8.kubernetes.model.apiextensions;
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive io.fabric8.kubernetes.model.gatewayapi;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/extensions/chaosmesh/client/pom.xml
+++ b/extensions/chaosmesh/client/pom.xml
@@ -72,6 +72,26 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.chaosmesh.client {
+                exports io.fabric8.chaosmesh.client;
+
+                requires transitive io.fabric8.chaosmesh.model;
+                requires transitive io.fabric8.kubernetes.client;
+                requires transitive io.fabric8.kubernetes.client.api;
+                requires static builder.annotations;
+                provides io.fabric8.kubernetes.client.extension.ExtensionAdapter with
+                    io.fabric8.chaosmesh.client.ChaosMeshExtensionAdapter;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>io.sundr</groupId>
         <artifactId>sundr-maven-plugin</artifactId>
         <version>${sundrio.version}</version>

--- a/extensions/chaosmesh/model/pom.xml
+++ b/extensions/chaosmesh/model/pom.xml
@@ -52,6 +52,29 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.chaosmesh.model {
+                exports io.fabric8.chaosmesh.v1alpha1;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/extensions/istio/client/pom.xml
+++ b/extensions/istio/client/pom.xml
@@ -67,4 +67,28 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.istio.client {
+                exports io.fabric8.istio.client;
+
+                requires transitive io.fabric8.istio.model;
+                requires transitive io.fabric8.kubernetes.client;
+                requires transitive io.fabric8.kubernetes.client.api;
+                requires static builder.annotations;
+                provides io.fabric8.kubernetes.client.extension.ExtensionAdapter with
+                    io.fabric8.istio.client.IstioExtensionAdapter;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/extensions/istio/model/pom.xml
+++ b/extensions/istio/model/pom.xml
@@ -73,6 +73,45 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.istio.model {
+                exports io.fabric8.istio.api.api.analysis.v1alpha1;
+                exports io.fabric8.istio.api.api.extensions.v1alpha1;
+                exports io.fabric8.istio.api.api.meta.v1alpha1;
+                exports io.fabric8.istio.api.api.networking.v1alpha3;
+                exports io.fabric8.istio.api.api.networking.v1beta1;
+                exports io.fabric8.istio.api.api.security.v1alpha1;
+                exports io.fabric8.istio.api.api.security.v1beta1;
+                exports io.fabric8.istio.api.api.telemetry.v1alpha1;
+                exports io.fabric8.istio.api.api.type.v1beta1;
+                exports io.fabric8.istio.api.extensions.v1alpha1;
+                exports io.fabric8.istio.api.networking.v1;
+                exports io.fabric8.istio.api.networking.v1alpha3;
+                exports io.fabric8.istio.api.networking.v1beta1;
+                exports io.fabric8.istio.api.security.v1;
+                exports io.fabric8.istio.api.security.v1beta1;
+                exports io.fabric8.istio.api.telemetry.v1;
+                exports io.fabric8.istio.api.telemetry.v1alpha1;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/extensions/knative/client/pom.xml
+++ b/extensions/knative/client/pom.xml
@@ -67,4 +67,29 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.knative.client {
+                exports io.fabric8.knative.client;
+                exports io.fabric8.knative.client.serving.v1;
+
+                requires transitive io.fabric8.knative.model;
+                requires transitive io.fabric8.kubernetes.client;
+                requires transitive io.fabric8.kubernetes.client.api;
+                requires static builder.annotations;
+                provides io.fabric8.kubernetes.client.extension.ExtensionAdapter with
+                    io.fabric8.knative.client.KnativeExtensionAdapter;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/extensions/knative/model/pom.xml
+++ b/extensions/knative/model/pom.xml
@@ -56,6 +56,58 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.knative.model {
+                exports io.fabric8.knative.bindings.v1;
+                exports io.fabric8.knative.bindings.v1alpha1;
+                exports io.fabric8.knative.bindings.v1beta1;
+                exports io.fabric8.knative.duck.v1;
+                exports io.fabric8.knative.duck.v1alpha1;
+                exports io.fabric8.knative.duck.v1beta1;
+                exports io.fabric8.knative.eventing.pkg.apis.common.integration.v1alpha1;
+                exports io.fabric8.knative.eventing.v1;
+                exports io.fabric8.knative.eventing.v1alpha1;
+                exports io.fabric8.knative.eventing.v1beta1;
+                exports io.fabric8.knative.eventing.v1beta2;
+                exports io.fabric8.knative.eventing.v1beta3;
+                exports io.fabric8.knative.flows.v1;
+                exports io.fabric8.knative.internal.autoscaling.v1alpha1;
+                exports io.fabric8.knative.internal.caching.v1alpha1;
+                exports io.fabric8.knative.internal.networking.v1alpha1;
+                exports io.fabric8.knative.messaging.v1;
+                exports io.fabric8.knative.messaging.v1beta1;
+                exports io.fabric8.knative.pkg.apis;
+                exports io.fabric8.knative.pkg.tracker;
+                exports io.fabric8.knative.serving.v1;
+                exports io.fabric8.knative.serving.v1alpha1;
+                exports io.fabric8.knative.serving.v1beta1;
+                exports io.fabric8.knative.sinks.v1alpha1;
+                exports io.fabric8.knative.sources.v1;
+                exports io.fabric8.knative.sources.v1alpha1;
+                exports io.fabric8.knative.sources.v1beta1;
+                exports io.fabric8.knative.sources.v1beta2;
+
+                requires transitive io.fabric8.kubernetes.model.apps;
+                requires transitive io.fabric8.kubernetes.model.batch;
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/extensions/open-cluster-management/client/pom.xml
+++ b/extensions/open-cluster-management/client/pom.xml
@@ -69,4 +69,29 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.open.cluster.management.client {
+                exports io.fabric8.openclustermanagement.client;
+                exports io.fabric8.openclustermanagement.client.dsl;
+
+                requires transitive io.fabric8.kubernetes.client;
+                requires transitive io.fabric8.kubernetes.client.api;
+                requires transitive io.fabric8.open.cluster.management.model;
+                requires static builder.annotations;
+                provides io.fabric8.kubernetes.client.extension.ExtensionAdapter with
+                    io.fabric8.openclustermanagement.client.OpenClusterManagementExtensionAdapter;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/extensions/open-cluster-management/model/pom.xml
+++ b/extensions/open-cluster-management/model/pom.xml
@@ -52,6 +52,43 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.open.cluster.management.model {
+                exports io.fabric8.openclustermanagement.api.model.agent.v1;
+                exports io.fabric8.openclustermanagement.api.model.apps.v1;
+                exports io.fabric8.openclustermanagement.api.model.cluster.v1;
+                exports io.fabric8.openclustermanagement.api.model.cluster.v1alpha1;
+                exports io.fabric8.openclustermanagement.api.model.cluster.v1beta1;
+                exports io.fabric8.openclustermanagement.api.model.cluster.v1beta2;
+                exports io.fabric8.openclustermanagement.api.model.discovery.v1;
+                exports io.fabric8.openclustermanagement.api.model.discovery.v1alpha1;
+                exports io.fabric8.openclustermanagement.api.model.observability.v1beta1;
+                exports io.fabric8.openclustermanagement.api.model.observability.v1beta2;
+                exports io.fabric8.openclustermanagement.api.model.operator.v1;
+                exports io.fabric8.openclustermanagement.api.model.policy.v1;
+                exports io.fabric8.openclustermanagement.api.model.policy.v1beta1;
+                exports io.fabric8.openclustermanagement.api.model.search.v1alpha1;
+                exports io.fabric8.openclustermanagement.api.model.shared;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/extensions/open-virtual-network/client/pom.xml
+++ b/extensions/open-virtual-network/client/pom.xml
@@ -102,4 +102,29 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.ovn.client {
+                exports io.fabric8.ovn.client;
+                exports io.fabric8.ovn.client.dsl;
+
+                requires transitive io.fabric8.kubernetes.client;
+                requires transitive io.fabric8.kubernetes.client.api;
+                requires transitive io.fabric8.ovn.model;
+                requires static builder.annotations;
+                provides io.fabric8.kubernetes.client.extension.ExtensionAdapter with
+                    io.fabric8.ovn.client.OpenVirtualNetworkingExtensionAdapter;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/extensions/open-virtual-network/model/pom.xml
+++ b/extensions/open-virtual-network/model/pom.xml
@@ -48,6 +48,29 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.ovn.model {
+                exports io.fabric8.kubernetes.api.model.ovn.v1;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/extensions/tekton/client/pom.xml
+++ b/extensions/tekton/client/pom.xml
@@ -66,4 +66,29 @@
       <scope>runtime</scope>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.tekton.client {
+                exports io.fabric8.tekton.client;
+                exports io.fabric8.tekton.client.dsl;
+
+                requires transitive io.fabric8.kubernetes.client;
+                requires transitive io.fabric8.kubernetes.client.api;
+                requires transitive io.fabric8.tekton.model;
+                requires static builder.annotations;
+                provides io.fabric8.kubernetes.client.extension.ExtensionAdapter with
+                    io.fabric8.tekton.client.TektonExtensionAdapter;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/extensions/tekton/model/pom.xml
+++ b/extensions/tekton/model/pom.xml
@@ -52,6 +52,39 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.tekton.model {
+                exports io.fabric8.tekton.pipeline.pkg.apis.config;
+                exports io.fabric8.tekton.pipeline.pkg.result;
+                exports io.fabric8.tekton.pod;
+                exports io.fabric8.tekton.resolution.v1alpha1;
+                exports io.fabric8.tekton.resolution.v1beta1;
+                exports io.fabric8.tekton.triggers.v1alpha1;
+                exports io.fabric8.tekton.triggers.v1beta1;
+                exports io.fabric8.tekton.v1;
+                exports io.fabric8.tekton.v1alpha1;
+                exports io.fabric8.tekton.v1beta1;
+
+                requires transitive io.fabric8.knative.model;
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/extensions/verticalpodautoscaler/client/pom.xml
+++ b/extensions/verticalpodautoscaler/client/pom.xml
@@ -67,4 +67,29 @@
       <scope>runtime</scope>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.verticalpodautoscaler.client {
+                exports io.fabric8.verticalpodautoscaler.client;
+                exports io.fabric8.verticalpodautoscaler.client.dsl;
+
+                requires transitive io.fabric8.kubernetes.client;
+                requires transitive io.fabric8.kubernetes.client.api;
+                requires transitive io.fabric8.verticalpodautoscaler.model;
+                requires static builder.annotations;
+                provides io.fabric8.kubernetes.client.extension.ExtensionAdapter with
+                    io.fabric8.verticalpodautoscaler.client.VerticalPodAutoscalerExtensionAdapter;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/extensions/verticalpodautoscaler/model/pom.xml
+++ b/extensions/verticalpodautoscaler/model/pom.xml
@@ -52,6 +52,32 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.verticalpodautoscaler.model {
+                exports io.fabric8.autoscaling.api.model.v1;
+                exports io.fabric8.autoscaling.api.model.v1beta1;
+                exports io.fabric8.autoscaling.api.model.v1beta2;
+
+                requires transitive io.fabric8.kubernetes.model.autoscaling;
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/extensions/volcano/client/pom.xml
+++ b/extensions/volcano/client/pom.xml
@@ -67,4 +67,29 @@
       <scope>runtime</scope>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.volcano.client {
+                exports io.fabric8.volcano.client;
+                exports io.fabric8.volcano.client.dsl;
+
+                requires transitive io.fabric8.kubernetes.client;
+                requires transitive io.fabric8.kubernetes.client.api;
+                requires transitive io.fabric8.volcano.model;
+                requires static builder.annotations;
+                provides io.fabric8.kubernetes.client.extension.ExtensionAdapter with
+                    io.fabric8.volcano.client.VolcanoExtensionAdapter;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/extensions/volcano/model/pom.xml
+++ b/extensions/volcano/model/pom.xml
@@ -48,6 +48,33 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.volcano.model {
+                exports io.fabric8.volcano.api.model.batch.v1alpha1;
+                exports io.fabric8.volcano.api.model.bus.v1alpha1;
+                exports io.fabric8.volcano.api.model.flow.v1alpha1;
+                exports io.fabric8.volcano.api.model.nodeinfo.v1alpha1;
+                exports io.fabric8.volcano.api.model.scheduling.v1beta1;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/extensions/volumesnapshot/client/pom.xml
+++ b/extensions/volumesnapshot/client/pom.xml
@@ -72,6 +72,27 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.volumesnapshot.client {
+                exports io.fabric8.volumesnapshot.client;
+                exports io.fabric8.volumesnapshot.client.internal;
+
+                requires transitive io.fabric8.kubernetes.client;
+                requires transitive io.fabric8.kubernetes.client.api;
+                requires transitive io.fabric8.volumesnapshot.model;
+                requires static builder.annotations;
+                provides io.fabric8.kubernetes.client.extension.ExtensionAdapter with
+                    io.fabric8.volumesnapshot.client.VolumeSnapshotExtensionAdapter;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>io.sundr</groupId>
         <artifactId>sundr-maven-plugin</artifactId>
         <version>${sundrio.version}</version>

--- a/extensions/volumesnapshot/model/pom.xml
+++ b/extensions/volumesnapshot/model/pom.xml
@@ -48,6 +48,29 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.volumesnapshot.model {
+                exports io.fabric8.volumesnapshot.api.model;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/httpclient-jdk/pom.xml
+++ b/httpclient-jdk/pom.xml
@@ -29,7 +29,6 @@
   <name>Fabric8 :: Kubernetes :: HttpClient :: JDK</name>
 
   <properties>
-    <jpms.module.name>io.fabric8.kubernetes.client.jdkhttp</jpms.module.name>
     <osgi.require-capability>
       osgi.extender;
       filter:="(osgi.extender=osgi.serviceloader.registrar)",
@@ -89,6 +88,25 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              module io.fabric8.kubernetes.client.jdkhttp {
+                exports io.fabric8.kubernetes.client.jdkhttp;
+
+                requires transitive io.fabric8.kubernetes.client.api;
+                requires java.net.http;
+
+                provides io.fabric8.kubernetes.client.http.HttpClient.Factory with
+                    io.fabric8.kubernetes.client.jdkhttp.JdkHttpClientFactory;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/httpclient-jetty/pom.xml
+++ b/httpclient-jetty/pom.xml
@@ -29,7 +29,6 @@
   <name>Fabric8 :: Kubernetes :: HttpClient :: Jetty</name>
 
   <properties>
-    <jpms.module.name>io.fabric8.kubernetes.client.jetty</jpms.module.name>
     <osgi.require-capability>
       osgi.extender;
       filter:="(osgi.extender=osgi.serviceloader.registrar)",
@@ -103,6 +102,27 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              module io.fabric8.kubernetes.client.jetty {
+                exports io.fabric8.kubernetes.client.jetty;
+
+                requires transitive io.fabric8.kubernetes.client.api;
+                requires org.eclipse.jetty.client;
+                requires org.eclipse.jetty.http2.http.client.transport;
+                requires org.eclipse.jetty.websocket.jetty.client;
+
+                provides io.fabric8.kubernetes.client.http.HttpClient.Factory with
+                    io.fabric8.kubernetes.client.jetty.JettyHttpClientFactory;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/httpclient-okhttp/pom.xml
+++ b/httpclient-okhttp/pom.xml
@@ -29,7 +29,6 @@
   <name>Fabric8 :: Kubernetes :: HttpClient :: OkHttp</name>
 
   <properties>
-    <jpms.module.name>io.fabric8.kubernetes.client.okhttp</jpms.module.name>
     <osgi.require-capability>
       osgi.extender;
       filter:="(osgi.extender=osgi.serviceloader.registrar)",
@@ -106,6 +105,26 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              module io.fabric8.kubernetes.client.okhttp {
+                exports io.fabric8.kubernetes.client.okhttp;
+
+                requires transitive io.fabric8.kubernetes.client.api;
+                requires okhttp3;
+                requires okhttp3.logging;
+
+                provides io.fabric8.kubernetes.client.http.HttpClient.Factory with
+                    io.fabric8.kubernetes.client.okhttp.OkHttpClientFactory;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/httpclient-vertx-5/pom.xml
+++ b/httpclient-vertx-5/pom.xml
@@ -29,7 +29,6 @@
   <name>Fabric8 :: Kubernetes :: HttpClient :: Vert.x 5</name>
 
   <properties>
-    <jpms.module.name>io.fabric8.kubernetes.client.vertx5</jpms.module.name>
     <vertx.version>${vertx5.version}</vertx.version>
     <osgi.require-capability>
       osgi.extender;
@@ -163,6 +162,31 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              module io.fabric8.kubernetes.client.vertx5 {
+                exports io.fabric8.kubernetes.client.vertx5;
+
+                requires transitive io.fabric8.kubernetes.client.api;
+                requires io.vertx.core;
+                requires io.vertx.web.client;
+                requires io.vertx.web.common;
+                requires io.vertx.auth.common;
+                requires io.vertx.web;
+                requires io.vertx.eventbusbridge;
+                requires io.vertx.uritemplate;
+
+                provides io.fabric8.kubernetes.client.http.HttpClient.Factory with
+                    io.fabric8.kubernetes.client.vertx5.Vertx5HttpClientFactory;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/httpclient-vertx/pom.xml
+++ b/httpclient-vertx/pom.xml
@@ -29,7 +29,6 @@
   <name>Fabric8 :: Kubernetes :: HttpClient :: Vert.x</name>
 
   <properties>
-    <jpms.module.name>io.fabric8.kubernetes.client.vertx</jpms.module.name>
     <osgi.require-capability>
       osgi.extender;
       filter:="(osgi.extender=osgi.serviceloader.registrar)",
@@ -108,6 +107,26 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              module io.fabric8.kubernetes.client.vertx {
+                exports io.fabric8.kubernetes.client.vertx;
+
+                requires transitive io.fabric8.kubernetes.client.api;
+                requires io.vertx.core;
+                requires io.vertx.web.client;
+
+                provides io.fabric8.kubernetes.client.http.HttpClient.Factory with
+                    io.fabric8.kubernetes.client.vertx.VertxHttpClientFactory;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/junit/kube-api-test/client-inject/pom.xml
+++ b/junit/kube-api-test/client-inject/pom.xml
@@ -73,6 +73,28 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <configuration>
+                    <module>
+                        <moduleInfoSource>
+                            open module io.fabric8.kube.api.test.client.inject {
+                              exports io.fabric8.kubeapitest.junit.inject;
+
+                              requires transitive io.fabric8.kube.api.test;
+                              requires io.fabric8.kubernetes.client;
+                              requires org.junit.jupiter.api;
+                              requires org.junit.jupiter.engine;
+                              requires org.slf4j;
+
+                              provides io.fabric8.kubeapitest.junit.ClientInjectionHandler with
+                                  io.fabric8.kubeapitest.junit.inject.Fabric8ClientInjectionHandler;
+                            }
+                        </moduleInfoSource>
+                    </module>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>

--- a/junit/kube-api-test/client-inject/src/main/java/io/fabric8/kubeapitest/junit/inject/Fabric8ClientInjectionHandler.java
+++ b/junit/kube-api-test/client-inject/src/main/java/io/fabric8/kubeapitest/junit/inject/Fabric8ClientInjectionHandler.java
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.kubeapitest.junit;
+package io.fabric8.kubeapitest.junit.inject;
 
 import io.fabric8.kubeapitest.KubeAPIServer;
 import io.fabric8.kubeapitest.KubeAPITestException;
+import io.fabric8.kubeapitest.junit.ClientInjectionHandler;
+import io.fabric8.kubeapitest.junit.KubeConfigInjectionHandler;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;

--- a/junit/kube-api-test/client-inject/src/main/resources/META-INF/services/io.fabric8.kubeapitest.junit.ClientInjectionHandler
+++ b/junit/kube-api-test/client-inject/src/main/resources/META-INF/services/io.fabric8.kubeapitest.junit.ClientInjectionHandler
@@ -1,1 +1,1 @@
-io.fabric8.kubeapitest.junit.Fabric8ClientInjectionHandler
+io.fabric8.kubeapitest.junit.inject.Fabric8ClientInjectionHandler

--- a/junit/kube-api-test/core/pom.xml
+++ b/junit/kube-api-test/core/pom.xml
@@ -116,6 +116,36 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <configuration>
+                    <module>
+                        <moduleInfoSource>
+                            open module io.fabric8.kube.api.test {
+                              exports io.fabric8.kubeapitest;
+                              exports io.fabric8.kubeapitest.binary;
+                              exports io.fabric8.kubeapitest.binary.repo;
+                              exports io.fabric8.kubeapitest.cert;
+                              exports io.fabric8.kubeapitest.junit;
+                              exports io.fabric8.kubeapitest.kubeconfig;
+                              exports io.fabric8.kubeapitest.process;
+
+                              requires org.apache.commons.compress;
+                              requires com.fasterxml.jackson.databind;
+                              requires com.fasterxml.jackson.dataformat.yaml;
+                              requires org.junit.jupiter.api;
+                              requires org.junit.jupiter.engine;
+                              requires org.slf4j;
+                              requires org.bouncycastle.pkix;
+                              requires org.bouncycastle.provider;
+
+                              uses io.fabric8.kubeapitest.junit.ClientInjectionHandler;
+                            }
+                        </moduleInfoSource>
+                    </module>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>

--- a/junit/kubernetes-junit-jupiter/pom.xml
+++ b/junit/kubernetes-junit-jupiter/pom.xml
@@ -51,4 +51,27 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.kubernetes.junit.jupiter {
+                exports io.fabric8.junit.jupiter;
+                exports io.fabric8.junit.jupiter.api;
+
+                requires transitive io.fabric8.kubernetes.client;
+                requires org.apache.commons.compress;
+                requires org.junit.jupiter.api;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/junit/kubernetes-server-mock/pom.xml
+++ b/junit/kubernetes-server-mock/pom.xml
@@ -75,4 +75,27 @@
     </dependency>
 
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.kubernetes.server.mock {
+                exports io.fabric8.kubernetes.client.server.mock;
+                exports io.fabric8.kubernetes.client.server.mock.crud;
+
+                requires transitive io.fabric8.mockwebserver;
+                requires static io.fabric8.kubernetes.client;
+                requires org.junit.jupiter.api;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/junit/mockwebserver/pom.xml
+++ b/junit/mockwebserver/pom.xml
@@ -75,6 +75,31 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.mockwebserver {
+                exports io.fabric8.mockwebserver;
+                exports io.fabric8.mockwebserver.crud;
+                exports io.fabric8.mockwebserver.dsl;
+                exports io.fabric8.mockwebserver.http;
+                exports io.fabric8.mockwebserver.internal;
+                exports io.fabric8.mockwebserver.utils;
+                exports io.fabric8.mockwebserver.vertx;
+
+                requires transitive com.fasterxml.jackson.databind;
+                requires io.vertx.web;
+                requires io.fabric8.zjsonpatch;
+                requires org.bouncycastle.pkix;
+                requires org.bouncycastle.provider;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.gmavenplus</groupId>
         <artifactId>gmavenplus-plugin</artifactId>
         <version>${gmavenplus-plugin.version}</version>

--- a/kubernetes-client-api/pom.xml
+++ b/kubernetes-client-api/pom.xml
@@ -223,6 +223,66 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.kubernetes.client.api {
+                exports io.fabric8.kubernetes.client;
+                exports io.fabric8.kubernetes.client.dsl;
+                exports io.fabric8.kubernetes.client.dsl.base;
+                exports io.fabric8.kubernetes.client.extended.leaderelection;
+                exports io.fabric8.kubernetes.client.extended.leaderelection.resourcelock;
+                exports io.fabric8.kubernetes.client.extended.run;
+                exports io.fabric8.kubernetes.client.extension;
+                exports io.fabric8.kubernetes.client.http;
+                exports io.fabric8.kubernetes.client.informers;
+                exports io.fabric8.kubernetes.client.informers.cache;
+                exports io.fabric8.kubernetes.client.internal;
+                exports io.fabric8.kubernetes.client.lib;
+                exports io.fabric8.kubernetes.client.readiness;
+                exports io.fabric8.kubernetes.client.utils;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive io.fabric8.kubernetes.model.admissionregistration;
+                requires transitive io.fabric8.kubernetes.model.apiextensions;
+                requires transitive io.fabric8.kubernetes.model.apps;
+                requires transitive io.fabric8.kubernetes.model.autoscaling;
+                requires transitive io.fabric8.kubernetes.model.batch;
+                requires transitive io.fabric8.kubernetes.model.certificates;
+                requires transitive io.fabric8.kubernetes.model.coordination;
+                requires transitive io.fabric8.kubernetes.model.discovery;
+                requires transitive io.fabric8.kubernetes.model.events;
+                requires transitive io.fabric8.kubernetes.model.extensions;
+                requires transitive io.fabric8.kubernetes.model.flowcontrol;
+                requires transitive io.fabric8.kubernetes.model.gatewayapi;
+                requires transitive io.fabric8.kubernetes.model.metrics;
+                requires transitive io.fabric8.kubernetes.model.networking;
+                requires transitive io.fabric8.kubernetes.model.node;
+                requires transitive io.fabric8.kubernetes.model.policy;
+                requires transitive io.fabric8.kubernetes.model.rbac;
+                requires transitive io.fabric8.kubernetes.model.resource;
+                requires transitive io.fabric8.kubernetes.model.scheduling;
+                requires transitive io.fabric8.kubernetes.model.storageclass;
+
+                requires transitive com.fasterxml.jackson.annotation;
+                requires transitive com.fasterxml.jackson.databind;
+                requires com.fasterxml.jackson.core;
+                requires com.fasterxml.jackson.dataformat.yaml;
+                requires com.fasterxml.jackson.datatype.jsr310;
+                requires org.snakeyaml.engine;
+                requires org.slf4j;
+                requires static builder.annotations;
+                requires static org.osgi.service.component.annotations;
+
+                uses io.fabric8.kubernetes.client.http.HttpClient.Factory;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>

--- a/kubernetes-client-deps-compatibility-tests/kubernetes-client-httpclient-jpms/src/test/java/io/fabric8/deps/compatibility/tests/HttpClientModuleDescriptorTest.java
+++ b/kubernetes-client-deps-compatibility-tests/kubernetes-client-httpclient-jpms/src/test/java/io/fabric8/deps/compatibility/tests/HttpClientModuleDescriptorTest.java
@@ -16,6 +16,7 @@
 package io.fabric8.deps.compatibility.tests;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -27,13 +28,11 @@ import java.nio.file.Paths;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.jar.JarFile;
-import java.util.jar.Manifest;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class HttpClientAutomaticModuleNameTest {
+class HttpClientModuleDescriptorTest {
 
   private static final Map<String, String> EXPECTED_MODULE_NAMES = new LinkedHashMap<>();
 
@@ -58,35 +57,7 @@ class HttpClientAutomaticModuleNameTest {
   }
 
   @Test
-  void httpClientModulesHaveCorrectAutomaticModuleName() throws IOException {
-    try (Stream<Path> jarFiles = Files.list(jarsDir)) {
-      Map<String, String> actualModuleNames = new LinkedHashMap<>();
-      jarFiles.filter(p -> p.toString().endsWith(".jar")).forEach(jarPath -> {
-        String fileName = jarPath.getFileName().toString();
-        Map.Entry<String, String> match = findMatchingArtifact(fileName);
-        if (match != null) {
-          try (JarFile jarFile = new JarFile(jarPath.toFile())) {
-            Manifest manifest = jarFile.getManifest();
-            assertThat(manifest)
-                .as("Manifest for %s", fileName)
-                .isNotNull();
-            String actualModuleName = manifest.getMainAttributes().getValue("Automatic-Module-Name");
-            assertThat(actualModuleName)
-                .as("Automatic-Module-Name in %s", fileName)
-                .isEqualTo(match.getValue());
-            actualModuleNames.put(match.getKey(), actualModuleName);
-          } catch (IOException e) {
-            throw new RuntimeException("Failed to read JAR: " + jarPath, e);
-          }
-        }
-      });
-      assertThat(actualModuleNames)
-          .as("All httpclient modules should have been verified")
-          .hasSize(EXPECTED_MODULE_NAMES.size());
-    }
-  }
-
-  @Test
+  @DisplayName("each httpclient jar carries a JPMS module descriptor with the expected, non-colliding module name")
   void httpClientModulesHaveValidJpmsModuleNames() throws IOException {
     try (Stream<Path> jarFiles = Files.list(jarsDir)) {
       Map<String, String> resolvedModuleNames = new LinkedHashMap<>();

--- a/kubernetes-client/pom.xml
+++ b/kubernetes-client/pom.xml
@@ -140,6 +140,51 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.kubernetes.client {
+                exports io.fabric8.kubernetes.client.dsl.internal;
+                exports io.fabric8.kubernetes.client.dsl.internal.apps.v1;
+                exports io.fabric8.kubernetes.client.dsl.internal.batch.v1;
+                exports io.fabric8.kubernetes.client.dsl.internal.certificates.v1;
+                exports io.fabric8.kubernetes.client.dsl.internal.certificates.v1beta1;
+                exports io.fabric8.kubernetes.client.dsl.internal.core.v1;
+                exports io.fabric8.kubernetes.client.dsl.internal.extensions.v1beta1;
+                exports io.fabric8.kubernetes.client.dsl.internal.uploadable;
+                exports io.fabric8.kubernetes.client.impl;
+                exports io.fabric8.kubernetes.client.informers.impl;
+                exports io.fabric8.kubernetes.client.informers.impl.cache;
+                exports io.fabric8.kubernetes.client.osgi;
+                exports io.fabric8.kubernetes.client.utils.internal;
+
+                requires transitive io.fabric8.kubernetes.client.api;
+                requires io.fabric8.zjsonpatch;
+                requires org.apache.commons.compress;
+                requires com.fasterxml.jackson.databind;
+                requires com.fasterxml.jackson.core;
+                requires com.fasterxml.jackson.dataformat.yaml;
+                requires com.fasterxml.jackson.datatype.jsr310;
+                requires org.snakeyaml.engine;
+                requires org.slf4j;
+                requires static builder.annotations;
+                requires static org.osgi.service.component.annotations;
+
+                uses io.fabric8.kubernetes.client.extension.ExtensionAdapter;
+                uses io.fabric8.kubernetes.client.ServiceToURLProvider;
+                provides io.fabric8.kubernetes.client.ServiceToURLProvider with
+                    io.fabric8.kubernetes.client.impl.URLFromEnvVarsImpl,
+                    io.fabric8.kubernetes.client.impl.URLFromIngressImpl,
+                    io.fabric8.kubernetes.client.impl.URLFromNodePortImpl,
+                    io.fabric8.kubernetes.client.impl.URLFromClusterIPImpl;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>

--- a/kubernetes-model-generator/kubernetes-model-admissionregistration/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-admissionregistration/pom.xml
@@ -48,6 +48,37 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.kubernetes.model.admissionregistration {
+                exports io.fabric8.kubernetes.api.model.admission.v1;
+                exports io.fabric8.kubernetes.api.model.admission.v1beta1;
+                exports io.fabric8.kubernetes.api.model.admissionregistration.v1;
+                exports io.fabric8.kubernetes.api.model.admissionregistration.v1alpha1;
+                exports io.fabric8.kubernetes.api.model.admissionregistration.v1beta1;
+                exports io.fabric8.kubernetes.api.model.authentication;
+                exports io.fabric8.kubernetes.api.model.authentication.v1beta1;
+                exports io.fabric8.kubernetes.api.model.authorization.v1;
+                exports io.fabric8.kubernetes.api.model.authorization.v1beta1;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/kubernetes-model-apiextensions/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-apiextensions/pom.xml
@@ -43,6 +43,30 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.kubernetes.model.apiextensions {
+                exports io.fabric8.kubernetes.api.model.apiextensions.v1;
+                exports io.fabric8.kubernetes.api.model.apiextensions.v1beta1;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/kubernetes-model-apps/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-apps/pom.xml
@@ -43,6 +43,29 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.kubernetes.model.apps {
+                exports io.fabric8.kubernetes.api.model.apps;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/pom.xml
@@ -43,6 +43,32 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.kubernetes.model.autoscaling {
+                exports io.fabric8.kubernetes.api.model.autoscaling.v1;
+                exports io.fabric8.kubernetes.api.model.autoscaling.v2;
+                exports io.fabric8.kubernetes.api.model.autoscaling.v2beta1;
+                exports io.fabric8.kubernetes.api.model.autoscaling.v2beta2;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/kubernetes-model-batch/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-batch/pom.xml
@@ -43,6 +43,30 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.kubernetes.model.batch {
+                exports io.fabric8.kubernetes.api.model.batch.v1;
+                exports io.fabric8.kubernetes.api.model.batch.v1beta1;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/kubernetes-model-certificates/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-certificates/pom.xml
@@ -43,6 +43,31 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.kubernetes.model.certificates {
+                exports io.fabric8.kubernetes.api.model.certificates.v1;
+                exports io.fabric8.kubernetes.api.model.certificates.v1alpha1;
+                exports io.fabric8.kubernetes.api.model.certificates.v1beta1;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/kubernetes-model-common/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-common/pom.xml
@@ -93,6 +93,29 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.kubernetes.model.common {
+                exports io.fabric8.kubernetes.api.builder;
+                exports io.fabric8.kubernetes.model;
+                exports io.fabric8.kubernetes.model.annotation;
+                exports io.fabric8.kubernetes.model.jackson;
+                exports io.fabric8.kubernetes.model.util;
+
+                requires transitive com.fasterxml.jackson.annotation;
+                requires transitive com.fasterxml.jackson.databind;
+                requires com.fasterxml.jackson.core;
+                requires org.slf4j;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/kubernetes-model-generator/kubernetes-model-coordination/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-coordination/pom.xml
@@ -48,6 +48,32 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.kubernetes.model.coordination {
+                exports io.fabric8.kubernetes.api.model.coordination.v1;
+                exports io.fabric8.kubernetes.api.model.coordination.v1alpha2;
+                exports io.fabric8.kubernetes.api.model.coordination.v1beta1;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires com.fasterxml.jackson.datatype.jsr310;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/kubernetes-model-core/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-core/pom.xml
@@ -125,6 +125,34 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.kubernetes.model.core {
+                exports io.fabric8.kubernetes.api;
+                exports io.fabric8.kubernetes.api.model;
+                exports io.fabric8.kubernetes.api.model.clusterapi.core.v1beta1;
+                exports io.fabric8.kubernetes.api.model.runtime;
+                exports io.fabric8.kubernetes.api.model.version;
+                exports io.fabric8.kubernetes.internal;
+
+                requires transitive io.fabric8.kubernetes.model.common;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/kubernetes-model-discovery/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-discovery/pom.xml
@@ -43,6 +43,30 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.kubernetes.model.discovery {
+                exports io.fabric8.kubernetes.api.model.discovery.v1;
+                exports io.fabric8.kubernetes.api.model.discovery.v1beta1;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/kubernetes-model-events/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-events/pom.xml
@@ -43,6 +43,30 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.kubernetes.model.events {
+                exports io.fabric8.kubernetes.api.model.events.v1;
+                exports io.fabric8.kubernetes.api.model.events.v1beta1;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/kubernetes-model-extensions/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-extensions/pom.xml
@@ -43,6 +43,29 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.kubernetes.model.extensions {
+                exports io.fabric8.kubernetes.api.model.extensions;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/kubernetes-model-flowcontrol/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-flowcontrol/pom.xml
@@ -46,6 +46,32 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.kubernetes.model.flowcontrol {
+                exports io.fabric8.kubernetes.api.model.flowcontrol.v1;
+                exports io.fabric8.kubernetes.api.model.flowcontrol.v1beta1;
+                exports io.fabric8.kubernetes.api.model.flowcontrol.v1beta2;
+                exports io.fabric8.kubernetes.api.model.flowcontrol.v1beta3;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/kubernetes-model-gatewayapi/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-gatewayapi/pom.xml
@@ -45,6 +45,32 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.kubernetes.model.gatewayapi {
+                exports io.fabric8.kubernetes.api.model.gatewayapi.v1;
+                exports io.fabric8.kubernetes.api.model.gatewayapi.v1alpha2;
+                exports io.fabric8.kubernetes.api.model.gatewayapi.v1alpha3;
+                exports io.fabric8.kubernetes.api.model.gatewayapi.v1beta1;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/kubernetes-model-kustomize/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-kustomize/pom.xml
@@ -50,6 +50,30 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.kubernetes.model.kustomize {
+                exports io.fabric8.kubernetes.api.model.kustomize.v1beta1;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires com.fasterxml.jackson.dataformat.yaml;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/kubernetes-model-metrics/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-metrics/pom.xml
@@ -43,6 +43,29 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.kubernetes.model.metrics {
+                exports io.fabric8.kubernetes.api.model.metrics.v1beta1;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/kubernetes-model-networking/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-networking/pom.xml
@@ -43,6 +43,30 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.kubernetes.model.networking {
+                exports io.fabric8.kubernetes.api.model.networking.v1;
+                exports io.fabric8.kubernetes.api.model.networking.v1beta1;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/kubernetes-model-node/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-node/pom.xml
@@ -45,6 +45,31 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.kubernetes.model.node {
+                exports io.fabric8.kubernetes.api.model.node.v1;
+                exports io.fabric8.kubernetes.api.model.node.v1alpha1;
+                exports io.fabric8.kubernetes.api.model.node.v1beta1;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/kubernetes-model-policy/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-policy/pom.xml
@@ -43,6 +43,30 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.kubernetes.model.policy {
+                exports io.fabric8.kubernetes.api.model.policy.v1;
+                exports io.fabric8.kubernetes.api.model.policy.v1beta1;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/kubernetes-model-rbac/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-rbac/pom.xml
@@ -45,6 +45,29 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.kubernetes.model.rbac {
+                exports io.fabric8.kubernetes.api.model.rbac;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/kubernetes-model-resource/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-resource/pom.xml
@@ -45,6 +45,33 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.kubernetes.model.resource {
+                exports io.fabric8.kubernetes.api.model.resource.v1;
+                exports io.fabric8.kubernetes.api.model.resource.v1alpha2;
+                exports io.fabric8.kubernetes.api.model.resource.v1alpha3;
+                exports io.fabric8.kubernetes.api.model.resource.v1beta1;
+                exports io.fabric8.kubernetes.api.model.resource.v1beta2;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/kubernetes-model-scheduling/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-scheduling/pom.xml
@@ -45,6 +45,32 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.kubernetes.model.scheduling {
+                exports io.fabric8.kubernetes.api.model.scheduling.v1;
+                exports io.fabric8.kubernetes.api.model.scheduling.v1alpha1;
+                exports io.fabric8.kubernetes.api.model.scheduling.v1alpha2;
+                exports io.fabric8.kubernetes.api.model.scheduling.v1beta1;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/kubernetes-model-storageclass/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-storageclass/pom.xml
@@ -45,6 +45,32 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.kubernetes.model.storageclass {
+                exports io.fabric8.kubernetes.api.model.storage;
+                exports io.fabric8.kubernetes.api.model.storage.v1alpha1;
+                exports io.fabric8.kubernetes.api.model.storage.v1beta1;
+                exports io.fabric8.kubernetes.api.model.storagemigration.v1beta1;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/openshift-model-autoscaling/pom.xml
+++ b/kubernetes-model-generator/openshift-model-autoscaling/pom.xml
@@ -45,6 +45,30 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.openshift.model.autoscaling {
+                exports io.fabric8.openshift.api.model.autoscaling.v1;
+                exports io.fabric8.openshift.api.model.autoscaling.v1beta1;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/openshift-model-config/pom.xml
+++ b/kubernetes-model-generator/openshift-model-config/pom.xml
@@ -45,6 +45,30 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.openshift.model.config {
+                exports io.fabric8.openshift.api.model.config.v1;
+                exports io.fabric8.openshift.api.model.config.v1alpha2;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/openshift-model-console/pom.xml
+++ b/kubernetes-model-generator/openshift-model-console/pom.xml
@@ -49,6 +49,30 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.openshift.model.console {
+                exports io.fabric8.openshift.api.model.console.v1;
+
+                requires transitive io.fabric8.kubernetes.model.admissionregistration;
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/openshift-model-hive/pom.xml
+++ b/kubernetes-model-generator/openshift-model-hive/pom.xml
@@ -49,6 +49,41 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.openshift.model.hive {
+                exports io.fabric8.openshift.api.model.hive.agent.v1;
+                exports io.fabric8.openshift.api.model.hive.aws.v1;
+                exports io.fabric8.openshift.api.model.hive.azure.v1;
+                exports io.fabric8.openshift.api.model.hive.baremetal.v1;
+                exports io.fabric8.openshift.api.model.hive.gcp.v1;
+                exports io.fabric8.openshift.api.model.hive.ibmcloud.v1;
+                exports io.fabric8.openshift.api.model.hive.metricsconfig.v1;
+                exports io.fabric8.openshift.api.model.hive.none.v1;
+                exports io.fabric8.openshift.api.model.hive.openstack.v1;
+                exports io.fabric8.openshift.api.model.hive.ovirt.v1;
+                exports io.fabric8.openshift.api.model.hive.v1;
+                exports io.fabric8.openshift.api.model.hive.vsphere.v1;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive io.fabric8.openshift.model;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/openshift-model-insights/pom.xml
+++ b/kubernetes-model-generator/openshift-model-insights/pom.xml
@@ -52,6 +52,31 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.openshift.model.insights {
+                exports io.fabric8.openshift.api.model.insights.v1alpha1;
+                exports io.fabric8.openshift.api.model.insights.v1alpha2;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive io.fabric8.openshift.model.config;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/openshift-model-installer/pom.xml
+++ b/kubernetes-model-generator/openshift-model-installer/pom.xml
@@ -57,6 +57,43 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.openshift.model.installer {
+                exports io.fabric8.openshift.api.model.installer.aws.v1;
+                exports io.fabric8.openshift.api.model.installer.baremetal.v1;
+                exports io.fabric8.openshift.api.model.installer.external.v1;
+                exports io.fabric8.openshift.api.model.installer.gcp.v1;
+                exports io.fabric8.openshift.api.model.installer.ibmcloud.v1;
+                exports io.fabric8.openshift.api.model.installer.none.v1;
+                exports io.fabric8.openshift.api.model.installer.nutanix.v1;
+                exports io.fabric8.openshift.api.model.installer.openstack.v1;
+                exports io.fabric8.openshift.api.model.installer.ovirt.v1;
+                exports io.fabric8.openshift.api.model.installer.powervc.v1;
+                exports io.fabric8.openshift.api.model.installer.powervs.v1;
+                exports io.fabric8.openshift.api.model.installer.v1;
+                exports io.fabric8.openshift.api.model.installer.vsphere.v1;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive io.fabric8.openshift.model.config;
+                requires transitive io.fabric8.openshift.model.machine;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/openshift-model-machine/pom.xml
+++ b/kubernetes-model-generator/openshift-model-machine/pom.xml
@@ -45,6 +45,31 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.openshift.model.machine {
+                exports io.fabric8.openshift.api.model.machine.v1;
+                exports io.fabric8.openshift.api.model.machine.v1alpha1;
+                exports io.fabric8.openshift.api.model.machine.v1beta1;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/openshift-model-machineconfiguration/pom.xml
+++ b/kubernetes-model-generator/openshift-model-machineconfiguration/pom.xml
@@ -49,6 +49,31 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.openshift.model.machineconfiguration {
+                exports io.fabric8.openshift.api.model.machineconfiguration.v1;
+                exports io.fabric8.openshift.api.model.machineconfiguration.v1alpha1;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive io.fabric8.openshift.model.config;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/openshift-model-miscellaneous/pom.xml
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/pom.xml
@@ -49,6 +49,38 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.openshift.model.miscellaneous {
+                exports io.fabric8.openshift.api.model.miscellaneous.apiserver.v1;
+                exports io.fabric8.openshift.api.model.miscellaneous.cloudcredential.v1;
+                exports io.fabric8.openshift.api.model.miscellaneous.cncf.cni.v1;
+                exports io.fabric8.openshift.api.model.miscellaneous.helm.v1beta1;
+                exports io.fabric8.openshift.api.model.miscellaneous.metal3.v1alpha1;
+                exports io.fabric8.openshift.api.model.miscellaneous.metal3.v1beta1;
+                exports io.fabric8.openshift.api.model.miscellaneous.network.cloud.v1;
+                exports io.fabric8.openshift.api.model.miscellaneous.network.v1;
+                exports io.fabric8.openshift.api.model.miscellaneous.network.v1alpha1;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive io.fabric8.openshift.model.config;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/openshift-model-monitoring/pom.xml
+++ b/kubernetes-model-generator/openshift-model-monitoring/pom.xml
@@ -49,6 +49,32 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.openshift.model.monitoring {
+                exports io.fabric8.openshift.api.model.monitoring.v1;
+                exports io.fabric8.openshift.api.model.monitoring.v1alpha1;
+                exports io.fabric8.openshift.api.model.monitoring.v1beta1;
+
+                requires transitive io.fabric8.kubernetes.model.apps;
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/openshift-model-operator/pom.xml
+++ b/kubernetes-model-generator/openshift-model-operator/pom.xml
@@ -54,6 +54,35 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.openshift.model.operator {
+                exports io.fabric8.openshift.api.model.operator.controlplane.v1alpha1;
+                exports io.fabric8.openshift.api.model.operator.imageregistry.v1;
+                exports io.fabric8.openshift.api.model.operator.ingress.v1;
+                exports io.fabric8.openshift.api.model.operator.network.v1;
+                exports io.fabric8.openshift.api.model.operator.v1;
+                exports io.fabric8.openshift.api.model.operator.v1alpha1;
+
+                requires transitive io.fabric8.kubernetes.model.admissionregistration;
+                requires transitive io.fabric8.openshift.model.config;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/openshift-model-operatorhub/pom.xml
+++ b/kubernetes-model-generator/openshift-model-operatorhub/pom.xml
@@ -57,6 +57,36 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.openshift.model.operatorhub {
+                exports io.fabric8.openshift.api.model.operatorhub.packages.v1;
+                exports io.fabric8.openshift.api.model.operatorhub.v1;
+                exports io.fabric8.openshift.api.model.operatorhub.v1alpha1;
+                exports io.fabric8.openshift.api.model.operatorhub.v1alpha2;
+                exports io.fabric8.openshift.api.model.operatorhub.v2;
+
+                requires transitive io.fabric8.kubernetes.model.admissionregistration;
+                requires transitive io.fabric8.kubernetes.model.apps;
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive io.fabric8.kubernetes.model.rbac;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/openshift-model-storageversionmigrator/pom.xml
+++ b/kubernetes-model-generator/openshift-model-storageversionmigrator/pom.xml
@@ -45,6 +45,29 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.openshift.model.storageversionmigrator {
+                exports io.fabric8.openshift.api.model.storageversionmigrator.v1alpha1;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/openshift-model-tuned/pom.xml
+++ b/kubernetes-model-generator/openshift-model-tuned/pom.xml
@@ -45,6 +45,29 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.openshift.model.tuned {
+                exports io.fabric8.openshift.api.model.tuned.v1;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/openshift-model-whereabouts/pom.xml
+++ b/kubernetes-model-generator/openshift-model-whereabouts/pom.xml
@@ -45,6 +45,29 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.openshift.model.whereabouts {
+                exports io.fabric8.openshift.api.model.whereabouts.v1alpha1;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/openshift-model/pom.xml
+++ b/kubernetes-model-generator/openshift-model/pom.xml
@@ -34,6 +34,10 @@
     <clone-kube>true</clone-kube>
     <osgi.import>*</osgi.import>
     <osgi.export>
+      <!-- config.* lives in openshift-model-config; excluded so bnd does not embed it
+           (would create a JPMS split package on the module path) -->
+      !io.fabric8.openshift.api.model.config,
+      !io.fabric8.openshift.api.model.config.*,
       io.fabric8.openshift.api.model**,
       io.fabric8.openshift.api.model.customresourcestatus.conditions.v1**,
     </osgi.export>
@@ -53,6 +57,32 @@
       <artifactId>openshift-model-config</artifactId>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.openshift.model {
+                exports io.fabric8.openshift.api.model;
+                exports io.fabric8.openshift.api.model.customresourcestatus.conditions.v1;
+
+                requires transitive io.fabric8.kubernetes.model.core;
+                requires transitive io.fabric8.kubernetes.model.rbac;
+                requires transitive io.fabric8.openshift.model.config;
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
   <profiles>
     <profile>

--- a/openshift-client-api/pom.xml
+++ b/openshift-client-api/pom.xml
@@ -169,6 +169,44 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.openshift.client.api {
+                exports io.fabric8.openshift.client;
+                exports io.fabric8.openshift.client.dsl;
+                exports io.fabric8.openshift.client.dsl.buildconfig;
+                exports io.fabric8.openshift.client.readiness;
+
+                requires transitive io.fabric8.kubernetes.client.api;
+                requires transitive io.fabric8.openshift.model;
+                requires transitive io.fabric8.openshift.model.autoscaling;
+                requires transitive io.fabric8.openshift.model.config;
+                requires transitive io.fabric8.openshift.model.console;
+                requires transitive io.fabric8.openshift.model.hive;
+                requires transitive io.fabric8.openshift.model.installer;
+                requires transitive io.fabric8.openshift.model.machine;
+                requires transitive io.fabric8.openshift.model.machineconfiguration;
+                requires transitive io.fabric8.openshift.model.miscellaneous;
+                requires transitive io.fabric8.openshift.model.monitoring;
+                requires transitive io.fabric8.openshift.model.operator;
+                requires transitive io.fabric8.openshift.model.operatorhub;
+                requires transitive io.fabric8.openshift.model.storageversionmigrator;
+                requires transitive io.fabric8.openshift.model.tuned;
+                requires transitive io.fabric8.openshift.model.whereabouts;
+
+                requires transitive com.fasterxml.jackson.annotation;
+                requires com.fasterxml.jackson.databind;
+                requires static builder.annotations;
+                requires static org.osgi.service.component.annotations;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>

--- a/openshift-client/pom.xml
+++ b/openshift-client/pom.xml
@@ -136,6 +136,41 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              open module io.fabric8.openshift.client {
+                exports io.fabric8.openshift.client.dsl.internal;
+                exports io.fabric8.openshift.client.dsl.internal.apps;
+                exports io.fabric8.openshift.client.dsl.internal.authorization;
+                exports io.fabric8.openshift.client.dsl.internal.build;
+                exports io.fabric8.openshift.client.dsl.internal.core;
+                exports io.fabric8.openshift.client.dsl.internal.project;
+                exports io.fabric8.openshift.client.impl;
+                exports io.fabric8.openshift.client.internal;
+                exports io.fabric8.openshift.client.osgi;
+
+                requires transitive io.fabric8.openshift.client.api;
+                requires io.fabric8.kubernetes.client;
+                requires com.fasterxml.jackson.databind;
+                requires com.fasterxml.jackson.core;
+                requires org.slf4j;
+                requires static builder.annotations;
+                requires static org.osgi.service.component.annotations;
+
+                provides io.fabric8.kubernetes.client.ServiceToURLProvider with
+                    io.fabric8.openshift.client.impl.URLFromOpenshiftRouteImpl;
+                provides io.fabric8.kubernetes.client.extension.ExtensionAdapter with
+                    io.fabric8.openshift.client.impl.OpenShiftExtensionAdapter,
+                    io.fabric8.openshift.client.impl.NamespacedOpenShiftExtensionAdapter;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,7 @@
     <exec.maven-plugin.version>3.6.3</exec.maven-plugin.version>
     <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
     <maven.bundle.plugin.version>5.1.9</maven.bundle.plugin.version>
+    <moditect.plugin.version>1.2.2.Final</moditect.plugin.version>
     <maven.buildhelper.plugin.version>3.6.1</maven.buildhelper.plugin.version>
     <maven.jar.plugin.version>3.5.0</maven.jar.plugin.version>
     <maven.surefire.plugin.version>3.5.6</maven.surefire.plugin.version>
@@ -1120,6 +1121,26 @@
             </analysisConfiguration>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.moditect</groupId>
+          <artifactId>moditect-maven-plugin</artifactId>
+          <version>${moditect.plugin.version}</version>
+          <executions>
+            <execution>
+              <id>add-module-info</id>
+              <phase>package</phase>
+              <goals>
+                <goal>add-module-info</goal>
+              </goals>
+              <configuration>
+                <!-- Explicit descriptors per module (moduleInfoSource), NOT jdeps auto-generation:
+                     jdeps fails on the provided-scope sundr toolchain, whose jars share a split
+                     package (sundr.model.base & sundr.model.utils both export io.sundr.model). -->
+                <overwriteExistingFiles>true</overwriteExistingFiles>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -1688,29 +1709,6 @@
           <plugin>
             <groupId>org.revapi</groupId>
             <artifactId>revapi-maven-plugin</artifactId>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>jpms-module-name</id>
-      <activation>
-        <file>
-          <exists>${basedir}/src/main/resources/META-INF/services/io.fabric8.kubernetes.client.http.HttpClient$Factory</exists>
-        </file>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-jar-plugin</artifactId>
-            <configuration>
-              <archive>
-                <manifestEntries>
-                  <Automatic-Module-Name>${jpms.module.name}</Automatic-Module-Name>
-                </manifestEntries>
-              </archive>
-            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -1133,9 +1133,13 @@
                 <goal>add-module-info</goal>
               </goals>
               <configuration>
-                <!-- Explicit descriptors per module (moduleInfoSource), NOT jdeps auto-generation:
-                     jdeps fails on the provided-scope sundr toolchain, whose jars share a split
-                     package (sundr.model.base & sundr.model.utils both export io.sundr.model). -->
+                <!-- Descriptors are injected post-compile rather than written as module-info.java:
+                     the model classes and all builders are produced by the Sundrio annotation
+                     processor, so the exported packages do not exist when javac would validate an
+                     inline module-info (it fails with "package is empty or does not exist").
+                     Explicit moduleInfoSource per module, NOT jdeps auto-generation: jdeps fails on
+                     the provided-scope sundr toolchain, whose jars share a split package
+                     (sundr.model.base & sundr.model.utils both export io.sundr.model). -->
                 <overwriteExistingFiles>true</overwriteExistingFiles>
               </configuration>
             </execution>

--- a/zjsonpatch/pom.xml
+++ b/zjsonpatch/pom.xml
@@ -91,6 +91,21 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <configuration>
+          <module>
+            <moduleInfoSource>
+              module io.fabric8.zjsonpatch {
+                exports io.fabric8.zjsonpatch;
+
+                requires transitive com.fasterxml.jackson.databind;
+              }
+            </moduleInfoSource>
+          </module>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Fix #1996.

### Description
Adds a real `module-info` to all 74 published modules via the moditect plugin (post-compile injection, since the model/builder classes are generated by the Sundrio annotation processor and can't be exported by inline `javac`). Module names follow `io.fabric8.<artifactId>`. Supersedes the abandoned #2110 — the original blockers are gone: split packages (resolved by the model split #2108) and Sundrio coupling (now compile-only).

### Notable changes
- **parent pom**: `moditect-maven-plugin` in `pluginManagement`; removed the `Automatic-Module-Name` profile (real descriptors replace it).
- **openshift-model**: tightened the OSGi `Export-Package` to stop embedding `config.*` — otherwise bnd copies `openshift-model-config` classes into the jar, creating a split package on the module path.
- **kube-api-test/client-inject**: moved `Fabric8ClientInjectionHandler` to `io.fabric8.kubeapitest.junit.inject` (the package was shared with core).

### Migration notes (consumers)
- HTTP-client and extension selection still work on the module path (SPI is translated to module `provides`/`uses`).
- `openshift-model` no longer re-exports `io.fabric8.openshift.api.model.config.*` — depend on `openshift-model-config` directly if you relied on this transitively.
- `Fabric8ClientInjectionHandler` moved to package `io.fabric8.kubeapitest.junit.inject`; new module name `io.fabric8.kube.api.test.client.inject`.

### Verification
Full reactor builds; all 74 descriptors validate (`--validate-modules`) with no split packages and unique names; runtime `ServiceLoader` (HTTP `Factory`, `ExtensionAdapter`, `ClientInjectionHandler`) confirmed working on the module path.

### Open question for maintainers
The `openshift-model` OSGi `Export-Package` change is the only behavior change — please confirm it's acceptable for existing OSGi consumers.