### PR TITLE
test(informers): black-box tests for the onBeforeList callback

### DIFF
--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/ResourceEventHandler.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/ResourceEventHandler.java
@@ -52,8 +52,10 @@ public interface ResourceEventHandler<T> {
    * detected by the list are not reconciled into the cache until just before {@code onList} is
    * called.</li>
    * <li>the last sync resource version reported here remains frozen for the duration of the
-   * list, but {@code onAdd} / {@code onUpdate} events can still be emitted from the in-flight
-   * list pages with resource versions newer than {@code lastSyncResourceVersion}.</li>
+   * list. On a re-list, {@code onAdd} / {@code onUpdate} events can still be emitted from the
+   * in-flight list pages with resource versions newer than {@code lastSyncResourceVersion}; on
+   * the initial list the additions are instead deferred and delivered as a single batch just
+   * before {@link #onList(String, boolean)}.</li>
    * </ul>
    *
    * <p>

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/impl/DefaultSharedIndexInformerResyncTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/impl/DefaultSharedIndexInformerResyncTest.java
@@ -16,9 +16,11 @@
 package io.fabric8.kubernetes.client.informers.impl;
 
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.PodListBuilder;
 import io.fabric8.kubernetes.client.dsl.internal.AbstractWatchManager;
+import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -28,6 +30,7 @@ import org.mockito.Mockito;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -167,6 +170,60 @@ class DefaultSharedIndexInformerResyncTest {
     // Then
     assertNull(controller.getResyncFuture());
     assertThat(countDown.getCount()).isLessThanOrEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("Resync redistributes onUpdate only and never invokes onBeforeList or onList")
+  void resyncDoesNotInvokeOnBeforeListOrOnList() throws InterruptedException {
+    // Given a non-empty initial list so a resync has a cached item to redistribute as an onUpdate.
+    // 1000ms is the minimum effective resync period (DefaultSharedIndexInformer#MINIMUM_RESYNC_PERIOD_MILLIS).
+    final long resyncPeriod = 1000L;
+    final Pod pod1 = new PodBuilder().withNewMetadata()
+        .withNamespace("ns").withName("pod1").withResourceVersion("1").endMetadata()
+        .build();
+    Mockito.when(listerWatcher.submitList(Mockito.any()))
+        .thenReturn(CompletableFuture.completedFuture(new PodListBuilder().withNewMetadata()
+            .withResourceVersion("1").endMetadata().withItems(pod1).build()));
+    final AtomicInteger onBeforeListCount = new AtomicInteger();
+    final AtomicInteger onListCount = new AtomicInteger();
+    final CountDownLatch resyncDelivered = new CountDownLatch(1);
+    DefaultSharedIndexInformer<Pod, PodList> controller = createDefaultSharedIndexInformer(resyncPeriod);
+    controller.addEventHandler(new ResourceEventHandler<Pod>() {
+      @Override
+      public void onBeforeList(String lastSyncResourceVersion) {
+        onBeforeListCount.incrementAndGet();
+      }
+
+      @Override
+      public void onAdd(Pod obj) {
+        // intentionally ignored: the initial list flushes pod1 as an onAdd, so only onUpdate
+        // (emitted exclusively by the resync) trips the latch and isolates the resync.
+      }
+
+      @Override
+      public void onUpdate(Pod oldObj, Pod newObj) {
+        resyncDelivered.countDown();
+      }
+
+      @Override
+      public void onDelete(Pod obj, boolean deletedFinalStateUnknown) {
+      }
+
+      @Override
+      public void onList(String resourceVersion, boolean remainedEmpty) {
+        onListCount.incrementAndGet();
+      }
+    });
+
+    // When the informer runs (initial list) and the periodic resync then fires
+    controller.run();
+
+    // Then the resync delivers the cached item as an onUpdate ...
+    assertThat(resyncDelivered.await(10, TimeUnit.SECONDS)).isTrue();
+    // ... but neither onBeforeList nor onList is emitted for the resync: each fired exactly once,
+    // for the single initial list only.
+    assertThat(onBeforeListCount.get()).isEqualTo(1);
+    assertThat(onListCount.get()).isEqualTo(1);
   }
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/InformTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/InformTest.java
@@ -22,9 +22,13 @@ import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodListBuilder;
+import io.fabric8.kubernetes.api.model.Status;
+import io.fabric8.kubernetes.api.model.StatusBuilder;
 import io.fabric8.kubernetes.api.model.WatchEvent;
+import io.fabric8.kubernetes.api.model.WatchEventBuilder;
 import io.fabric8.kubernetes.api.model.apps.ReplicaSetBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
@@ -34,15 +38,19 @@ import io.fabric8.kubernetes.client.informers.cache.ReducedStateItemStore;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.kubernetes.client.utils.KubernetesSerialization;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -52,6 +60,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class InformTest {
 
   private static final Long EVENT_WAIT_PERIOD_MS = 10L;
+
+  private static final Status outdatedStatus = new StatusBuilder().withCode(HttpURLConnection.HTTP_GONE)
+      .withMessage("410: the requested watch resource version is outdated")
+      .build();
+  private static final WatchEvent outdatedEvent = new WatchEventBuilder().withType(Watcher.Action.ERROR.name())
+      .withObject(outdatedStatus)
+      .build();
 
   KubernetesMockServer server;
   KubernetesClient client;
@@ -546,6 +561,156 @@ class InformTest {
     assertEquals("1", byKey.getMetadata().getResourceVersion());
     assertEquals(1, byKey.getMetadata().getOwnerReferences().size());
     assertNull(byKey.getSpec());
+
+    informer.stop();
+  }
+
+  @Test
+  @DisplayName("onBeforeList(null) is delivered before the initial list adds and before onList, through the real informer pipeline")
+  void onBeforeListPrecedesInitialListAddsAndOnList() throws InterruptedException {
+    // Given
+    Pod pod1 = new PodBuilder().withNewMetadata()
+        .withNamespace("test").withName("pod1").withResourceVersion("1").endMetadata()
+        .build();
+
+    server.expect()
+        .withPath("/api/v1/namespaces/test/pods?resourceVersion=0")
+        .andReturn(HttpURLConnection.HTTP_OK,
+            new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().withItems(pod1).build())
+        .once();
+    server.expect()
+        .withPath("/api/v1/namespaces/test/pods?allowWatchBookmarks=true&resourceVersion=1&timeoutSeconds=600&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .done()
+        .once();
+
+    final List<String> events = new CopyOnWriteArrayList<>();
+    final CountDownLatch listLatch = new CountDownLatch(1);
+    final ResourceEventHandler<Pod> handler = new ResourceEventHandler<Pod>() {
+      @Override
+      public void onBeforeList(String lastSyncResourceVersion) {
+        events.add("beforeList:" + lastSyncResourceVersion);
+      }
+
+      @Override
+      public void onAdd(Pod obj) {
+        events.add("add:" + obj.getMetadata().getName());
+      }
+
+      @Override
+      public void onUpdate(Pod oldObj, Pod newObj) {
+        events.add("update:" + newObj.getMetadata().getName());
+      }
+
+      @Override
+      public void onDelete(Pod obj, boolean deletedFinalStateUnknown) {
+        events.add("delete:" + obj.getMetadata().getName());
+      }
+
+      @Override
+      public void onList(String resourceVersion, boolean remainedEmpty) {
+        events.add("list:" + resourceVersion);
+        listLatch.countDown();
+      }
+    };
+
+    // When
+    SharedIndexInformer<Pod> informer = client.pods().inform(handler);
+    assertTrue(listLatch.await(10, TimeUnit.SECONDS));
+
+    // Then the central ordering guarantee holds end to end: onBeforeList(null) is delivered first,
+    // then the (deferred, batch-flushed) initial add, then the matching onList.
+    assertThat(events).startsWith("beforeList:null");
+    assertThat(events.indexOf("beforeList:null")).isLessThan(events.indexOf("add:pod1"));
+    assertThat(events.indexOf("add:pod1")).isLessThan(events.indexOf("list:1"));
+
+    informer.stop();
+  }
+
+  @Test
+  @DisplayName("On an HTTP GONE re-list, onBeforeList re-fires with the frozen prior resourceVersion before the re-list's newer events and onList")
+  void onBeforeListReportsFrozenResourceVersionOnRelist() throws InterruptedException {
+    // Given an initial list at v1 ...
+    Pod pod1v1 = new PodBuilder().withNewMetadata()
+        .withNamespace("test").withName("pod1").withResourceVersion("1").endMetadata()
+        .build();
+    Pod pod1v2 = new PodBuilder().withNewMetadata()
+        .withNamespace("test").withName("pod1").withResourceVersion("2").endMetadata()
+        .build();
+
+    server.expect()
+        .withPath("/api/v1/namespaces/test/pods?resourceVersion=0")
+        .andReturn(HttpURLConnection.HTTP_OK,
+            new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().withItems(pod1v1).build())
+        .once();
+    // ... whose watch then sees an HTTP GONE, forcing a fresh re-list cycle
+    server.expect()
+        .withPath("/api/v1/namespaces/test/pods?allowWatchBookmarks=true&resourceVersion=1&timeoutSeconds=600&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(EVENT_WAIT_PERIOD_MS)
+        .andEmit(outdatedEvent)
+        .done()
+        .once();
+    // the re-list omits resourceVersion (it is no longer a cached listing) and returns pod1 at v2
+    server.expect()
+        .withPath("/api/v1/namespaces/test/pods")
+        .andReturn(HttpURLConnection.HTTP_OK,
+            new PodListBuilder().withNewMetadata().withResourceVersion("2").endMetadata().withItems(pod1v2).build())
+        .times(2);
+    server.expect()
+        .withPath("/api/v1/namespaces/test/pods?allowWatchBookmarks=true&resourceVersion=2&timeoutSeconds=600&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .done()
+        .always();
+
+    final List<String> events = new CopyOnWriteArrayList<>();
+    final List<String> beforeListArgs = new CopyOnWriteArrayList<>();
+    final CountDownLatch relistDone = new CountDownLatch(1);
+    final ResourceEventHandler<Pod> handler = new ResourceEventHandler<Pod>() {
+      @Override
+      public void onBeforeList(String lastSyncResourceVersion) {
+        events.add("beforeList:" + lastSyncResourceVersion);
+        beforeListArgs.add(lastSyncResourceVersion);
+      }
+
+      @Override
+      public void onAdd(Pod obj) {
+        events.add("add:" + obj.getMetadata().getName() + ":" + obj.getMetadata().getResourceVersion());
+      }
+
+      @Override
+      public void onUpdate(Pod oldObj, Pod newObj) {
+        events.add("update:" + newObj.getMetadata().getName() + ":" + newObj.getMetadata().getResourceVersion());
+      }
+
+      @Override
+      public void onDelete(Pod obj, boolean deletedFinalStateUnknown) {
+        events.add("delete:" + obj.getMetadata().getName());
+      }
+
+      @Override
+      public void onList(String resourceVersion, boolean remainedEmpty) {
+        events.add("list:" + resourceVersion);
+        if ("2".equals(resourceVersion)) {
+          relistDone.countDown();
+        }
+      }
+    };
+
+    // When
+    SharedIndexInformer<Pod> informer = client.pods().inform(handler);
+    assertTrue(relistDone.await(10, TimeUnit.SECONDS));
+
+    // Then the initial cycle reports null and the re-list cycle reports the frozen prior version "1"
+    assertThat(beforeListArgs).hasSizeGreaterThanOrEqualTo(2);
+    assertThat(beforeListArgs.get(0)).isNull();
+    assertThat(beforeListArgs.get(1)).isEqualTo("1");
+    // and that frozen version is reported before the re-list emits the newer (v2) update and onList
+    assertThat(events.indexOf("beforeList:1")).isLessThan(events.indexOf("update:pod1:2"));
+    assertThat(events.indexOf("beforeList:1")).isLessThan(events.indexOf("list:2"));
 
     informer.stop();
   }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchListInformTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchListInformTest.java
@@ -18,23 +18,39 @@ package io.fabric8.kubernetes.client.mock;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.Status;
+import io.fabric8.kubernetes.api.model.StatusBuilder;
 import io.fabric8.kubernetes.api.model.WatchEvent;
+import io.fabric8.kubernetes.api.model.WatchEventBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.net.HttpURLConnection;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableKubernetesMockClient(https = false, kubernetesClientBuilderCustomizer = WatchListCustomizer.class)
 class WatchListInformTest {
 
   private static final Long EVENT_WAIT_PERIOD_MS = 10L;
+
+  private static final Status outdatedStatus = new StatusBuilder().withCode(HttpURLConnection.HTTP_GONE)
+      .withMessage("410: the requested watch resource version is outdated")
+      .build();
+  private static final WatchEvent outdatedEvent = new WatchEventBuilder().withType(Watcher.Action.ERROR.name())
+      .withObject(outdatedStatus)
+      .build();
 
   KubernetesMockServer server;
   KubernetesClient client;
@@ -96,6 +112,133 @@ class WatchListInformTest {
     assertTrue(deleteLatch.await(10, TimeUnit.SECONDS));
     assertTrue(addLatch.await(10, TimeUnit.SECONDS));
     assertTrue(nonEmptyList.await(10, TimeUnit.SECONDS));
+
+    informer.stop();
+  }
+
+  @Test
+  @DisplayName("watchList path delivers onBeforeList(null) before the initial add and before onList, through the real informer pipeline")
+  void onBeforeListPrecedesInitialEventsOnWatchListPath() throws InterruptedException {
+    // Given
+    Pod pod1 = new PodBuilder().withNewMetadata()
+        .withNamespace("test").withName("pod1").withResourceVersion("1").endMetadata()
+        .build();
+
+    server.expect()
+        .withPath(
+            "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&labelSelector=my-label&resourceVersionMatch=NotOlderThan&sendInitialEvents=true&timeoutSeconds=600&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(EVENT_WAIT_PERIOD_MS)
+        .andEmit(new WatchEvent(pod1, "ADDED"))
+        .waitFor(EVENT_WAIT_PERIOD_MS)
+        .andEmit(new WatchEvent(new PodBuilder().withNewMetadata().withResourceVersion("2").endMetadata().build(), "BOOKMARK"))
+        .done()
+        .once();
+
+    final List<String> events = new CopyOnWriteArrayList<>();
+    final CountDownLatch listLatch = new CountDownLatch(1);
+    final ResourceEventHandler<Pod> handler = new ResourceEventHandler<Pod>() {
+      @Override
+      public void onBeforeList(String lastSyncResourceVersion) {
+        events.add("beforeList:" + lastSyncResourceVersion);
+      }
+
+      @Override
+      public void onAdd(Pod obj) {
+        events.add("add:" + obj.getMetadata().getName());
+      }
+
+      @Override
+      public void onUpdate(Pod oldObj, Pod newObj) {
+        events.add("update:" + newObj.getMetadata().getName());
+      }
+
+      @Override
+      public void onDelete(Pod obj, boolean deletedFinalStateUnknown) {
+        events.add("delete:" + obj.getMetadata().getName());
+      }
+
+      @Override
+      public void onList(String resourceVersion, boolean remainedEmpty) {
+        events.add("list:" + resourceVersion);
+        listLatch.countDown();
+      }
+    };
+
+    // When
+    SharedIndexInformer<Pod> informer = client.pods().withLabel("my-label").inform(handler);
+    assertTrue(listLatch.await(10, TimeUnit.SECONDS));
+
+    // Then the ordering guarantee holds on the watchList path too: onBeforeList(null) is first,
+    // the initial add (flushed when the bookmark completes the synthetic list) precedes onList.
+    assertThat(events.indexOf("beforeList:null")).isZero();
+    assertThat(events.indexOf("beforeList:null")).isLessThan(events.indexOf("add:pod1"));
+    assertThat(events.indexOf("add:pod1")).isLessThan(events.indexOf("list:2"));
+
+    informer.stop();
+  }
+
+  @Test
+  @DisplayName("watchList path re-arms onBeforeList after the bookmark completes the list, firing again with the frozen bookmark resourceVersion on HTTP GONE re-list")
+  void onBeforeListReArmsOnWatchListRelist() throws InterruptedException {
+    // Given a first watchList cycle that completes via a bookmark at v2, then sees an HTTP GONE
+    Pod pod1 = new PodBuilder().withNewMetadata()
+        .withNamespace("test").withName("pod1").withResourceVersion("1").endMetadata()
+        .build();
+
+    server.expect()
+        .withPath(
+            "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&labelSelector=my-label&resourceVersionMatch=NotOlderThan&sendInitialEvents=true&timeoutSeconds=600&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(EVENT_WAIT_PERIOD_MS)
+        .andEmit(new WatchEvent(pod1, "ADDED"))
+        .waitFor(EVENT_WAIT_PERIOD_MS)
+        .andEmit(new WatchEvent(new PodBuilder().withNewMetadata().withResourceVersion("2").endMetadata().build(), "BOOKMARK"))
+        .waitFor(EVENT_WAIT_PERIOD_MS)
+        .andEmit(outdatedEvent)
+        .done()
+        .once();
+    // the re-list cycle re-establishes a watchList from the frozen bookmark version (resourceVersion=2)
+    server.expect()
+        .withPath(
+            "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&labelSelector=my-label&resourceVersion=2&resourceVersionMatch=NotOlderThan&sendInitialEvents=true&timeoutSeconds=600&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .done()
+        .always();
+
+    final List<String> beforeListArgs = new CopyOnWriteArrayList<>();
+    final CountDownLatch twoBeforeLists = new CountDownLatch(2);
+    final ResourceEventHandler<Pod> handler = new ResourceEventHandler<Pod>() {
+      @Override
+      public void onBeforeList(String lastSyncResourceVersion) {
+        beforeListArgs.add(lastSyncResourceVersion);
+        twoBeforeLists.countDown();
+      }
+
+      @Override
+      public void onAdd(Pod obj) {
+      }
+
+      @Override
+      public void onUpdate(Pod oldObj, Pod newObj) {
+      }
+
+      @Override
+      public void onDelete(Pod obj, boolean deletedFinalStateUnknown) {
+      }
+    };
+
+    // When
+    SharedIndexInformer<Pod> informer = client.pods().withLabel("my-label").inform(handler);
+    assertTrue(twoBeforeLists.await(10, TimeUnit.SECONDS));
+
+    // Then onBeforeList re-armed via the BOOKMARK branch and fired again for the fresh cycle,
+    // carrying the frozen bookmark version "2".
+    assertThat(beforeListArgs.get(0)).isNull();
+    assertThat(beforeListArgs.get(1)).isEqualTo("2");
 
     informer.stop();
   }


### PR DESCRIPTION
Follow-up to #7899, which added `ResourceEventHandler.onBeforeList(String lastSyncResourceVersion)`. The unit tests introduced there mock `ProcessorStore`, so the documented `onBeforeList` -> `onAdd`/`onUpdate` -> `onList` ordering is only verified against the mock, never against the real `SharedProcessor`/`SerialExecutor` pipeline.

This change adds fast, black-box, mock-free tests (real client + mock server + real `ResourceEventHandler` + `CountDownLatch`, plain HTTP) that close the coverage gaps:

- **End-to-end ordering** on both the legacy list path (`InformTest`) and the watchList path (`WatchListInformTest`): `onBeforeList(null)` is delivered before the initial add and before the matching `onList`.
- **watchList re-arm**: after a bookmark completes the synthetic list, an HTTP GONE re-list re-fires `onBeforeList` with the frozen bookmark resourceVersion.
- **Frozen resourceVersion on re-list**: on an HTTP GONE re-list, `onBeforeList` reports the prior (frozen) resourceVersion before the re-list emits newer events.
- **Not called for resync** (`DefaultSharedIndexInformerResyncTest`): a resync redistributes `onUpdate` only and invokes neither `onBeforeList` nor `onList`.

Also qualifies the `ResourceEventHandler#onBeforeList` javadoc to distinguish the initial list (adds deferred and batch-flushed just before `onList`) from a re-list (adds/updates emitted per in-flight page).

Closes #7913

CC @csviri 