### PR TITLE
fix(ci): correct actor allow-list check in release workflows

### DIFF
--- a/.github/workflows/release-snapshots.yaml
+++ b/.github/workflows/release-snapshots.yaml
@@ -46,7 +46,7 @@ jobs:
     name: Release Java 11 SNAPSHOT
     # Cheap way to prevent accidental releases
     # Modify the list to add users with release permissions
-    if: contains('["manusa","ash-thakur-rh"]', github.actor)
+    if: contains(fromJSON('["manusa","ash-thakur-rh"]'), github.actor)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
     name: Release Java 11 ${{ github.event.inputs.tag }}
     # Cheap way to prevent accidental releases
     # Modify the list to add users with release permissions
-    if: contains('["manusa","ash-thakur-rh"]', github.actor)
+    if: contains(fromJSON('["manusa","ash-thakur-rh"]'), github.actor)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Description

Release workflows have a safety check that matches by usernames. The check has a bug: it matches a string instead of array, making it easy to bypass.

The issue is not a vulnerability as the workflows can only be triggered (`workflow_dispatch`) by authorized users anyway.

Paweł Płatek from Trail of Bits in collaboration with OpenAI.

## Type of change

 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] N/A I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] N/A I have implemented unit tests to cover my changes
 - [ ] N/A I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [X] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] N/A I tested my code in Kubernetes
 - [ ] N/A I tested my code in OpenShift
