### PR TITLE
fix: move first-connection JDK TLS initialization off the Vert.x event loop

### DIFF
--- a/httpclient-vertx-5/src/main/java/io/fabric8/kubernetes/client/vertx5/Vertx5HttpClientBuilder.java
+++ b/httpclient-vertx-5/src/main/java/io/fabric8/kubernetes/client/vertx5/Vertx5HttpClientBuilder.java
@@ -19,6 +19,8 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.http.HttpClient;
 import io.fabric8.kubernetes.client.http.StandardHttpClientBuilder;
 import io.fabric8.kubernetes.client.http.TlsVersion;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.file.FileSystemOptions;
@@ -62,6 +64,7 @@ public class Vertx5HttpClientBuilder<F extends HttpClient.Factory>
     extends StandardHttpClientBuilder<Vertx5HttpClient<F>, F, Vertx5HttpClientBuilder<F>> {
 
   private static final Logger logger = LoggerFactory.getLogger(Vertx5HttpClientBuilder.class);
+  private static final AtomicBoolean TLS_STACK_WARMED = new AtomicBoolean(false);
   private static final int MAX_CONNECTIONS = 8192;
 
   // the default for etcd seems to be 3 MB, but we'll default to unlimited, so we have the same behavior across clients
@@ -176,6 +179,7 @@ public class Vertx5HttpClientBuilder<F extends HttpClient.Factory>
 
     if (this.sslContext != null) {
       applyTlsOptions(httpOptions, protocols);
+      warmTlsStackOffEventLoop();
     }
 
     final WebSocketClientOptions wsOptions = createWebSocketClientOptions(protocols);
@@ -258,6 +262,31 @@ public class Vertx5HttpClientBuilder<F extends HttpClient.Factory>
       }
     }
     return vertx;
