### PR TITLE
test: await recorded CONNECT to fix flaky proxy HTTPS test

### DIFF
--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpClientProxyHttpsTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpClientProxyHttpsTest.java
@@ -15,7 +15,6 @@
  */
 package io.fabric8.kubernetes.client.http;
 
-import io.fabric8.kubernetes.client.RequestConfigBuilder;
 import io.fabric8.kubernetes.client.internal.SSLUtils;
 import io.fabric8.mockwebserver.Context;
 import io.fabric8.mockwebserver.DefaultMockServer;
@@ -29,6 +28,7 @@ import io.fabric8.mockwebserver.internal.MockDispatcher;
 import io.fabric8.mockwebserver.internal.SimpleRequest;
 import io.fabric8.mockwebserver.internal.SimpleResponse;
 import io.fabric8.mockwebserver.utils.ResponseProvider;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -101,16 +101,17 @@ public abstract class AbstractHttpClientProxyHttpsTest {
         .sslContext(null, SSLUtils.trustManagers(null, null, true, null, null))
         .proxyAddress(new InetSocketAddress("localhost", proxyServer.getPort()))
         .proxyAuthorization(basicCredentials("auth", "cred"));
-    builder.tag(new RequestConfigBuilder().withRequestRetryBackoffInterval(1).build());
     try (HttpClient client = builder.build()) {
-      // When (just send and ignore response, we only care about the CONNECT request headers)
+      // When (just send and ignore the response, we only care about the CONNECT request headers)
       client.sendAsync(client.newHttpRequestBuilder().uri("https://example.com/proxied").build(), String.class)
-          .exceptionally(t -> null)
-          .get(30, TimeUnit.SECONDS);
+          .exceptionally(t -> null);
       // Then
-      assertThat(initialConnectRequest)
+      // The mock proxy can't complete the TLS handshake through the tunnel, so the request will eventually fail
+      // (and be retried). The CONNECT request we care about is recorded as soon as the authenticated tunnel is
+      // established, so we await that observable instead of blocking on the request's (irrelevant) final outcome.
+      Awaitility.await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> assertThat(initialConnectRequest)
           .doesNotHaveNullValue()
-          .hasValueMatching(r -> r.getHeader("Proxy-Authorization").equals("Basic YXV0aDpjcmVk"));
+          .hasValueMatching(r -> r.getHeader("Proxy-Authorization").equals("Basic YXV0aDpjcmVk")));
     }
   }
 }


### PR DESCRIPTION
## What

`JettyHttpClientProxyHttpsTest.proxyConfigurationAddsRequiredHeadersForHttps`,
inherited from the shared `AbstractHttpClientProxyHttpsTest`, was flaky and
intermittently failed on CI with a `TimeoutException` at `.get(30, SECONDS)`.

## Root cause

The mock proxy is a plain-HTTP server, so the tunnelled TLS handshake after the
authenticated `CONNECT` can never complete. The handshake fails with an
`IOException`, which the standard client retries up to the default limit. The
test blocked on that entire retry cycle draining; under CI scheduling pressure a
stalled handshake could push the cumulative wall-clock past 30s. The only thing
the test actually asserts on, the recorded `CONNECT` request, is captured on the
first authenticated `CONNECT`, before any handshake.

## Change

Await the recorded `CONNECT` via Awaitility instead of blocking on the request's
irrelevant final outcome, and drop the now-dead `withRequestRetryBackoffInterval(1)`
tag. Test-only change. The shared abstract test is exercised by all four HTTP
client implementations that extend it (Jetty, OkHttp, Vert.x, Vert.x5), all of
which stay green.

## Verification

- Jetty test, 10 consecutive runs: all green, ~1.5s each (previously a 30s timeout).
- All four client subclasses green.
- `spotless:check` passes.

## Follow-up

The investigation surfaced a separate, pre-existing concern: `StandardHttpClient.shouldRetry`
retries on any `IOException`, so a non-transient TLS handshake failure is retried up
to the full backoff limit. Filed as #7915 (not addressed here).

Closes #7912