### PR TITLE
fix: make WatchRequestState.startedAtNs volatile (#7919)

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManager.java
@@ -101,7 +101,9 @@ public abstract class AbstractWatchManager<T extends HasMetadata> implements Wat
     final CompletableFuture<Void> ended = new CompletableFuture<>();
     final AtomicBoolean started = new AtomicBoolean();
     final AtomicBoolean messageReceived = new AtomicBoolean();
-    long startedAtNs;
+    // volatile: written in startWatch() after the volatile publication of latestRequestState and read
+    // on the WebSocket receive thread in watchEnded(); volatile guarantees that read sees the write.
+    volatile long startedAtNs;
   }
 
   private static final Logger logger = LoggerFactory.getLogger(AbstractWatchManager.class);
@@ -130,7 +132,7 @@ public abstract class AbstractWatchManager<T extends HasMetadata> implements Wat
 
   private final boolean receiveBookmarks;
 
-  @SuppressWarnings("java:S3077") // inner fields (AtomicBoolean, CompletableFuture) are thread-safe
+  @SuppressWarnings("java:S3077") // inner fields (AtomicBoolean, CompletableFuture, volatile long) are thread-safe
   volatile WatchRequestState latestRequestState;
   private final Map<Class<?>, Integer> endErrors = new ConcurrentHashMap<>();
   private AtomicInteger retryAfterSeconds = new AtomicInteger();

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManagerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManagerTest.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.URL;
@@ -296,6 +298,16 @@ class AbstractWatchManagerTest {
     assertThat(awm.isForceClosed()).isFalse();
     assertThat(state.reconnected.get()).isTrue();
     assertThat(watcher.closeWithCauseCount.get()).isEqualTo(0);
+  }
+
+  @Test
+  @DisplayName("WatchRequestState.startedAtNs is volatile so the receive thread sees the start thread's write")
+  void startedAtNsIsVolatile() throws NoSuchFieldException {
+    // startedAtNs is written in startWatch() after the volatile store of latestRequestState (so that
+    // publication does not cover it) and read on the WebSocket receive thread in watchEnded(); it must
+    // be volatile for that read to observe the write.
+    final Field startedAtNs = WatchRequestState.class.getDeclaredField("startedAtNs");
+    assertThat(Modifier.isVolatile(startedAtNs.getModifiers())).isTrue();
   }
 
   @Test


### PR DESCRIPTION
Follow-up cleanup from #7898 (the #7896 GKE stale-resourceVersion fix).

`WatchRequestState.startedAtNs` was a non-volatile `long` written in `startWatch()` *after* the volatile publication of `latestRequestState`:

    latestRequestState = new WatchRequestState();        // volatile store publishes the reference
    latestRequestState.startedAtNs = System.nanoTime();  // plain write, happens-after the publish

The happens-before edge of the volatile store only covers writes that precede it in program order, so it does not publish the later `startedAtNs` write. The WebSocket receive thread that reads it in `watchEnded()` could therefore observe a stale `0`, making `connectionAgeNs = System.nanoTime() - 0` a meaningless value that could either skip the GKE stale-rv guard or fire it spuriously.

Making the field `volatile` gives the write release semantics and the read acquire semantics, so the receive thread always observes the start time. The `@SuppressWarnings("java:S3077")` rationale on `latestRequestState` is updated to enumerate the new field.

Severity is low/latent: the race is masked by an incidental happens-before from `start()` on most HTTP client implementations and never reproduces on x86, so this is hardening rather than a fix for observed behaviour.

No CHANGELOG entry: `startedAtNs` was introduced in #7898 within the unreleased 7.8-SNAPSHOT cycle, so no released version ever shipped the bug.

Closes #7919