### PR TITLE
feat: add opt-in TLS warm-up for the Vert.x HTTP clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Fix #7875: bump vertx5.version from 5.0.12 to 5.1.1, adapting httpclient-vertx-5 to Vert.x 5.1 behaviour changes (SSL engine options no longer accept an empty protocol array; request-body stream errors are reset with HTTP/2 CANCEL so they are not retried as transient IOExceptions)
 
 #### New Features
+* Fix #7926: (httpclient-vertx-5, httpclient-vertx) opt-in TLS warm-up on the Vert.x HTTP client factory. `Vertx5HttpClientFactory`/`VertxHttpClientFactory` now expose `setTlsWarmup(TlsWarmup)` with modes `OFF`, `CONTEXT` (default, unchanged) and `FULL`. `FULL` runs a synchronous, once-per-JVM, throwaway loopback TLS handshake off the event loop when the client is built, so the first real connection no longer blocks the event loop on the one-time JDK/Netty TLS class loading — for users on cold or hard-CPU-throttled JVMs hitting the first-connection block/timeout described in #7921. Default behavior is unchanged; see the FAQ for CDS and pod CPU-sizing guidance for hard-throttled pods
 * Fix #5084: Jbang scripts to generate graalVM metadata
 * Fix #7375: (crd-generator) Support @JsonClassDescription for adding descriptions to classes in the generated CRD schema.
 

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -69,6 +69,34 @@ If you would rather take full control over the threading use KubernetesClientBui
 
 Finally, the fabric8 client will use 1 thread per PortForward and an additional thread per socket connection - this may be improved upon in the future.
 
