### PR TITLE
chore(deps): hold swagger-request-validator on its 2.x line

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,10 @@ updates:
   # JUnit 6 raises the runtime baseline to Java 17; we still target Java 11.
   - dependency-name: "org.junit*:*"
     update-types: ["version-update:semver-major"]
+  # swagger-request-validator 3.x raises the runtime baseline to Java 21 (and
+  # renames the artifacts to openapi-request-validator-*); we still target Java 11.
+  - dependency-name: "com.atlassian.oai:*"
+    update-types: ["version-update:semver-major"]
   groups:
     bouncycastle:
       patterns:


### PR DESCRIPTION
`swagger-request-validator` 3.0.0 bumps its runtime baseline to Java 21
(`maven.compiler.release = 21`) and renames its artifacts from
`swagger-request-validator-*` to `openapi-request-validator-*`. Since the
project still targets Java 11, the `kubernetes-model-validator` module fails
to compile against the 3.x bytecode (`class file has wrong version 65.0,
should be 55.0`).

This mirrors the existing ignore rules for `io.vertx:*` and `org.junit*:*`,
holding `com.atlassian.oai:*` on its latest compatible 2.x release. 2.46.1 is
already the newest 2.x version, so no version change is needed.

Supersedes #7859, which Dependabot will close automatically on its next run
once the major update is ignored.