### PR TITLE
feat(mock-server): allow injection of java.time.Clock for determinist…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Fix #7875: bump vertx5.version from 5.0.12 to 5.1.1, adapting httpclient-vertx-5 to Vert.x 5.1 behaviour changes (SSL engine options no longer accept an empty protocol array; request-body stream errors are reset with HTTP/2 CANCEL so they are not retried as transient IOExceptions)
 
 #### New Features
+* Fix #7019: (kubernetes-server-mock) Allow injection of `java.time.Clock` via `KubernetesMockServer.setClock(Clock)` for deterministic timestamps in CRUD mode
 * Fix #5084: Jbang scripts to generate graalVM metadata
 * Fix #7375: (crd-generator) Support @JsonClassDescription for adding descriptions to classes in the generated CRD schema.
 

--- a/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesCrudDispatcher.java
+++ b/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesCrudDispatcher.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.time.ZoneOffset;
+import java.time.Clock;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
@@ -67,13 +67,19 @@ public class KubernetesCrudDispatcher extends CrudDispatcher implements Kubernet
   private final KubernetesCrudDispatcherHandler putHandler;
   private final KubernetesCrudDispatcherHandler patchHandler;
   private final ReadWriteLock lock = new ReentrantReadWriteLock();
+  private volatile Clock clock;
 
   public KubernetesCrudDispatcher() {
     this(Collections.emptyList());
   }
 
   public KubernetesCrudDispatcher(List<CustomResourceDefinitionContext> crdContexts) {
+    this(crdContexts, Clock.systemUTC());
+  }
+
+  public KubernetesCrudDispatcher(List<CustomResourceDefinitionContext> crdContexts, Clock clock) {
     super(new Context(Serialization.jsonMapper()), new KubernetesAttributesExtractor(), new KubernetesResponseComposer());
+    this.clock = Objects.requireNonNull(clock, "clock");
     this.kubernetesAttributesExtractor = (KubernetesAttributesExtractor) this.attributeExtractor;
     this.kubernetesResponseComposer = (KubernetesResponseComposer) this.responseComposer;
     watchEventListeners = new CopyOnWriteArraySet<>();
@@ -81,7 +87,7 @@ public class KubernetesCrudDispatcher extends CrudDispatcher implements Kubernet
     this.kubernetesAttributesExtractor.setCustomResourceDefinitionProcessor(crdProcessor);
     resourceVersion = new AtomicLong();
 
-    postHandler = new PostHandler(this.kubernetesAttributesExtractor, this);
+    postHandler = new PostHandler(this.kubernetesAttributesExtractor, this, () -> this.clock);
     putHandler = new PutHandler(this);
     patchHandler = new PatchHandler(this);
     crdContexts.forEach(this::expectCustomResource);
@@ -209,7 +215,7 @@ public class KubernetesCrudDispatcher extends CrudDispatcher implements Kubernet
     if (!resource.isMarkedForDeletion()) {
       // Mark the resource as deleted, but don't remove it yet (wait for finalizer-removal).
       resource.getMetadata().setDeletionTimestamp(
-          ZonedDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+          ZonedDateTime.now(clock).truncatedTo(ChronoUnit.SECONDS).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
       resource.getMetadata().setResourceVersion(String.valueOf(requestResourceVersion()));
       String updatedResource = Serialization.asJson(resource);
       processEvent(path, pathAttributes, oldAttributes, resource, updatedResource);
@@ -221,6 +227,10 @@ public class KubernetesCrudDispatcher extends CrudDispatcher implements Kubernet
   @Override
   public long requestResourceVersion() {
     return resourceVersion.incrementAndGet();
+  }
+
+  public void setClock(Clock clock) {
+    this.clock = Objects.requireNonNull(clock, "clock");
   }
 
   @Override

--- a/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMixedDispatcher.java
+++ b/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMixedDispatcher.java
@@ -25,6 +25,7 @@ import io.fabric8.mockwebserver.http.RecordedRequest;
 import io.fabric8.mockwebserver.internal.MockDispatcher;
 import io.fabric8.mockwebserver.internal.SimpleRequest;
 
+import java.time.Clock;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -52,9 +53,14 @@ public class KubernetesMixedDispatcher extends Dispatcher implements Resetable, 
 
   public KubernetesMixedDispatcher(
       Map<ServerRequest, Queue<ServerResponse>> responses, List<CustomResourceDefinitionContext> crdContexts) {
+    this(responses, crdContexts, Clock.systemUTC());
+  }
+
+  public KubernetesMixedDispatcher(
+      Map<ServerRequest, Queue<ServerResponse>> responses, List<CustomResourceDefinitionContext> crdContexts, Clock clock) {
     this.responses = responses;
     mockDispatcher = new MockDispatcher(responses);
-    kubernetesCrudDispatcher = new KubernetesCrudDispatcher(crdContexts);
+    kubernetesCrudDispatcher = new KubernetesCrudDispatcher(crdContexts, clock);
   }
 
   @Override
@@ -87,5 +93,9 @@ public class KubernetesMixedDispatcher extends Dispatcher implements Resetable, 
   @Override
   public void expectCustomResource(CustomResourceDefinitionContext rdc) {
     this.kubernetesCrudDispatcher.expectCustomResource(rdc);
+  }
+
+  public void setClock(Clock clock) {
+    this.kubernetesCrudDispatcher.setClock(clock);
   }
 }

--- a/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServer.java
+++ b/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServer.java
@@ -45,6 +45,7 @@ import io.fabric8.mockwebserver.internal.MockDispatcher;
 
 import java.net.HttpURLConnection;
 import java.net.InetAddress;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -164,6 +165,27 @@ public class KubernetesMockServer extends DefaultMockServer implements Resetable
    */
   public final void setVersionInfo(VersionInfo versionInfo) {
     this.versionInfo = Objects.requireNonNull(versionInfo);
+  }
+
+  /**
+   * Sets the {@link Clock} used by the CRUD dispatcher for generating timestamps
+   * (creationTimestamp, deletionTimestamp).
+   * <p>
+   * Only has effect when the server is configured with a CRUD or mixed dispatcher.
+   * Defaults to {@link Clock#systemUTC()}.
+   *
+   * @param clock the clock to use.
+   * @throws IllegalStateException if the dispatcher does not support CRUD operations.
+   */
+  public void setClock(Clock clock) {
+    Objects.requireNonNull(clock, "clock");
+    if (this.dispatcher instanceof KubernetesMixedDispatcher) {
+      ((KubernetesMixedDispatcher) this.dispatcher).setClock(clock);
+    } else if (this.dispatcher instanceof KubernetesCrudDispatcher) {
+      ((KubernetesCrudDispatcher) this.dispatcher).setClock(clock);
+    } else {
+      throw new IllegalStateException("setClock is only supported when the server uses a CRUD dispatcher");
+    }
   }
 
   /**

--- a/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/crud/PostHandler.java
+++ b/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/crud/PostHandler.java
@@ -26,11 +26,13 @@ import io.fabric8.mockwebserver.crud.AttributeSet;
 import io.fabric8.mockwebserver.http.MockResponse;
 
 import java.net.HttpURLConnection;
-import java.time.ZoneOffset;
+import java.time.Clock;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 import static io.fabric8.kubernetes.client.utils.Utils.generateId;
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
@@ -39,10 +41,17 @@ public class PostHandler implements KubernetesCrudDispatcherHandler {
 
   private final KubernetesAttributesExtractor attributeExtractor;
   private final KubernetesCrudPersistence persistence;
+  private final Supplier<Clock> clockSupplier;
 
   public PostHandler(KubernetesAttributesExtractor attributeExtractor, KubernetesCrudPersistence persistence) {
+    this(attributeExtractor, persistence, Clock::systemUTC);
+  }
+
+  public PostHandler(KubernetesAttributesExtractor attributeExtractor, KubernetesCrudPersistence persistence,
+      Supplier<Clock> clockSupplier) {
     this.attributeExtractor = attributeExtractor;
     this.persistence = persistence;
+    this.clockSupplier = Objects.requireNonNull(clockSupplier, "clockSupplier");
   }
 
   @Override
@@ -86,7 +95,7 @@ public class PostHandler implements KubernetesCrudDispatcherHandler {
     resource.getMetadata().setNamespace(pathNamespace);
     resource.getMetadata().setUid(uuid.toString());
     resource.getMetadata().setCreationTimestamp(
-        ZonedDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS).format(DateTimeFormatter.ISO_INSTANT));
+        ZonedDateTime.now(clockSupplier.get()).truncatedTo(ChronoUnit.SECONDS).format(DateTimeFormatter.ISO_INSTANT));
     resource.getMetadata().setResourceVersion(String.valueOf(persistence.requestResourceVersion()));
     resource.getMetadata().setGeneration(1L);
   }

--- a/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerClockTest.java
+++ b/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerClockTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.server.mock;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.mockwebserver.Context;
+import io.fabric8.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class KubernetesMockServerClockTest {
+
+  private KubernetesMockServer server;
+  private KubernetesClient client;
+
+  @BeforeEach
+  void setUp() {
+    server = new KubernetesMockServer(new Context(),
+        new MockWebServer(), new HashMap<>(),
+        new KubernetesMixedDispatcher(new HashMap<>()), false);
+    server.start();
+    client = server.createClient();
+  }
+
+  @AfterEach
+  void tearDown() {
+    client.close();
+    server.shutdown();
+  }
+
+  @Test
+  @DisplayName("setClock with fixed clock controls creationTimestamp on resource creation")
+  void fixedClockControlsCreationTimestamp() {
+    server.setClock(Clock.fixed(Instant.parse("2024-01-15T10:30:00Z"), ZoneOffset.UTC));
+
+    ConfigMap cm = client.configMaps().inNamespace("default").create(
+        new ConfigMapBuilder().withNewMetadata().withName("test-cm").endMetadata().build());
+
+    assertThat(cm.getMetadata().getCreationTimestamp()).isEqualTo("2024-01-15T10:30:00Z");
+  }
+
+  @Test
+  @DisplayName("setClock with fixed clock controls deletionTimestamp when resource has finalizers")
+  void fixedClockControlsDeletionTimestamp() {
+    server.setClock(Clock.fixed(Instant.parse("2024-06-20T14:00:00Z"), ZoneOffset.UTC));
+
+    client.pods().inNamespace("default").create(
+        new PodBuilder().withNewMetadata().withName("test-pod").withFinalizers("test/finalizer").endMetadata().build());
+
+    client.pods().inNamespace("default").withName("test-pod").delete();
+
+    Pod deleted = client.pods().inNamespace("default").withName("test-pod").get();
+    assertThat(deleted.getMetadata().getDeletionTimestamp()).isEqualTo("2024-06-20T14:00:00Z");
+  }
+
+  @Test
+  @DisplayName("setClock throws IllegalStateException when dispatcher is not CRUD-enabled")
+  void setClockOnNonCrudServerThrows() {
+    KubernetesMockServer nonCrudServer = new KubernetesMockServer(false);
+    nonCrudServer.start();
+    try {
+      assertThatIllegalStateException()
+          .isThrownBy(() -> nonCrudServer.setClock(Clock.systemUTC()))
+          .withMessageContaining("CRUD dispatcher");
+    } finally {
+      nonCrudServer.shutdown();
+    }
+  }
+
+  @Test
+  @DisplayName("setClock with null throws NullPointerException")
+  void setClockNullThrows() {
+    assertThatNullPointerException()
+        .isThrownBy(() -> server.setClock(null));
+  }
+
+  @Test
+  @DisplayName("clock can be changed between operations to simulate time progression")
+  void clockCanBeChangedMidTest() {
+    server.setClock(Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC));
+    ConfigMap first = client.configMaps().inNamespace("default").create(
+        new ConfigMapBuilder().withNewMetadata().withName("first").endMetadata().build());
+
+    server.setClock(Clock.fixed(Instant.parse("2024-06-01T12:00:00Z"), ZoneOffset.UTC));
+    ConfigMap second = client.configMaps().inNamespace("default").create(
+        new ConfigMapBuilder().withNewMetadata().withName("second").endMetadata().build());
+
+    assertThat(first.getMetadata().getCreationTimestamp()).isEqualTo("2024-01-01T00:00:00Z");
+    assertThat(second.getMetadata().getCreationTimestamp()).isEqualTo("2024-06-01T12:00:00Z");
+  }
+
+  @Test
+  @DisplayName("multiple resources created with same fixed clock get identical timestamps")
+  void multipleResourcesSameTimestamp() {
+    server.setClock(Clock.fixed(Instant.parse("2024-03-10T08:15:00Z"), ZoneOffset.UTC));
+
+    ConfigMap cm = client.configMaps().inNamespace("default").create(
+        new ConfigMapBuilder().withNewMetadata().withName("cm1").endMetadata().build());
+    Secret secret = client.secrets().inNamespace("default").create(
+        new SecretBuilder().withNewMetadata().withName("s1").endMetadata().build());
+
+    assertThat(cm.getMetadata().getCreationTimestamp())
+        .isEqualTo(secret.getMetadata().getCreationTimestamp())
+        .isEqualTo("2024-03-10T08:15:00Z");
+  }
+
+  @Test
+  @DisplayName("without setClock, creationTimestamp is still set (uses system clock)")
+  void defaultClockStillSetsTimestamp() {
+    ConfigMap cm = client.configMaps().inNamespace("default").create(
+        new ConfigMapBuilder().withNewMetadata().withName("default-clock").endMetadata().build());
+
+    assertThat(cm.getMetadata().getCreationTimestamp())
+        .isNotNull()
+        .matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z");
+  }
+
+  @Test
+  @DisplayName("fixed clock applies to both creationTimestamp and deletionTimestamp consistently")
+  void sameClockForCreateAndDelete() {
+    server.setClock(Clock.fixed(Instant.parse("2024-09-01T06:00:00Z"), ZoneOffset.UTC));
+
+    Pod pod = client.pods().inNamespace("default").create(
+        new PodBuilder().withNewMetadata().withName("consistent-pod").withFinalizers("keep/alive").endMetadata().build());
+
+    assertThat(pod.getMetadata().getCreationTimestamp()).isEqualTo("2024-09-01T06:00:00Z");
+
+    client.pods().inNamespace("default").withName("consistent-pod").delete();
+
+    Pod deleted = client.pods().inNamespace("default").withName("consistent-pod").get();
+    assertThat(deleted.getMetadata().getDeletionTimestamp()).isEqualTo("2024-09-01T06:00:00Z");
+  }
+}


### PR DESCRIPTION
  Fixes https://github.com/fabric8io/kubernetes-client/issues/7019                                                                                                                   
                                                                                                                                                                                     
  The CRUD dispatcher hardcoded ZonedDateTime.now(ZoneOffset.UTC) for creationTimestamp and deletionTimestamp, making it impossible to assert exact timestamp values in tests.       
                                                                                                                                                                                     
  This PR introduces a configurable java.time.Clock that flows through the dispatcher chain:                                                                                         
                                                                                                                                                                                     
  KubernetesMockServer → KubernetesMixedDispatcher → KubernetesCrudDispatcher → PostHandler                                                                                          
                                                                                                                                                                                     
  Usage:                                                                                                                                                                             
  server.setClock(Clock.fixed(Instant.parse("2024-01-15T10:00:00Z"), ZoneOffset.UTC));                                                                                               
                                                                                                                                                                                     
  Defaults to Clock.systemUTC() — no behavioral change for existing code.                                                                                                            


 Type of change                                                                                                                                                                     
                                                                                                                                                                                     
  - [ ] Bug fix (non-breaking change which fixes an issue)                                                                                                                           
  - [x] Feature (non-breaking change which adds functionality)                                                                                                                       
  - [ ] Breaking change (fix or feature that would cause existing functionality to change                                                                                            
  - [ ] Chore (non-breaking change which doesn't affect codebase;                                                                                                                    
  test, version modification, documentation, etc.)                                                                                                                                   
                                                                                                                                                                                     
  Checklist                                                                                                                                                                          
                                                                                                                                                                                     
  - [x] Code contributed by me aligns with current project license: Apache 2.0 (https://www.apache.org/licenses/LICENSE-2.0)                                                         
  - [x] I Added CHANGELOG (https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change                                                        
  - [x] I have implemented unit tests to cover my changes                                                                                                                            
  - [x] I have added/updated the javadocs and other documentation accordingly                                                                                                        
  - [x] No new bugs, code smells, etc. in SonarCloud (https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report                                                         
  - [ ] I tested my code in Kubernetes                                                                                                                                               
  - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