+### Why does the first HTTPS request block / time out on a cold or CPU-throttled JVM?
+
+With the Vert.x HTTP clients (the default `kubernetes-httpclient-vertx` and `kubernetes-httpclient-vertx-5`), the Netty `SslContext`, `SslHandler` and `SSLEngine` are materialized lazily on the Vert.x event loop on the **first** TLS connection.
+On a cold JVM this pays the one-time class loading of the entire JDK/Netty TLS stack plus the first handshake on the event loop.
+On a healthy host this is fast, but on a JVM that is starting cold under heavy CPU throttling (for example a Kubernetes pod with a low CPU `limit`) it can take several seconds, trip Vert.x's `BlockedThreadChecker`, and in the worst case exceed the connect timeout so the first request fails.
+
+By default the client already builds and discards an SSL context off the event loop at client-construction time (`TlsWarmup.CONTEXT`), which removes about half of that first-connection cost.
+If you are still seeing first-connection blocking or timeouts under hard CPU throttling, you can opt in to a more complete warm-up that runs a throwaway loopback TLS handshake off the event loop, once per JVM, when the client is built:
+
+```java
+// Vert.x 5 client (kubernetes-httpclient-vertx-5)
+Vertx5HttpClientFactory factory = new Vertx5HttpClientFactory();
+factory.setTlsWarmup(TlsWarmup.FULL);
+KubernetesClient client = new KubernetesClientBuilder().withHttpClientFactory(factory).build();
+```
+
+`TlsWarmup.FULL` runs **synchronously**, so client construction takes longer (sub-second on a healthy host, a few seconds under hard throttling) but the first real connection no longer blocks the event loop, which deterministically prevents the first-connection timeout.
+Because it blocks the building thread, build a `FULL`-configured client from a regular (startup) thread, not from inside a Vert.x event-loop callback.
+It is best-effort and bounded: the bind and handshake share an overall deadline of roughly 30 seconds, after which the warm-up gives up and the client falls back to the default behavior (this also covers a restricted environment that blocks the loopback bind), so it never blocks startup indefinitely.
+`TlsWarmup.OFF` disables the warm-up entirely.
+The same setting is available on `VertxHttpClientFactory` for the Vert.x 4 client.
+
+> [!NOTE]
+> A warm-up only **relocates** the one-time TLS work off the event loop and off your first request; it cannot make a CPU-starved JVM faster.
+> Under a hard CPU cap the levers that actually reduce the work or raise the budget are:
+> - **Class Data Sharing (CDS)** — an AppCDS / dynamic CDS archive shrinks the class-loading slice (and on Java 24+ the AOT cache, `-XX:AOTCache`, additionally attacks the JIT slice CDS cannot). These are JVM launch flags, so they compose with the warm-up above.
+> - **Pod CPU sizing** — right-size the pod CPU `requests`/`limits` and enable the Kubernetes startup CPU boost so the JVM has more CPU available during startup.
+
 ### What additional logging is available?
 
 Like many Java application the Fabric8 Client utilizes [slf4j](https://www.slf4j.org/).

--- a/httpclient-vertx-5/src/main/java/io/fabric8/kubernetes/client/vertx5/TlsWarmup.java
+++ b/httpclient-vertx-5/src/main/java/io/fabric8/kubernetes/client/vertx5/TlsWarmup.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.vertx5;
+
+/**
+ * Controls how aggressively the Vert.x HTTP client warms up the JDK/Netty TLS stack off the
+ * Vert.x event loop when a client is built.
+ *
+ * <p>
+ * Vert.x materialises the Netty {@code SslContext}, the {@code SslHandler} and the {@code SSLEngine}
+ * lazily on the event loop on the first TLS connection, which on a cold or CPU-throttled JVM pays
+ * the one-time class loading of the entire TLS stack on the loop and can trip the
+ * {@code BlockedThreadChecker} (or, under hard throttling, the connect timeout). Warming the stack
+ * once per JVM off the event loop relocates that cost. See
+ * <a href="https://github.com/fabric8io/kubernetes-client/issues/7926">fabric8io/kubernetes-client#7926</a>.
+ *
+ * <p>
+ * The mode is configured programmatically on the Vert.x HTTP client factory, for example:
+ *
+ * <pre>{@code
+ * Vertx5HttpClientFactory factory = new Vertx5HttpClientFactory();
+ * factory.setTlsWarmup(TlsWarmup.FULL);
+ * KubernetesClient client = new KubernetesClientBuilder().withHttpClientFactory(factory).build();
+ * }</pre>
+ */
+public enum TlsWarmup {
+
+  /**
+   * No warm-up. The TLS stack is materialised lazily by Vert.x on the event loop on the first
+   * connection (the behaviour before #7922).
+   */
+  OFF,
+
+  /**
+   * Build and discard a Netty {@code SslContext} on the building thread (the default). This loads
+   * the SSL engine and cipher catalogue off the event loop but not the {@code SslHandler}/handshake
+   * classes. This is the behaviour introduced in #7922 and is sufficient for most environments.
+   */
+  CONTEXT,
+
+  /**
+   * Run a complete throwaway loopback TLS handshake on the building thread, once per JVM. A tiny
+   * self-signed HTTPS server is stood up on {@code 127.0.0.1}, one client handshake is driven
+   * against it and both are torn down. This warms the full Netty + JDK TLS class path and the
+   * Vert.x connect path, so the first real connection no longer blocks the event loop. It runs
+   * synchronously, adding the warm-up cost to client construction (sub-second on a healthy host, a
+   * few seconds under hard CPU throttling), which is the explicit trade opt-in users make to avoid
+   * a first-connection timeout. The bind and handshake are bounded by a single overall deadline
+   * (about 30 seconds), after which the warm-up gives up and falls back rather than blocking for
+   * long; because it blocks the building thread, do not build a {@code FULL}-configured client from
+   * a Vert.x event-loop thread. Best-effort: if the warm-up cannot run (for example a blocked
+   * loopback bind), the client falls back to {@link #CONTEXT}.
+   */
+  FULL
+}

--- a/httpclient-vertx-5/src/main/java/io/fabric8/kubernetes/client/vertx5/Vertx5HttpClientBuilder.java
+++ b/httpclient-vertx-5/src/main/java/io/fabric8/kubernetes/client/vertx5/Vertx5HttpClientBuilder.java
@@ -24,6 +24,10 @@ import io.netty.handler.ssl.SslProvider;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.file.FileSystemOptions;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.http.PoolOptions;
 import io.vertx.core.http.WebSocketClientOptions;
@@ -31,12 +35,14 @@ import io.vertx.core.net.JdkSSLEngineOptions;
 import io.vertx.core.net.KeyCertOptions;
 import io.vertx.core.net.ProxyOptions;
 import io.vertx.core.net.ProxyType;
+import io.vertx.core.net.SelfSignedCertificate;
 import io.vertx.core.net.TCPSSLOptions;
 import io.vertx.core.net.TrustOptions;
 import io.vertx.ext.web.client.WebClientOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.concurrent.TimeUnit;
@@ -64,8 +70,14 @@ public class Vertx5HttpClientBuilder<F extends HttpClient.Factory>
     extends StandardHttpClientBuilder<Vertx5HttpClient<F>, F, Vertx5HttpClientBuilder<F>> {
 
   private static final Logger logger = LoggerFactory.getLogger(Vertx5HttpClientBuilder.class);
-  private static final AtomicBoolean TLS_STACK_WARMED = new AtomicBoolean(false);
+  private static final AtomicBoolean TLS_CONTEXT_WARMED = new AtomicBoolean(false);
+  private static final AtomicBoolean TLS_FULL_WARMED = new AtomicBoolean(false);
   private static final int MAX_CONNECTIONS = 8192;
+  private static final String LOOPBACK_HOST = "127.0.0.1";
+  // Single overall deadline for the warm-up's useful work (bind + handshake) so the synchronous stall
+  // on build() is bounded to roughly this, not multiplied per phase. Teardown gets its own short budget.
+  private static final long WARMUP_TIMEOUT_SECONDS = 30;
+  private static final long WARMUP_CLOSE_TIMEOUT_SECONDS = 10;
 
   // the default for etcd seems to be 3 MB, but we'll default to unlimited, so we have the same behavior across clients
   private static final int MAX_WS_MESSAGE_SIZE = Integer.MAX_VALUE;
@@ -179,7 +191,7 @@ public class Vertx5HttpClientBuilder<F extends HttpClient.Factory>
 
     if (this.sslContext != null) {
       applyTlsOptions(httpOptions, protocols);
-      warmTlsStackOffEventLoop();
+      warmTlsStack();
     }
 
     final WebSocketClientOptions wsOptions = createWebSocketClientOptions(protocols);
@@ -242,6 +254,13 @@ public class Vertx5HttpClientBuilder<F extends HttpClient.Factory>
 
   /** Creates Vert.x instance with DNS resolver disabled to prevent Vault resolution issues. */
   private static Vertx createVertxInstance() {
+    return createVertxInstance(new VertxOptions()
+        .setFileSystemOptions(new FileSystemOptions().setFileCachingEnabled(false).setClassPathResolvingEnabled(false))
+        .setUseDaemonThread(true));
+  }
+
+  /** Creates a Vert.x instance from the given options with the async DNS resolver disabled. */
+  private static Vertx createVertxInstance(final VertxOptions options) {
     // We must disable the async DNS resolver as it can cause issues when resolving the Vault instance.
     // This is done using the DISABLE_DNS_RESOLVER_PROP_NAME system property.
     // The DNS resolver used by vert.x is configured during the (synchronous) initialization.
@@ -250,9 +269,7 @@ public class Vertx5HttpClientBuilder<F extends HttpClient.Factory>
     Vertx vertx;
     try {
       System.setProperty(DISABLE_DNS_RESOLVER.name, "true");
-      vertx = Vertx.vertx(new VertxOptions()
-          .setFileSystemOptions(new FileSystemOptions().setFileCachingEnabled(false).setClassPathResolvingEnabled(false))
-          .setUseDaemonThread(true));
+      vertx = Vertx.vertx(options);
     } finally {
       // Restore the original value
       if (originalValue == null) {
@@ -265,8 +282,31 @@ public class Vertx5HttpClientBuilder<F extends HttpClient.Factory>
   }
 
   /**
-   * One-time, off-event-loop warm-up of the JDK TLS stack. Vert.x 5.1 materialises the
-   * client SslContext lazily on the event loop on the first handshake
+   * Dispatches the configured {@link TlsWarmup} mode read off the (typed) client factory. Done the
+   * same way as {@link Vertx5HttpClientFactory#additionalConfig}: only honoured when the factory is
+   * a {@link Vertx5HttpClientFactory}, otherwise the default {@link TlsWarmup#CONTEXT} applies.
+   */
+  private void warmTlsStack() {
+    TlsWarmup mode = TlsWarmup.CONTEXT;
+    if (clientFactory instanceof Vertx5HttpClientFactory) {
+      mode = ((Vertx5HttpClientFactory) clientFactory).getTlsWarmup();
+    }
+    switch (mode) {
+      case OFF:
+        return;
+      case FULL:
+        warmTlsStackFull();
+        break;
+      case CONTEXT:
+      default:
+        warmTlsStackContext();
+        break;
+    }
+  }
+
+  /**
+   * One-time, off-event-loop warm-up of the JDK TLS stack ({@link TlsWarmup#CONTEXT}, the default).
+   * Vert.x 5.1 materialises the client SslContext lazily on the event loop on the first handshake
    * (ClientSslContextProvider.createClientContext), which loads
    * JdkDefaultApplicationProtocolNegotiator and compiles SSL-path lambda forms — enough to
    * trip BlockedThreadChecker on a cold/constrained JVM. Building and discarding a context
@@ -278,8 +318,9 @@ public class Vertx5HttpClientBuilder<F extends HttpClient.Factory>
    * when netty-tcnative is on the classpath (which would otherwise make the default provider
    * OpenSSL and warm the wrong stack).
    */
-  private static void warmTlsStackOffEventLoop() {
-    if (!TLS_STACK_WARMED.compareAndSet(false, true)) {
+  private static void warmTlsStackContext() {
+    // A full handshake already warms a superset of the context, so skip if FULL ran first.
+    if (TLS_FULL_WARMED.get() || !TLS_CONTEXT_WARMED.compareAndSet(false, true)) {
       return;
     }
     try {
@@ -287,6 +328,111 @@ public class Vertx5HttpClientBuilder<F extends HttpClient.Factory>
     } catch (Exception e) {
       logger.debug("TLS stack warm-up skipped: {}", e.getMessage());
     }
+  }
+
+  /**
+   * One-time, off-event-loop warm-up that drives a complete throwaway loopback TLS handshake
+   * ({@link TlsWarmup#FULL}). The {@link TlsWarmup#CONTEXT} warm-up leaves the {@code SslHandler}
+   * creation and the handshake {@code wrap}/{@code unwrap} (the bulk of the one-time TLS class
+   * loading) on the event loop on the first connection; under hard CPU throttling that residual can
+   * still exceed the connect timeout. Running a real handshake against a self-signed loopback server
+   * here warms the full Netty + JDK TLS class path and the Vert.x connect/DNS path, so the first
+   * real connection no longer blocks the loop. Runs synchronously on the building thread (the
+   * explicit trade opt-in users make). Best-effort: any failure falls back to the context warm-up.
+   * See #7926.
+   */
+  private static void warmTlsStackFull() {
+    if (!TLS_FULL_WARMED.compareAndSet(false, true)) {
+      return;
+    }
+    // A full handshake subsumes the context-only warm-up; mark it done so a later CONTEXT build is a no-op.
+    TLS_CONTEXT_WARMED.set(true);
+    try {
+      loopbackTlsHandshake();
+    } catch (Exception e) {
+      logger.debug("Full TLS stack warm-up skipped, falling back to context warm-up: {}", e.getMessage());
+      try {
+        SslContextBuilder.forClient().sslProvider(SslProvider.JDK).build();
+      } catch (Exception ignore) {
+        // best-effort: warm-up must never fail client construction
+      }
+    }
+  }
+
+  /**
+   * Stands up a self-signed HTTPS server on a loopback ephemeral port, performs one client TLS
+   * handshake against it and tears both down, on a disposable Vert.x instance created with the same
+   * DNS-resolver setting as the real client so the same classes are loaded. The trust-all manager is
+   * scoped to this throwaway client and never touches real traffic.
+   */
+  private static void loopbackTlsHandshake() throws Exception {
+    final long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(WARMUP_TIMEOUT_SECONDS);
+    final Vertx warmVertx = createVertxInstance(new VertxOptions()
+        .setEventLoopPoolSize(1)
+        .setUseDaemonThread(true)
+        // The warm-up deliberately drives a TLS handshake on this throwaway event loop, which is exactly
+        // the work we are relocating off the real loop. Relax the blocked-thread checker so the warm-up
+        // does not emit alarming "thread blocked" warnings in the user's logs under CPU throttling.
+        .setBlockedThreadCheckInterval(WARMUP_TIMEOUT_SECONDS).setBlockedThreadCheckIntervalUnit(TimeUnit.SECONDS)
+        .setMaxEventLoopExecuteTime(WARMUP_TIMEOUT_SECONDS).setMaxEventLoopExecuteTimeUnit(TimeUnit.SECONDS));
+    SelfSignedCertificate certificate = null;
+    try {
+      certificate = SelfSignedCertificate.create();
+      final HttpServer server = warmVertx
+          .createHttpServer(new HttpServerOptions()
+              .setSsl(true)
+              .setKeyCertOptions(certificate.keyCertOptions())
+              .setHost(LOOPBACK_HOST)
+              .setPort(0))
+          .requestHandler(req -> req.response().end("ok"));
+      server.listen().toCompletionStage().toCompletableFuture()
+          .get(remainingMillis(deadlineNanos), TimeUnit.MILLISECONDS);
+      final int port = server.actualPort();
+      final HttpClientOptions clientOptions = new HttpClientOptions()
+          .setSsl(true)
+          .setSslEngineOptions(new JdkSSLEngineOptions())
+          .setTrustOptions(TrustOptions.wrap(trustAllManager()));
+      final io.vertx.core.http.HttpClient warmClient = warmVertx.createHttpClient(clientOptions);
+      warmClient.request(HttpMethod.GET, port, LOOPBACK_HOST, "/")
+          .compose(req -> req.send())
+          .compose(resp -> resp.body())
+          .toCompletionStage().toCompletableFuture()
+          .get(remainingMillis(deadlineNanos), TimeUnit.MILLISECONDS);
+    } finally {
+      try {
+        warmVertx.close().toCompletionStage().toCompletableFuture().get(WARMUP_CLOSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      } finally {
+        // Remove the throwaway self-signed cert/key temp files now rather than relying on deleteOnExit.
+        if (certificate != null) {
+          certificate.delete();
+        }
+      }
+    }
+  }
+
+  /** Milliseconds left until the warm-up deadline, floored at 1 so a {@code get} never waits indefinitely. */
+  private static long remainingMillis(final long deadlineNanos) {
+    return Math.max(1L, (deadlineNanos - System.nanoTime()) / 1_000_000L);
+  }
+
+  /** Trust-all manager used solely by the throwaway loopback warm-up client; never used for real traffic. */
+  private static X509TrustManager trustAllManager() {
+    return new X509TrustManager() {
+      @Override
+      public void checkClientTrusted(X509Certificate[] chain, String authType) {
+        // no-op: throwaway warm-up only
+      }
+
+      @Override
+      public void checkServerTrusted(X509Certificate[] chain, String authType) {
+        // no-op: throwaway warm-up only
+      }
+
+      @Override
+      public X509Certificate[] getAcceptedIssuers() {
+        return new X509Certificate[0];
+      }
+    };
   }
 
   /**

--- a/httpclient-vertx-5/src/main/java/io/fabric8/kubernetes/client/vertx5/Vertx5HttpClientFactory.java
+++ b/httpclient-vertx-5/src/main/java/io/fabric8/kubernetes/client/vertx5/Vertx5HttpClientFactory.java
@@ -42,6 +42,7 @@ public class Vertx5HttpClientFactory implements HttpClient.Factory {
   private static final String VERTX5_MARKER_CLASS = "io.vertx.core.impl.SysProps";
 
   final Vertx vertx;
+  private volatile TlsWarmup tlsWarmup = TlsWarmup.CONTEXT;
 
   /**
    * Return a factory that reuses the supplied Vert.x instance.
@@ -110,5 +111,24 @@ public class Vertx5HttpClientFactory implements HttpClient.Factory {
   protected void additionalConfig(WebClientOptions webClientOptions, WebSocketClientOptions wsOptions,
       PoolOptions poolOptions) {
     // no default implementation
+  }
+
+  /**
+   * Returns the configured {@link TlsWarmup} mode (never {@code null}).
+   *
+   * @return the TLS warm-up mode applied when building TLS-enabled clients
+   */
+  public TlsWarmup getTlsWarmup() {
+    return tlsWarmup;
+  }
+
+  /**
+   * Configures how the TLS stack is warmed up off the Vert.x event loop when a TLS-enabled client
+   * is built. See {@link TlsWarmup} for the trade-offs of each mode.
+   *
+   * @param tlsWarmup the warm-up mode; {@code null} resets it to the default {@link TlsWarmup#CONTEXT}
+   */
+  public void setTlsWarmup(TlsWarmup tlsWarmup) {
+    this.tlsWarmup = tlsWarmup == null ? TlsWarmup.CONTEXT : tlsWarmup;
   }
 }

--- a/httpclient-vertx-5/src/test/java/io/fabric8/kubernetes/client/vertx5/Vertx5SslTest.java
+++ b/httpclient-vertx-5/src/test/java/io/fabric8/kubernetes/client/vertx5/Vertx5SslTest.java
@@ -103,6 +103,62 @@ class Vertx5SslTest {
   }
 
   @Test
+  @DisplayName("TLS warm-up defaults to CONTEXT so existing clients keep the #7922 build-time warm-up unchanged")
+  void tlsWarmupDefaultsToContext() {
+    assertEquals(TlsWarmup.CONTEXT, new Vertx5HttpClientFactory().getTlsWarmup());
+  }
+
+  @Test
+  @DisplayName("A null TLS warm-up mode falls back to CONTEXT rather than disabling the warm-up")
+  void tlsWarmupSetterRejectsNull() {
+    final Vertx5HttpClientFactory factory = new Vertx5HttpClientFactory();
+    factory.setTlsWarmup(null);
+    assertEquals(TlsWarmup.CONTEXT, factory.getTlsWarmup());
+  }
+
+  @Test
+  @DisplayName("setTlsWarmup round-trips each mode (OFF, CONTEXT, FULL) through getTlsWarmup")
+  void tlsWarmupRoundTripsAllModes() {
+    final Vertx5HttpClientFactory factory = new Vertx5HttpClientFactory();
+    factory.setTlsWarmup(TlsWarmup.OFF);
+    assertEquals(TlsWarmup.OFF, factory.getTlsWarmup());
+    factory.setTlsWarmup(TlsWarmup.FULL);
+    assertEquals(TlsWarmup.FULL, factory.getTlsWarmup());
+    factory.setTlsWarmup(TlsWarmup.CONTEXT);
+    assertEquals(TlsWarmup.CONTEXT, factory.getTlsWarmup());
+  }
+
+  @Test
+  @DisplayName("FULL TLS warm-up is harmless and idempotent: two successive FULL client builds both connect over HTTPS")
+  void fullTlsWarmupIsHarmlessAndIdempotent() throws Exception {
+    requestHandler = req -> req.response().end("OK");
+    final Vertx5HttpClientFactory factory = new Vertx5HttpClientFactory();
+    factory.setTlsWarmup(TlsWarmup.FULL);
+    for (int i = 0; i < 2; i++) {
+      try (HttpClient client = factory.newBuilder().sslContext(null, trustManagers).build()) {
+        HttpRequest request = client.newHttpRequestBuilder().uri("https://localhost:" + port).build();
+        HttpResponse<String> resp = client.sendAsync(request, String.class).get(30, TimeUnit.SECONDS);
+        assertEquals(200, resp.code());
+        assertEquals("OK", resp.bodyString());
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("OFF TLS warm-up skips warm-up entirely yet a client built with it still connects over HTTPS")
+  void offTlsWarmupClientConnectsOverHttps() throws Exception {
+    requestHandler = req -> req.response().end("OK");
+    final Vertx5HttpClientFactory factory = new Vertx5HttpClientFactory();
+    factory.setTlsWarmup(TlsWarmup.OFF);
+    try (HttpClient client = factory.newBuilder().sslContext(null, trustManagers).build()) {
+      HttpRequest request = client.newHttpRequestBuilder().uri("https://localhost:" + port).build();
+      HttpResponse<String> resp = client.sendAsync(request, String.class).get(10, TimeUnit.SECONDS);
+      assertEquals(200, resp.code());
+      assertEquals("OK", resp.bodyString());
+    }
+  }
+
+  @Test
   @DisplayName("HTTPS rejects an untrusted server certificate instead of falling back to a permissive trust")
   void httpsRejectsUntrustedCertificate() throws Exception {
     requestHandler = req -> req.response().end("OK");

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/TlsWarmup.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/TlsWarmup.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.vertx;
+
+/**
+ * Controls how aggressively the Vert.x HTTP client warms up the JDK/Netty TLS stack off the
+ * Vert.x event loop when a client is built.
+ *
+ * <p>
+ * Vert.x materialises the Netty {@code SslContext}, the {@code SslHandler} and the {@code SSLEngine}
+ * lazily on the event loop on the first TLS connection, which on a cold or CPU-throttled JVM pays
+ * the one-time class loading of the entire TLS stack on the loop and can trip the
+ * {@code BlockedThreadChecker} (or, under hard throttling, the connect timeout). Warming the stack
+ * once per JVM off the event loop relocates that cost. See
+ * <a href="https://github.com/fabric8io/kubernetes-client/issues/7926">fabric8io/kubernetes-client#7926</a>.
+ *
+ * <p>
+ * The mode is configured programmatically on the Vert.x HTTP client factory, for example:
+ *
+ * <pre>{@code
+ * VertxHttpClientFactory factory = new VertxHttpClientFactory();
+ * factory.setTlsWarmup(TlsWarmup.FULL);
+ * KubernetesClient client = new KubernetesClientBuilder().withHttpClientFactory(factory).build();
+ * }</pre>
+ */
+public enum TlsWarmup {
+
+  /**
+   * No warm-up. The Netty {@code JdkSslContext} is built lazily by Vert.x on the event loop on the
+   * first connection (the behaviour before #7922).
+   */
+  OFF,
+
+  /**
+   * Build the Netty {@code JdkSslContext} eagerly on the building thread and hand it to Vert.x (the
+   * default). This keeps the SSL context construction off the event loop. This is the behaviour
+   * introduced in #7922 and is sufficient for most environments.
+   */
+  CONTEXT,
+
+  /**
+   * In addition to the eager context pre-build of {@link #CONTEXT}, run a complete throwaway loopback
+   * TLS handshake on the building thread, once per JVM. A tiny self-signed HTTPS server is stood up
+   * on {@code 127.0.0.1}, one client handshake is driven against it and both are torn down. This
+   * warms the full Netty + JDK TLS class path and the Vert.x connect path, so the first real
+   * connection no longer blocks the event loop. It runs synchronously, adding the warm-up cost to
+   * client construction (sub-second on a healthy host, a few seconds under hard CPU throttling),
+   * which is the explicit trade opt-in users make to avoid a first-connection timeout. The bind and
+   * handshake are bounded by a single overall deadline (about 30 seconds), after which the warm-up
+   * gives up and falls back rather than blocking for long; because it blocks the building thread, do
+   * not build a {@code FULL}-configured client from a Vert.x event-loop thread. Best-effort: if the
+   * loopback handshake cannot run (for example a blocked loopback bind), the eager context pre-build
+   * of {@link #CONTEXT} still applies.
+   */
+  FULL
+}

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientBuilder.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientBuilder.java
@@ -26,20 +26,29 @@ import io.netty.handler.ssl.JdkSslContext;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.file.FileSystemOptions;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.net.JdkSSLEngineOptions;
 import io.vertx.core.net.ProxyOptions;
 import io.vertx.core.net.ProxyType;
+import io.vertx.core.net.SelfSignedCertificate;
+import io.vertx.core.net.TrustOptions;
 import io.vertx.core.spi.tls.SslContextFactory;
 import io.vertx.ext.web.client.WebClientOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
+
+import javax.net.ssl.X509TrustManager;
 
 import static io.fabric8.kubernetes.client.utils.HttpClientUtils.decodeBasicCredentials;
 import static io.vertx.core.spi.resolver.ResolverProvider.DISABLE_DNS_RESOLVER_PROP_NAME;
@@ -48,7 +57,13 @@ public class VertxHttpClientBuilder<F extends HttpClient.Factory>
     extends StandardHttpClientBuilder<VertxHttpClient<F>, F, VertxHttpClientBuilder<F>> {
 
   private static final Logger logger = LoggerFactory.getLogger(VertxHttpClientBuilder.class);
+  private static final AtomicBoolean TLS_FULL_WARMED = new AtomicBoolean(false);
   private static final int MAX_CONNECTIONS = 8192;
+  private static final String LOOPBACK_HOST = "127.0.0.1";
+  // Single overall deadline for the warm-up's useful work (bind + handshake) so the synchronous stall
+  // on build() is bounded to roughly this, not multiplied per phase. Teardown gets its own short budget.
+  private static final long WARMUP_TIMEOUT_SECONDS = 30;
+  private static final long WARMUP_CLOSE_TIMEOUT_SECONDS = 10;
   // the default for etcd seems to be 3 MB, but we'll default to unlimited, so we have the same behavior across clients
   private static final int MAX_WS_MESSAGE_SIZE = Integer.MAX_VALUE;
 
@@ -127,13 +142,18 @@ public class VertxHttpClientBuilder<F extends HttpClient.Factory>
 
     if (this.sslContext != null) {
       options.setSsl(true);
-      // Build the Netty SslContext here, off the Vert.x event loop. Vert.x otherwise calls
-      // SslContextFactory.create() lazily on the event loop during the first handshake;
-      // returning a pre-built instance keeps that construction off the loop. See #7921.
-      final JdkSslContext jdkSslContext = new JdkSslContext(
-          sslContext, true, null, IdentityCipherSuiteFilter.INSTANCE,
-          ApplicationProtocolConfig.DISABLED, ClientAuth.NONE,
-          protocols, false);
+      final TlsWarmup warmup = resolveTlsWarmup();
+      // Build the Netty SslContext off the Vert.x event loop. Vert.x otherwise calls
+      // SslContextFactory.create() lazily on the event loop during the first handshake; pre-building
+      // it (CONTEXT/FULL, the default) keeps that construction off the loop. With OFF the context is
+      // built lazily on the loop as before #7922. See #7921 / #7926.
+      final SslContextFactory sslContextFactory;
+      if (warmup == TlsWarmup.OFF) {
+        sslContextFactory = () -> buildJdkSslContext(protocols);
+      } else {
+        final JdkSslContext jdkSslContext = buildJdkSslContext(protocols);
+        sslContextFactory = () -> jdkSslContext;
+      }
       options.setSslEngineOptions(new JdkSSLEngineOptions() {
         @Override
         public JdkSSLEngineOptions copy() {
@@ -142,9 +162,12 @@ public class VertxHttpClientBuilder<F extends HttpClient.Factory>
 
         @Override
         public SslContextFactory sslContextFactory() {
-          return () -> jdkSslContext;
+          return sslContextFactory;
         }
       });
+      if (warmup == TlsWarmup.FULL) {
+        warmTlsStackFull();
+      }
     }
 
     // Since the factory is not explicitly typed as VertxHttpClientFactory, we need to check the type before invoking
@@ -175,6 +198,12 @@ public class VertxHttpClientBuilder<F extends HttpClient.Factory>
   }
 
   private static Vertx createVertxInstance() {
+    return createVertxInstance(new VertxOptions()
+        .setFileSystemOptions(new FileSystemOptions().setFileCachingEnabled(false).setClassPathResolvingEnabled(false))
+        .setUseDaemonThread(true));
+  }
+
+  private static Vertx createVertxInstance(final VertxOptions options) {
     // We must disable the async DNS resolver as it can cause issues when resolving the Vault instance.
     // This is done using the DISABLE_DNS_RESOLVER_PROP_NAME system property.
     // The DNS resolver used by vert.x is configured during the (synchronous) initialization.
@@ -183,9 +212,7 @@ public class VertxHttpClientBuilder<F extends HttpClient.Factory>
     Vertx vertx;
     try {
       System.setProperty(DISABLE_DNS_RESOLVER_PROP_NAME, "true");
-      vertx = Vertx.vertx(new VertxOptions()
-          .setFileSystemOptions(new FileSystemOptions().setFileCachingEnabled(false).setClassPathResolvingEnabled(false))
-          .setUseDaemonThread(true));
+      vertx = Vertx.vertx(options);
     } finally {
       // Restore the original value
       if (originalValue == null) {
@@ -195,5 +222,118 @@ public class VertxHttpClientBuilder<F extends HttpClient.Factory>
       }
     }
     return vertx;
+  }
+
+  /** Resolves the configured {@link TlsWarmup} mode off the (typed) client factory, defaulting to CONTEXT. */
+  private TlsWarmup resolveTlsWarmup() {
+    if (clientFactory instanceof VertxHttpClientFactory) {
+      return ((VertxHttpClientFactory) clientFactory).getTlsWarmup();
+    }
+    return TlsWarmup.CONTEXT;
+  }
+
+  /** Builds the Netty {@link JdkSslContext} wrapping the configured {@code sslContext} for the given protocols. */
+  private JdkSslContext buildJdkSslContext(final String[] protocols) {
+    return new JdkSslContext(
+        sslContext, true, null, IdentityCipherSuiteFilter.INSTANCE,
+        ApplicationProtocolConfig.DISABLED, ClientAuth.NONE,
+        protocols, false);
+  }
+
+  /**
+   * One-time, off-event-loop warm-up that drives a complete throwaway loopback TLS handshake
+   * ({@link TlsWarmup#FULL}). The eager context pre-build keeps the {@code JdkSslContext} construction
+   * off the event loop, but the {@code SslHandler} creation and the handshake {@code wrap}/{@code unwrap}
+   * (the bulk of the one-time TLS class loading) still happen on the loop on the first connection; under
+   * hard CPU throttling that residual can exceed the connect timeout. Running a real handshake against a
+   * self-signed loopback server here warms the full Netty + JDK TLS class path and the Vert.x connect/DNS
+   * path. Runs synchronously on the building thread (the explicit trade opt-in users make). Best-effort:
+   * any failure is swallowed since the eager context pre-build already happened. See #7926.
+   */
+  private static void warmTlsStackFull() {
+    if (!TLS_FULL_WARMED.compareAndSet(false, true)) {
+      return;
+    }
+    try {
+      loopbackTlsHandshake();
+    } catch (Exception e) {
+      logger.debug("Full TLS stack warm-up skipped: {}", e.getMessage());
+    }
+  }
+
+  /**
+   * Stands up a self-signed HTTPS server on a loopback ephemeral port, performs one client TLS
+   * handshake against it and tears both down, on a disposable Vert.x instance created with the same
+   * DNS-resolver setting as the real client so the same classes are loaded. The trust-all manager is
+   * scoped to this throwaway client and never touches real traffic.
+   */
+  private static void loopbackTlsHandshake() throws Exception {
+    final long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(WARMUP_TIMEOUT_SECONDS);
+    final Vertx warmVertx = createVertxInstance(new VertxOptions()
+        .setEventLoopPoolSize(1)
+        .setUseDaemonThread(true)
+        // The warm-up deliberately drives a TLS handshake on this throwaway event loop, which is exactly
+        // the work we are relocating off the real loop. Relax the blocked-thread checker so the warm-up
+        // does not emit alarming "thread blocked" warnings in the user's logs under CPU throttling.
+        .setBlockedThreadCheckInterval(WARMUP_TIMEOUT_SECONDS).setBlockedThreadCheckIntervalUnit(TimeUnit.SECONDS)
+        .setMaxEventLoopExecuteTime(WARMUP_TIMEOUT_SECONDS).setMaxEventLoopExecuteTimeUnit(TimeUnit.SECONDS));
+    SelfSignedCertificate certificate = null;
+    try {
+      certificate = SelfSignedCertificate.create();
+      final HttpServer server = warmVertx
+          .createHttpServer(new HttpServerOptions()
+              .setSsl(true)
+              .setKeyCertOptions(certificate.keyCertOptions())
+              .setHost(LOOPBACK_HOST)
+              .setPort(0))
+          .requestHandler(req -> req.response().end("ok"));
+      server.listen().toCompletionStage().toCompletableFuture()
+          .get(remainingMillis(deadlineNanos), TimeUnit.MILLISECONDS);
+      final int port = server.actualPort();
+      final HttpClientOptions clientOptions = new HttpClientOptions()
+          .setSsl(true)
+          .setSslEngineOptions(new JdkSSLEngineOptions())
+          .setTrustOptions(TrustOptions.wrap(trustAllManager()));
+      final io.vertx.core.http.HttpClient warmClient = warmVertx.createHttpClient(clientOptions);
+      warmClient.request(HttpMethod.GET, port, LOOPBACK_HOST, "/")
+          .compose(req -> req.send())
+          .compose(resp -> resp.body())
+          .toCompletionStage().toCompletableFuture()
+          .get(remainingMillis(deadlineNanos), TimeUnit.MILLISECONDS);
+    } finally {
+      try {
+        warmVertx.close().toCompletionStage().toCompletableFuture().get(WARMUP_CLOSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      } finally {
+        // Remove the throwaway self-signed cert/key temp files now rather than relying on deleteOnExit.
+        if (certificate != null) {
+          certificate.delete();
+        }
+      }
+    }
+  }
+
+  /** Milliseconds left until the warm-up deadline, floored at 1 so a {@code get} never waits indefinitely. */
+  private static long remainingMillis(final long deadlineNanos) {
+    return Math.max(1L, (deadlineNanos - System.nanoTime()) / 1_000_000L);
+  }
+
+  /** Trust-all manager used solely by the throwaway loopback warm-up client; never used for real traffic. */
+  private static X509TrustManager trustAllManager() {
+    return new X509TrustManager() {
+      @Override
+      public void checkClientTrusted(X509Certificate[] chain, String authType) {
+        // no-op: throwaway warm-up only
+      }
+
+      @Override
+      public void checkServerTrusted(X509Certificate[] chain, String authType) {
+        // no-op: throwaway warm-up only
+      }
+
+      @Override
+      public X509Certificate[] getAcceptedIssuers() {
+        return new X509Certificate[0];
+      }
+    };
   }
 }

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientFactory.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientFactory.java
@@ -22,6 +22,7 @@ import io.vertx.ext.web.client.WebClientOptions;
 public class VertxHttpClientFactory implements io.fabric8.kubernetes.client.http.HttpClient.Factory {
 
   final Vertx sharedVertx;
+  private volatile TlsWarmup tlsWarmup = TlsWarmup.CONTEXT;
 
   @Override
   public int priority() {
@@ -54,5 +55,24 @@ public class VertxHttpClientFactory implements io.fabric8.kubernetes.client.http
    */
   protected void additionalConfig(WebClientOptions options) {
     // no default implementation
+  }
+
+  /**
+   * Returns the configured {@link TlsWarmup} mode (never {@code null}).
+   *
+   * @return the TLS warm-up mode applied when building TLS-enabled clients
+   */
+  public TlsWarmup getTlsWarmup() {
+    return tlsWarmup;
+  }
+
+  /**
+   * Configures how the TLS stack is warmed up off the Vert.x event loop when a TLS-enabled client
+   * is built. See {@link TlsWarmup} for the trade-offs of each mode.
+   *
+   * @param tlsWarmup the warm-up mode; {@code null} resets it to the default {@link TlsWarmup#CONTEXT}
+   */
+  public void setTlsWarmup(TlsWarmup tlsWarmup) {
+    this.tlsWarmup = tlsWarmup == null ? TlsWarmup.CONTEXT : tlsWarmup;
   }
 }

--- a/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/SslTest.java
+++ b/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/SslTest.java
@@ -26,6 +26,7 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.net.SelfSignedCertificate;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
@@ -81,5 +82,61 @@ class SslTest {
     HttpResponse<String> resp = client.sendAsync(request, String.class).get(10, TimeUnit.SECONDS);
     assertEquals(200, resp.code());
     assertEquals("OK", resp.bodyString());
+  }
+
+  @Test
+  @DisplayName("TLS warm-up defaults to CONTEXT so existing clients keep the #7922 eager context pre-build unchanged")
+  void tlsWarmupDefaultsToContext() {
+    assertEquals(TlsWarmup.CONTEXT, new VertxHttpClientFactory().getTlsWarmup());
+  }
+
+  @Test
+  @DisplayName("A null TLS warm-up mode falls back to CONTEXT rather than disabling the warm-up")
+  void tlsWarmupSetterRejectsNull() {
+    final VertxHttpClientFactory factory = new VertxHttpClientFactory();
+    factory.setTlsWarmup(null);
+    assertEquals(TlsWarmup.CONTEXT, factory.getTlsWarmup());
+  }
+
+  @Test
+  @DisplayName("setTlsWarmup round-trips each mode (OFF, CONTEXT, FULL) through getTlsWarmup")
+  void tlsWarmupRoundTripsAllModes() {
+    final VertxHttpClientFactory factory = new VertxHttpClientFactory();
+    factory.setTlsWarmup(TlsWarmup.OFF);
+    assertEquals(TlsWarmup.OFF, factory.getTlsWarmup());
+    factory.setTlsWarmup(TlsWarmup.FULL);
+    assertEquals(TlsWarmup.FULL, factory.getTlsWarmup());
+    factory.setTlsWarmup(TlsWarmup.CONTEXT);
+    assertEquals(TlsWarmup.CONTEXT, factory.getTlsWarmup());
+  }
+
+  @Test
+  @DisplayName("FULL TLS warm-up is harmless and idempotent: two successive FULL client builds both connect over HTTPS")
+  void fullTlsWarmupIsHarmlessAndIdempotent() throws Exception {
+    requestHandler = req -> req.response().end("OK");
+    final VertxHttpClientFactory factory = new VertxHttpClientFactory();
+    factory.setTlsWarmup(TlsWarmup.FULL);
+    for (int i = 0; i < 2; i++) {
+      try (HttpClient client = factory.newBuilder().sslContext(null, trustManagers).build()) {
+        HttpRequest request = client.newHttpRequestBuilder().uri("https://localhost:" + port).build();
+        HttpResponse<String> resp = client.sendAsync(request, String.class).get(30, TimeUnit.SECONDS);
+        assertEquals(200, resp.code());
+        assertEquals("OK", resp.bodyString());
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("OFF TLS warm-up skips the eager context pre-build yet a client built with it still connects over HTTPS")
+  void offTlsWarmupClientConnectsOverHttps() throws Exception {
+    requestHandler = req -> req.response().end("OK");
+    final VertxHttpClientFactory factory = new VertxHttpClientFactory();
+    factory.setTlsWarmup(TlsWarmup.OFF);
+    try (HttpClient client = factory.newBuilder().sslContext(null, trustManagers).build()) {
+      HttpRequest request = client.newHttpRequestBuilder().uri("https://localhost:" + port).build();
+      HttpResponse<String> resp = client.sendAsync(request, String.class).get(10, TimeUnit.SECONDS);
+      assertEquals(200, resp.code());
+      assertEquals("OK", resp.bodyString());
+    }
   }
 }


### PR DESCRIPTION
## Description

Follow-up to #7921 / #7922. After #7922 moved the SSL-context construction off the Vert.x event loop, the first TLS connection still blocks the loop on the one-time JDK/Netty class loading during `SslContext.newHandler` and the handshake, which on a cold or CPU-throttled JVM can exceed the connect timeout.

This adds an opt-in, more complete TLS warm-up, configured programmatically on the Vert.x HTTP client factory:

```java
Vertx5HttpClientFactory factory = new Vertx5HttpClientFactory();
factory.setTlsWarmup(TlsWarmup.FULL);
KubernetesClient client = new KubernetesClientBuilder().withHttpClientFactory(factory).build();
```

### `TlsWarmup` modes

- `OFF` — no warm-up (TLS materialized lazily on the event loop, pre-#7922 behavior).
- `CONTEXT` — **default, unchanged**: the build-time `SslContextBuilder…build()` warm-up from #7922.
- `FULL` — a synchronous, once-per-JVM, off-event-loop throwaway loopback TLS handshake: a disposable Vert.x instance stands up a self-signed HTTPS server on `127.0.0.1`, drives one client handshake against it, then tears both down. This warms the full Netty + JDK TLS class path and the Vert.x connect path, so the first real connection no longer blocks the event loop. Best-effort (falls back if the loopback bind is blocked) and time-bounded.

### Notes

- Default behavior is unchanged; the feature only activates when a user explicitly opts in.
- Programmatic only (no `Config` field, system property, or SPI default in this iteration), targeting the narrow set of users hitting the first-connection block under hard CPU throttling.
- Mirrored in both `kubernetes-httpclient-vertx` (Vert.x 4) and `kubernetes-httpclient-vertx-5` (Vert.x 5).
- A warm-up only relocates the one-time cost off the event loop; it cannot beat a hard CPU cap. The FAQ documents CDS / AOT cache and pod CPU sizing as the levers for hard-throttled pods.

Fixes #7926