### PR TITLE
docs: add java-generator option examples for the remaining tunables

### DIFF
--- a/doc/java-generation-from-CRD.md
+++ b/doc/java-generation-from-CRD.md
@@ -457,6 +457,166 @@ public class Toy implements HasMetadata {
 }
 ```
 
+#### 6. Extra Annotations (Lombok / Sundrio)
+
+Defaults to `false`. When enabled, the generated classes are decorated with extra Lombok and [Sundrio](https://github.com/sundrio/sundrio) annotations and made editable through a generated builder. This option requires the additional dependencies and annotation processor configuration described in the [Quick start Maven](#quick-start-maven) / [Quick start Gradle](#quick-start-gradle) sections above and in [Annotation processor configuration for `extraAnnotations`](#annotation-processor-configuration-for-extraannotations) below.
+
+**Maven:**
+
+```xml
+<configuration>
+  <extraAnnotations>true</extraAnnotations>
+</configuration>
+```
+
+**Gradle:**
+
+```groovy
+javaGen {
+  extraAnnotations = true
+}
+```
+
+**CLI:**
+
+```bash
+--add-extra-annotations
+```
+
+**Generated Code (with `extraAnnotations = true`):**
+
+```java
+@lombok.ToString
+@lombok.EqualsAndHashCode
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class)
+    // ...
+})
+public class ToySpec implements io.fabric8.kubernetes.api.builder.Editable<ToySpecBuilder>, KubernetesResource {
+
+    @Override
+    public ToySpecBuilder edit() {
+        return new ToySpecBuilder(this);
+    }
+    // ...
+}
+```
+
+#### 7. Generated Annotations
+
+Defaults to `true`, which emits the `@javax.annotation.processing.Generated` annotation on the generated types. Set to `false` to omit it.
+
+**Maven:**
+
+```xml
+<configuration>
+  <generatedAnnotations>false</generatedAnnotations>
+</configuration>
+```
+
+**Gradle:**
+
+```groovy
+javaGen {
+  generatedAnnotations = false
+}
+```
+
+**CLI:**
+
+The annotation is emitted by default. To suppress it from the CLI, use the (hidden) skip flag:
+
+```bash
+--skip-generated-annotations
+```
+
+**Generated Code (default — annotation emitted):**
+
+```java
+@javax.annotation.processing.Generated("io.fabric8.java.generator.CRGeneratorRunner")
+public class ToySpec implements KubernetesResource {
+    // ...
+}
+```
+
+**Generated Code (with `generatedAnnotations = false`):**
+
+```java
+public class ToySpec implements KubernetesResource {
+    // ...
+}
+```
+
+#### 8. DateTime Serialization Format
+
+Sets the date/time pattern used when serializing fields of type `date-time`. Defaults to `yyyy-MM-dd'T'HH:mm:ssXXX`. The pattern is applied as a `@com.fasterxml.jackson.annotation.JsonFormat` annotation on the generated getter.
+
+**Maven:**
+
+```xml
+<configuration>
+  <datetimeSerializationFormat>yyyy-MM-dd'T'HH:mm:ss.SSSXXX</datetimeSerializationFormat>
+</configuration>
+```
+
+**Gradle:**
+
+```groovy
+javaGen {
+  serializationDatetimeFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
+}
+```
+
+**CLI:**
+
+```bash
+--serialization-datetime-format="yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
+```
+
+**Generated Code (for a CRD field of format `date-time`):**
+
+```java
+@com.fasterxml.jackson.annotation.JsonFormat(shape = com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+public java.time.ZonedDateTime getCreatedAt() {
+    return createdAt;
+}
+```
+
+#### 9. DateTime Deserialization Format
+
+Sets the date/time pattern used when deserializing fields of type `date-time`. Defaults to `yyyy-MM-dd'T'HH:mm:ssXXX`. The pattern is applied as a `@com.fasterxml.jackson.annotation.JsonFormat` annotation on the generated setter.
+
+**Maven:**
+
+```xml
+<configuration>
+  <datetimeDeserializationFormat>yyyy-MM-dd'T'HH:mm:ss.SSSXXX</datetimeDeserializationFormat>
+</configuration>
+```
+
+**Gradle:**
+
+```groovy
+javaGen {
+  deserializationDatetimeFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
+}
+```
+
+**CLI:**
+
+```bash
+--deserialization-datetime-format="yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
+```
+
+**Generated Code (for a CRD field of format `date-time`):**
+
+```java
+@com.fasterxml.jackson.annotation.JsonFormat(shape = com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+public void setCreatedAt(java.time.ZonedDateTime createdAt) {
+    this.createdAt = createdAt;
+}
+```
+
 
 ## Compiling the generated code
 


### PR DESCRIPTION
## Summary

Adds Configuration Examples subsections to `doc/java-generation-from-CRD.md` for the four java-generator options that were left without examples after PR #7383:

- `extraAnnotations` (`--add-extra-annotations`)
- `generatedAnnotations`
- `datetimeSerializationFormat` (`--serialization-datetime-format`)
- `datetimeDeserializationFormat` (`--deserialization-datetime-format`)

Each subsection follows the existing pattern: Maven config, Gradle config, CLI invocation, and a generated-code snippet showing the effect. The `extraAnnotations` subsection cross-links the existing Maven/Gradle dependency and annotation-processor sections in the same doc.

## Why this matters

Issue #5285 asked for usage examples of the java-generator options. PR #7383 covered the first five (`enumUppercase`, `packageOverrides`, `alwaysPreserveUnknown`, `filesSuffixes`, `existingJavaTypes`), and manusa deliberately kept the issue open for these four remaining options. This completes that already-scoped follow-up so every documented option now has an example.

## Testing

Docs-only change. Each option was verified against the generator source rather than assumed:

- `extraAnnotations` default `false`; the emitted `@lombok.ToString`, `@lombok.EqualsAndHashCode`, and `@io.sundr.builder.annotations.Buildable(...)` annotations plus the `Editable`/`edit()` wiring come from `java-generator/core/.../nodes/JObjectExtraAnnotations.java`.
- `generatedAnnotations` default `true` (annotation emitted by default); the exact `@javax.annotation.processing.Generated("io.fabric8.java.generator.CRGeneratorRunner")` form comes from `AbstractJSONSchema2Pojo.newGeneratedAnnotation()`. The CLI exposes only the hidden `--skip-generated-annotations` flag to suppress it (it is `hidden = true`, which is why it does not appear in the `--help` output), so the CLI example documents that flag rather than a positive one.
- `datetimeSerializationFormat` / `datetimeDeserializationFormat` default `yyyy-MM-dd'T'HH:mm:ssXXX`; the `@com.fasterxml.jackson.annotation.JsonFormat(shape = ...Shape.STRING, pattern = "...")` annotation on the getter (serialization) and setter (deserialization) comes from `java-generator/core/.../nodes/JObject.java`.

Option keys, CLI flags, and Gradle property names were confirmed against `Config.java`, `GenerateJavaSources.java`, `JavaGeneratorMojo.java`, and `JavaGeneratorPluginExtension.java`. Code fences are balanced and the cross-links resolve to in-doc anchors.

Fixes #5285