+  }
+
+  /**
+   * One-time, off-event-loop warm-up of the JDK TLS stack. Vert.x 5.1 materialises the
+   * client SslContext lazily on the event loop on the first handshake
+   * (ClientSslContextProvider.createClientContext), which loads
+   * JdkDefaultApplicationProtocolNegotiator and compiles SSL-path lambda forms — enough to
+   * trip BlockedThreadChecker on a cold/constrained JVM. Building and discarding a context
+   * here (on the caller's thread) loads those JVM-global classes first. Best-effort: must
+   * never fail client construction. See #7921. We cannot reuse the instance (unlike the
+   * Vert.x 4 module) because #7907 requires trust to flow through TrustOptions/KeyCertOptions,
+   * not a custom SslContextFactory. The provider is pinned to {@link SslProvider#JDK} so the
+   * warm-up loads the same classes the client's {@code JdkSSLEngineOptions} path uses, even
+   * when netty-tcnative is on the classpath (which would otherwise make the default provider
+   * OpenSSL and warm the wrong stack).
+   */
+  private static void warmTlsStackOffEventLoop() {
+    if (!TLS_STACK_WARMED.compareAndSet(false, true)) {
+      return;
+    }
+    try {
+      SslContextBuilder.forClient().sslProvider(SslProvider.JDK).build();
+    } catch (Exception e) {
+      logger.debug("TLS stack warm-up skipped: {}", e.getMessage());
+    }
   }
 
   /**

--- a/httpclient-vertx-5/src/test/java/io/fabric8/kubernetes/client/vertx5/Vertx5SslTest.java
+++ b/httpclient-vertx-5/src/test/java/io/fabric8/kubernetes/client/vertx5/Vertx5SslTest.java
@@ -89,6 +89,20 @@ class Vertx5SslTest {
   }
 
   @Test
+  @DisplayName("TLS warm-up is harmless and idempotent: two successive client builds both connect successfully")
+  void tlsWarmUpIsHarmlessAndIdempotent() throws Exception {
+    requestHandler = req -> req.response().end("OK");
+    for (int i = 0; i < 2; i++) {
+      try (HttpClient client = clientFactory.newBuilder().sslContext(null, trustManagers).build()) {
+        HttpRequest request = client.newHttpRequestBuilder().uri("https://localhost:" + port).build();
+        HttpResponse<String> resp = client.sendAsync(request, String.class).get(10, TimeUnit.SECONDS);
+        assertEquals(200, resp.code());
+        assertEquals("OK", resp.bodyString());
+      }
+    }
+  }
+
+  @Test
   @DisplayName("HTTPS rejects an untrusted server certificate instead of falling back to a permissive trust")
   void httpsRejectsUntrustedCertificate() throws Exception {
     requestHandler = req -> req.response().end("OK");

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientBuilder.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientBuilder.java
@@ -20,6 +20,7 @@ import io.fabric8.kubernetes.client.http.HttpClient;
 import io.fabric8.kubernetes.client.http.StandardHttpClientBuilder;
 import io.fabric8.kubernetes.client.http.TlsVersion;
 import io.netty.handler.ssl.ApplicationProtocolConfig;
+import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.IdentityCipherSuiteFilter;
 import io.netty.handler.ssl.JdkSslContext;
 import io.vertx.core.Vertx;
@@ -126,6 +127,13 @@ public class VertxHttpClientBuilder<F extends HttpClient.Factory>
 
     if (this.sslContext != null) {
       options.setSsl(true);
+      // Build the Netty SslContext here, off the Vert.x event loop. Vert.x otherwise calls
+      // SslContextFactory.create() lazily on the event loop during the first handshake;
+      // returning a pre-built instance keeps that construction off the loop. See #7921.
+      final JdkSslContext jdkSslContext = new JdkSslContext(
+          sslContext, true, null, IdentityCipherSuiteFilter.INSTANCE,
+          ApplicationProtocolConfig.DISABLED, ClientAuth.NONE,
+          protocols, false);
       options.setSslEngineOptions(new JdkSSLEngineOptions() {
         @Override
         public JdkSSLEngineOptions copy() {
@@ -134,15 +142,7 @@ public class VertxHttpClientBuilder<F extends HttpClient.Factory>
 
         @Override
         public SslContextFactory sslContextFactory() {
-          return () -> new JdkSslContext(
-              sslContext,
-              true,
-              null,
-              IdentityCipherSuiteFilter.INSTANCE,
-              ApplicationProtocolConfig.DISABLED,
-              io.netty.handler.ssl.ClientAuth.NONE,
-              protocols,
-              false);
+          return () -> jdkSslContext;
         }
       });
     }

--- a/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientBuilderTest.java
+++ b/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientBuilderTest.java
@@ -18,6 +18,7 @@ package io.fabric8.kubernetes.client.vertx;
 import io.fabric8.kubernetes.client.http.HttpClient;
 import io.vertx.core.Vertx;
 import io.vertx.core.impl.VertxImpl;
+import io.vertx.core.net.JdkSSLEngineOptions;
 import io.vertx.ext.web.client.WebClientOptions;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.DisplayName;
@@ -91,6 +92,34 @@ class VertxHttpClientBuilderTest {
     assertThat(builder.vertx)
         .asInstanceOf(InstanceOfAssertFactories.type(VertxImpl.class))
         .returns(true, vi -> vi.closeFuture().isClosed());
+  }
+
+  @Nested
+  @DisplayName("SSL Context Construction")
+  class SslContextConstructionTests {
+
+    @Test
+    @DisplayName("JDK SslContext is built once at client-build time and reused, never constructed per connection")
+    void sslContextBuiltOnceAndReused() throws Exception {
+      final AtomicReference<WebClientOptions> captured = new AtomicReference<>();
+
+      VertxHttpClientFactory customFactory = new VertxHttpClientFactory() {
+        @Override
+        protected void additionalConfig(WebClientOptions options) {
+          captured.set(options);
+        }
+      };
+
+      try (HttpClient client = customFactory.newBuilder().sslContext(null, null).build()) {
+        assertThat(captured.get()).isNotNull();
+        JdkSSLEngineOptions engine = (JdkSSLEngineOptions) captured.get().getSslEngineOptions();
+        assertThat(engine).isNotNull();
+        assertThat(engine.sslContextFactory()).isNotNull();
+        assertThat(engine.sslContextFactory().create())
+            .isNotNull()
+            .isSameAs(engine.sslContextFactory().create());
+      }
+    }
   }
 
   @Nested


### PR DESCRIPTION
## Summary

Moves the first-connection JDK/Netty TLS initialization off the Vert.x event-loop thread in both Vert.x HTTP-client modules. Vert.x materializes the client `SslContext` lazily on the event loop during the first TLS handshake; on a cold or constrained JVM the one-time class loading (`JdkDefaultApplicationProtocolNegotiator`, SSL-path lambda forms) can exceed the 2000 ms `BlockedThreadChecker` threshold.

- **httpclient-vertx (Vert.x 4.5):** the module already supplies a custom `SslContextFactory`, so the `JdkSslContext` is now built once in `build()` (on the caller's thread) and that single instance is returned from the factory, instead of being constructed per `create()` call on the event loop. Netty `SslContext` is thread-safe and reusable, so this is behavior-preserving; the one intentional change is that a malformed `SSLContext` now fails at `build()` rather than on first connect.
- **httpclient-vertx-5 (Vert.x 5.1):** no custom `SslContextFactory` is reintroduced (that was removed in #7907 so trust flows through `TrustOptions`/`KeyCertOptions` for WebSocket-over-TLS). Instead the JDK TLS class-loading path is warmed once per JVM by building and discarding a throwaway `SslContext` during `build()`. Best-effort: it never fails client construction.

## Scope

This covers the SSL-context construction leg surfaced while investigating #7921. The remaining first-connection costs the reporter observed (Netty DNS `DefaultAddressResolverGroup.newResolver` and `LambdaForm.compileToBytecode` on `NetClientImpl.connectInternal2`) are generic JVM/Netty warm-up paid by any Vert.x app, not fabric8-specific, and are out of scope. **#7921 stays open** for the remaining vertx-5 investigation: the reporter's latest traces point at `SslContext.newHandler` / `SslHandler.handlerAdded`, which this warm-up does not cover.

Fixes #7922

## Tests

- vertx-4: existing self-signed TLS round-trip (`SslTest`) stays green; new mock-free contract test asserts the `JdkSslContext` is built once and reused (`sslContextFactory().create()` returns the same instance), which fails if per-connection construction is restored.
- vertx-5: existing `Vertx5SslTest` / `Vertx5MutualTlsTest` / `Vertx5WebSocketTlsTest` stay green (the warm-up neither breaks trust nor throws); new test builds a TLS client twice and runs real HTTPS round-trips to confirm the warm-up is harmless and idempotent.

`BlockedThreadChecker` timing is too flaky to gate in CI; confirming the warning disappears under the constrained-container recipe is a manual step.
