### PR TITLE
Limit pod copy extraction size

### DIFF
--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -89,6 +89,8 @@ public class Config extends SundrioConfig {
   public static final String KUBERNETES_REQUEST_RETRY_BACKOFFLIMIT_SYSTEM_PROPERTY = "kubernetes.request.retry.backoffLimit";
   public static final String KUBERNETES_REQUEST_RETRY_BACKOFFINTERVAL_SYSTEM_PROPERTY = "kubernetes.request.retry.backoffInterval";
   public static final String KUBERNETES_LOGGING_INTERVAL_SYSTEM_PROPERTY = "kubernetes.logging.interval";
+  public static final String KUBERNETES_POD_COPY_MAX_FILE_BYTES_SYSTEM_PROPERTY = "kubernetes.pod.copy.max.file.bytes";
+  public static final String KUBERNETES_POD_COPY_MAX_TOTAL_BYTES_SYSTEM_PROPERTY = "kubernetes.pod.copy.max.total.bytes";
   public static final String KUBERNETES_SCALE_TIMEOUT_SYSTEM_PROPERTY = "kubernetes.scale.timeout";
   public static final String KUBERNETES_WEBSOCKET_PING_INTERVAL_SYSTEM_PROPERTY = "kubernetes.websocket.ping.interval";
   public static final String KUBERNETES_MAX_CONCURRENT_REQUESTS = "kubernetes.max.concurrent.requests";
@@ -127,6 +129,8 @@ public class Config extends SundrioConfig {
   public static final Long DEFAULT_SCALE_TIMEOUT = 10 * 60 * 1000L;
   public static final int DEFAULT_REQUEST_TIMEOUT = 10 * 1000;
   public static final int DEFAULT_LOGGING_INTERVAL = 20 * 1000;
+  public static final Long DEFAULT_POD_COPY_MAX_FILE_BYTES = -1L;
+  public static final Long DEFAULT_POD_COPY_MAX_TOTAL_BYTES = -1L;
   public static final Long DEFAULT_WEBSOCKET_PING_INTERVAL = 30 * 1000L;
 
   public static final Integer DEFAULT_MAX_CONCURRENT_REQUESTS = 64;
@@ -265,6 +269,8 @@ public class Config extends SundrioConfig {
       this.setRequestTimeout(DEFAULT_REQUEST_TIMEOUT);
       this.setScaleTimeout(DEFAULT_SCALE_TIMEOUT);
       this.setLoggingInterval(DEFAULT_LOGGING_INTERVAL);
+      this.setPodCopyMaxFileBytes(DEFAULT_POD_COPY_MAX_FILE_BYTES);
+      this.setPodCopyMaxTotalBytes(DEFAULT_POD_COPY_MAX_TOTAL_BYTES);
       this.setUserAgent("fabric8-kubernetes-client/" + Version.clientVersion());
       this.setTlsVersions(new TlsVersion[] { TlsVersion.TLS_1_3, TlsVersion.TLS_1_2 });
     }
@@ -352,6 +358,12 @@ public class Config extends SundrioConfig {
     }
     if (config.getUploadRequestTimeout() != null) {
       setUploadRequestTimeout(config.getUploadRequestTimeout());
+    }
+    if (config.getPodCopyMaxFileBytes() != null) {
+      setPodCopyMaxFileBytes(config.getPodCopyMaxFileBytes());
+    }
+    if (config.getPodCopyMaxTotalBytes() != null) {
+      setPodCopyMaxTotalBytes(config.getPodCopyMaxTotalBytes());
     }
     if (Utils.isNotNullOrEmpty(config.getImpersonateUsername())) {
       setImpersonateUsername(config.getImpersonateUsername());
@@ -512,6 +524,10 @@ public class Config extends SundrioConfig {
         config.getRequestRetryBackoffLimit()));
     config.setRequestRetryBackoffInterval(Utils.getSystemPropertyOrEnvVar(
         KUBERNETES_REQUEST_RETRY_BACKOFFINTERVAL_SYSTEM_PROPERTY, config.getRequestRetryBackoffInterval()));
+    config.setPodCopyMaxFileBytes(parseByteLimit(KUBERNETES_POD_COPY_MAX_FILE_BYTES_SYSTEM_PROPERTY,
+        config.getPodCopyMaxFileBytes()));
+    config.setPodCopyMaxTotalBytes(parseByteLimit(KUBERNETES_POD_COPY_MAX_TOTAL_BYTES_SYSTEM_PROPERTY,
+        config.getPodCopyMaxTotalBytes()));
 
     String configuredWebsocketPingInterval = Utils.getSystemPropertyOrEnvVar(KUBERNETES_WEBSOCKET_PING_INTERVAL_SYSTEM_PROPERTY,
         String.valueOf(config.getWebsocketPingInterval()));
@@ -561,6 +577,23 @@ public class Config extends SundrioConfig {
         tlsVersions[i] = TlsVersion.forJavaName(tlsVersionsSplit[i]);
       }
       config.setTlsVersions(tlsVersions);
+    }
+  }
+
+  private static Long parseByteLimit(String propertyName, Long defaultValue) {
+    String value = Utils.getSystemPropertyOrEnvVar(propertyName,
+        defaultValue == null ? null : String.valueOf(defaultValue));
+    if (value == null) {
+      return null;
+    }
+    try {
+      long byteLimit = Long.parseLong(value);
+      if (byteLimit < -1L) {
+        throw new IllegalArgumentException(propertyName + " must be -1 or greater");
+      }
+      return byteLimit;
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(propertyName + " must be a byte count", e);
     }
   }
 
@@ -996,6 +1029,28 @@ public class Config extends SundrioConfig {
   @Override
   public void setLoggingInterval(Integer loggingInterval) {
     this.requestConfig.setLoggingInterval(loggingInterval);
+  }
+
+  @Override
+  @JsonProperty("podCopyMaxFileBytes")
+  public Long getPodCopyMaxFileBytes() {
+    return getRequestConfig().getPodCopyMaxFileBytes();
+  }
+
+  @Override
+  public void setPodCopyMaxFileBytes(Long podCopyMaxFileBytes) {
+    this.requestConfig.setPodCopyMaxFileBytes(podCopyMaxFileBytes);
+  }
+
+  @Override
+  @JsonProperty("podCopyMaxTotalBytes")
+  public Long getPodCopyMaxTotalBytes() {
+    return getRequestConfig().getPodCopyMaxTotalBytes();
+  }
+
+  @Override
+  public void setPodCopyMaxTotalBytes(Long podCopyMaxTotalBytes) {
+    this.requestConfig.setPodCopyMaxTotalBytes(podCopyMaxTotalBytes);
   }
 
   @JsonProperty("http2Disable")

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/ConfigFluent.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/ConfigFluent.java
@@ -84,6 +84,14 @@ public class ConfigFluent<A extends ConfigFluent<A>> extends SundrioConfigFluent
     return this.withLoggingInterval(Integer.valueOf(loggingInterval));
   }
 
+  public A withPodCopyMaxFileBytes(long podCopyMaxFileBytes) {
+    return this.withPodCopyMaxFileBytes(Long.valueOf(podCopyMaxFileBytes));
+  }
+
+  public A withPodCopyMaxTotalBytes(long podCopyMaxTotalBytes) {
+    return this.withPodCopyMaxTotalBytes(Long.valueOf(podCopyMaxTotalBytes));
+  }
+
   public A withHttp2Disable(boolean http2Disable) {
     return this.withHttp2Disable(Boolean.valueOf(http2Disable));
   }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/RequestConfig.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/RequestConfig.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Map;
 
 import static io.fabric8.kubernetes.client.Config.DEFAULT_LOGGING_INTERVAL;
+import static io.fabric8.kubernetes.client.Config.DEFAULT_POD_COPY_MAX_FILE_BYTES;
+import static io.fabric8.kubernetes.client.Config.DEFAULT_POD_COPY_MAX_TOTAL_BYTES;
 import static io.fabric8.kubernetes.client.Config.DEFAULT_REQUEST_RETRY_BACKOFFINTERVAL;
 import static io.fabric8.kubernetes.client.Config.DEFAULT_REQUEST_RETRY_BACKOFFLIMIT;
 import static io.fabric8.kubernetes.client.Config.DEFAULT_REQUEST_TIMEOUT;
@@ -46,14 +48,25 @@ public class RequestConfig {
   private Integer requestTimeout = DEFAULT_REQUEST_TIMEOUT;
   private Long scaleTimeout = DEFAULT_SCALE_TIMEOUT;
   private Integer loggingInterval = DEFAULT_LOGGING_INTERVAL;
+  private Long podCopyMaxFileBytes = DEFAULT_POD_COPY_MAX_FILE_BYTES;
+  private Long podCopyMaxTotalBytes = DEFAULT_POD_COPY_MAX_TOTAL_BYTES;
 
   RequestConfig() {
+  }
+
+  public RequestConfig(Integer watchReconnectLimit, Integer watchReconnectInterval, Integer requestTimeout,
+      Long scaleTimeout, Integer loggingInterval, Integer requestRetryBackoffLimit,
+      Integer requestRetryBackoffInterval, Integer uploadRequestTimeout) {
+    this(watchReconnectLimit, watchReconnectInterval, requestTimeout, scaleTimeout, loggingInterval,
+        requestRetryBackoffLimit, requestRetryBackoffInterval, uploadRequestTimeout,
+        DEFAULT_POD_COPY_MAX_FILE_BYTES, DEFAULT_POD_COPY_MAX_TOTAL_BYTES);
   }
 
   @Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", editableEnabled = false)
   public RequestConfig(Integer watchReconnectLimit, Integer watchReconnectInterval, Integer requestTimeout,
       Long scaleTimeout, Integer loggingInterval, Integer requestRetryBackoffLimit,
-      Integer requestRetryBackoffInterval, Integer uploadRequestTimeout) {
+      Integer requestRetryBackoffInterval, Integer uploadRequestTimeout, Long podCopyMaxFileBytes,
+      Long podCopyMaxTotalBytes) {
     this.watchReconnectLimit = watchReconnectLimit;
     this.watchReconnectInterval = watchReconnectInterval;
     this.requestTimeout = requestTimeout;
@@ -62,6 +75,8 @@ public class RequestConfig {
     this.requestRetryBackoffLimit = requestRetryBackoffLimit;
     this.requestRetryBackoffInterval = requestRetryBackoffInterval;
     this.uploadRequestTimeout = uploadRequestTimeout;
+    this.podCopyMaxFileBytes = podCopyMaxFileBytes;
+    this.podCopyMaxTotalBytes = podCopyMaxTotalBytes;
   }
 
   public Integer getWatchReconnectInterval() {
@@ -126,6 +141,22 @@ public class RequestConfig {
 
   public void setLoggingInterval(Integer loggingInterval) {
     this.loggingInterval = loggingInterval;
+  }
+
+  public Long getPodCopyMaxFileBytes() {
+    return podCopyMaxFileBytes;
+  }
+
+  public void setPodCopyMaxFileBytes(Long podCopyMaxFileBytes) {
+    this.podCopyMaxFileBytes = podCopyMaxFileBytes;
+  }
+
+  public Long getPodCopyMaxTotalBytes() {
+    return podCopyMaxTotalBytes;
+  }
+
+  public void setPodCopyMaxTotalBytes(Long podCopyMaxTotalBytes) {
+    this.podCopyMaxTotalBytes = podCopyMaxTotalBytes;
   }
 
   public void setImpersonateUsername(String impersonateUsername) {

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/SundrioConfig.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/SundrioConfig.java
@@ -99,6 +99,8 @@ public class SundrioConfig {
   private Integer requestTimeout;
   private Long scaleTimeout;
   private Integer loggingInterval;
+  private Long podCopyMaxFileBytes;
+  private Long podCopyMaxTotalBytes;
   private String impersonateUsername;
   private String[] impersonateGroups;
   private Map<String, List<String>> impersonateExtras;

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/RequestConfigTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/RequestConfigTest.java
@@ -17,21 +17,15 @@ package io.fabric8.kubernetes.client;
 
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Modifier;
-import java.util.Arrays;
-import java.util.stream.Collectors;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+class RequestConfigTest {
 
-class SundrioConfigBuilderTest {
   @Test
-  void hasExpectedNumberOfFields() {
-    assertThat(Arrays.stream(SundrioConfigFluent.class.getDeclaredFields())
-        .filter(f -> !Modifier.isStatic(f.getModifiers()))
-        .map(f -> f.getName())
-        .collect(Collectors.toList()))
-        .withFailMessage("You've probably modified SundrioConfig, please update the Config copy constructor as well")
-        .hasSize(57)
-        .contains("podCopyMaxFileBytes", "podCopyMaxTotalBytes");
+  void eightArgumentConstructorKeepsPodCopyLimitsUnlimited() {
+    RequestConfig requestConfig = new RequestConfig(null, null, null, null, null, null, null, null);
+
+    assertThat(requestConfig.getPodCopyMaxFileBytes()).isEqualTo(Config.DEFAULT_POD_COPY_MAX_FILE_BYTES);
+    assertThat(requestConfig.getPodCopyMaxTotalBytes()).isEqualTo(Config.DEFAULT_POD_COPY_MAX_TOTAL_BYTES);
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
@@ -31,6 +31,7 @@ import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.LocalPortForward;
 import io.fabric8.kubernetes.client.PortForward;
+import io.fabric8.kubernetes.client.RequestConfig;
 import io.fabric8.kubernetes.client.dsl.BytesLimitTerminateTimeTailPrettyLoggable;
 import io.fabric8.kubernetes.client.dsl.CopyOrReadable;
 import io.fabric8.kubernetes.client.dsl.EphemeralContainersResource;
@@ -83,7 +84,7 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -100,6 +101,8 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
   public static final int DEFAULT_POD_READY_WAIT_TIMEOUT_MS = 0;
   private static final String[] EMPTY_COMMAND = { "/bin/sh", "-i" };
   public static final String DEFAULT_CONTAINER_ANNOTATION_NAME = "kubectl.kubernetes.io/default-container";
+  private static final long NO_POD_COPY_LIMIT = -1L;
+  private static final int COPY_BUFFER_SIZE = 8192;
 
   static final Logger LOG = LoggerFactory.getLogger(PodOperationsImpl.class);
 
@@ -528,6 +531,10 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
                   is))
 
           {
+            RequestConfig requestConfig = getPodCopyRequestConfig();
+            long maxFileBytes = normalizePodCopyLimit(requestConfig.getPodCopyMaxFileBytes(), "podCopyMaxFileBytes");
+            long[] remainingBytes = new long[] {
+                normalizePodCopyLimit(requestConfig.getPodCopyMaxTotalBytes(), "podCopyMaxTotalBytes") };
             for (org.apache.commons.compress.archivers.ArchiveEntry entry = tis.getNextTarEntry(); entry != null; entry = tis
                 .getNextEntry()) {
               if (tis.canReadEntryData(entry)) {
@@ -535,6 +542,10 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
                 if (normalizedEntryName == null) {
                   throw new IOException("Tar entry '" + entry.getName() + "' has an invalid name");
                 }
+                if (((org.apache.commons.compress.archivers.tar.TarArchiveEntry) entry).isSparse()) {
+                  throw new IOException("Refusing to extract sparse tar entry: " + entry.getName());
+                }
+                ensureEntryFitsConfiguredLimits(entry, maxFileBytes, remainingBytes[0]);
                 File f = new File(destination, normalizedEntryName);
                 if (entry.isDirectory()) {
                   if (!f.isDirectory() && !f.mkdirs()) {
@@ -545,7 +556,7 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
                   if (!parent.isDirectory() && !parent.mkdirs()) {
                     throw new IOException("Failed to create directory: " + f);
                   }
-                  Files.copy(tis, f.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                  copyEntry(tis, f.toPath(), maxFileBytes, remainingBytes);
                 }
               }
             }
@@ -557,6 +568,66 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
     } catch (NoClassDefFoundError e) {
       throw new KubernetesClientException(
           "TarArchiveInputStream class is provided by commons-compress, an optional dependency. To use the read/copy functionality you must explicitly add commons-compress and commons-io dependency to the classpath.");
+    }
+  }
+
+  private RequestConfig getPodCopyRequestConfig() {
+    RequestConfig requestConfig = context.getRequestConfig();
+    if (requestConfig == null && config != null) {
+      requestConfig = config.getRequestConfig();
+    }
+    if (requestConfig == null) {
+      return new RequestConfig(null, null, null, null, null, null, null, null);
+    }
+    return requestConfig;
+  }
+
+  private static long normalizePodCopyLimit(Long byteLimit, String configName) throws IOException {
+    if (byteLimit == null) {
+      return NO_POD_COPY_LIMIT;
+    }
+    if (byteLimit < NO_POD_COPY_LIMIT) {
+      throw new IOException(configName + " must be -1 or greater");
+    }
+    return byteLimit;
+  }
+
+  private static void ensureEntryFitsConfiguredLimits(
+      org.apache.commons.compress.archivers.ArchiveEntry entry, long maxFileBytes, long remainingBytes)
+      throws IOException {
+    long entrySize = entry.getSize();
+    if (entrySize < 0) {
+      return;
+    }
+    if (maxFileBytes != NO_POD_COPY_LIMIT && entrySize > maxFileBytes) {
+      throw new IOException("Tar entry '" + entry.getName() + "' exceeds the configured file copy limit");
+    }
+    if (remainingBytes != NO_POD_COPY_LIMIT && entrySize > remainingBytes) {
+      throw new IOException("Tar entry '" + entry.getName() + "' exceeds the configured total copy limit");
+    }
+  }
+
+  private static void copyEntry(
+      InputStream input, Path destination, long maxFileBytes, long[] remainingBytes)
+      throws IOException {
+    long written = 0L;
+    byte[] buffer = new byte[COPY_BUFFER_SIZE];
+    try (OutputStream output = Files.newOutputStream(destination, StandardOpenOption.CREATE,
+        StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE)) {
+      int read;
+      while ((read = input.read(buffer)) >= 0) {
+        if (maxFileBytes != NO_POD_COPY_LIMIT && read > maxFileBytes - written) {
+          throw new IOException("Tar entry exceeds the configured file copy limit");
+        }
+        if (remainingBytes[0] != NO_POD_COPY_LIMIT && read > remainingBytes[0]) {
+          throw new IOException("Tar archive exceeds the configured total copy limit");
+        }
+        output.write(buffer, 0, read);
+        written += read;
+        if (remainingBytes[0] != NO_POD_COPY_LIMIT) {
+          remainingBytes[0] -= read;
+        }
+      }
     }
   }
 

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImplCopyLimitsTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImplCopyLimitsTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.internal.core.v1;
+
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.RequestConfig;
+import io.fabric8.kubernetes.client.dsl.internal.OperationContext;
+import io.fabric8.kubernetes.client.dsl.internal.PodOperationContext;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+class PodOperationsImplCopyLimitsTest {
+
+  private static final String SOURCE_DIR = "/var/source-dir";
+  private static final int TAR_RECORD_SIZE = 512;
+  private static final int CHECKSUM_OFFSET = 148;
+  private static final int CHECKSUM_LENGTH = 8;
+
+  @Test
+  void copyRejectsSparseTarEntry(@TempDir Path targetDir) {
+    PodOperationsImpl operation = podOperation(new ByteArrayInputStream(oldGnuSparseTar()), -1L, -1L);
+
+    KubernetesClientException exception = assertThrows(KubernetesClientException.class, () -> operation.copy(targetDir));
+
+    assertThat(exception).getCause()
+        .hasMessage("Refusing to extract sparse tar entry: sparse.bin");
+    assertThat(targetDir).isDirectoryNotContaining("glob:**/sparse.bin");
+  }
+
+  @Test
+  void copyRejectsEntryAboveConfiguredFileLimit(@TempDir Path targetDir) throws Exception {
+    PodOperationsImpl operation = podOperation(tarStream(Map.of("artifact.bin", bytes(4))), 3L, -1L);
+
+    KubernetesClientException exception = assertThrows(KubernetesClientException.class, () -> operation.copy(targetDir));
+
+    assertThat(exception).getCause()
+        .hasMessage("Tar entry 'artifact.bin' exceeds the configured file copy limit");
+    assertThat(targetDir).isDirectoryNotContaining("glob:**/artifact.bin");
+  }
+
+  @Test
+  void copyRejectsEntryAboveConfiguredTotalLimit(@TempDir Path targetDir) throws Exception {
+    Map<String, byte[]> files = new LinkedHashMap<>();
+    files.put("first.bin", bytes(3));
+    files.put("second.bin", bytes(3));
+    PodOperationsImpl operation = podOperation(tarStream(files), -1L, 5L);
+
+    KubernetesClientException exception = assertThrows(KubernetesClientException.class, () -> operation.copy(targetDir));
+
+    assertThat(exception).getCause()
+        .hasMessage("Tar entry 'second.bin' exceeds the configured total copy limit");
+    assertThat(targetDir).isDirectoryContaining("glob:**/first.bin");
+    assertThat(targetDir).isDirectoryNotContaining("glob:**/second.bin");
+  }
+
+  @Test
+  void copyAllowsEntriesWithinConfiguredLimits(@TempDir Path targetDir) throws Exception {
+    Map<String, byte[]> files = new LinkedHashMap<>();
+    files.put("first.bin", bytes(3));
+    files.put("second.bin", bytes(2));
+    PodOperationsImpl operation = podOperation(tarStream(files), 3L, 5L);
+
+    boolean result = operation.copy(targetDir);
+
+    assertThat(result).isTrue();
+    assertThat(targetDir).isDirectoryContaining("glob:**/first.bin");
+    assertThat(targetDir).isDirectoryContaining("glob:**/second.bin");
+  }
+
+  private static PodOperationsImpl podOperation(InputStream tarStream, Long maxFileBytes, Long maxTotalBytes) {
+    RequestConfig requestConfig = new RequestConfig(null, null, null, null, null, null, null, null, maxFileBytes,
+        maxTotalBytes);
+    OperationContext operationContext = new OperationContext().withRequestConfig(requestConfig);
+    PodOperationsImpl operation = spy(new PodOperationsImpl(new PodOperationContext().withDir(SOURCE_DIR), operationContext));
+    doReturn(tarStream).when(operation).readTar(SOURCE_DIR);
+    return operation;
+  }
+
+  private static InputStream tarStream(Map<String, byte[]> files) throws IOException {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    try (TarArchiveOutputStream tar = new TarArchiveOutputStream(output)) {
+      for (Map.Entry<String, byte[]> file : files.entrySet()) {
+        TarArchiveEntry entry = new TarArchiveEntry(file.getKey());
+        entry.setSize(file.getValue().length);
+        tar.putArchiveEntry(entry);
+        tar.write(file.getValue());
+        tar.closeArchiveEntry();
+      }
+      tar.finish();
+    }
+    return new ByteArrayInputStream(output.toByteArray());
+  }
+
+  private static byte[] oldGnuSparseTar() {
+    byte[] header = new byte[TAR_RECORD_SIZE];
+    writeAscii(header, 0, "sparse.bin");
+    writeOctal(header, 100, 8, 0644);
+    writeOctal(header, 108, 8, 0);
+    writeOctal(header, 116, 8, 0);
+    writeOctal(header, 124, 12, 1);
+    writeOctal(header, 136, 12, 0);
+    Arrays.fill(header, CHECKSUM_OFFSET, CHECKSUM_OFFSET + CHECKSUM_LENGTH, (byte) ' ');
+    header[156] = 'S';
+    writeAscii(header, 257, "ustar ");
+    header[263] = ' ';
+    writeAscii(header, 265, "root");
+    writeAscii(header, 297, "root");
+    writeOctal(header, 386, 12, 1024);
+    writeOctal(header, 398, 12, 1);
+    writeOctal(header, 483, 12, 1025);
+    writeChecksum(header);
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    output.writeBytes(header);
+    output.write('A');
+    output.writeBytes(new byte[TAR_RECORD_SIZE - 1]);
+    output.writeBytes(new byte[TAR_RECORD_SIZE * 2]);
+    return output.toByteArray();
+  }
+
+  private static void writeAscii(byte[] buffer, int offset, String value) {
+    byte[] raw = value.getBytes(StandardCharsets.US_ASCII);
+    System.arraycopy(raw, 0, buffer, offset, raw.length);
+  }
+
+  private static void writeOctal(byte[] buffer, int offset, int length, long value) {
+    writeAscii(buffer, offset, String.format(Locale.ROOT, "%0" + (length - 1) + "o", value));
+    buffer[offset + length - 1] = 0;
+  }
+
+  private static void writeChecksum(byte[] header) {
+    long checksum = 0;
+    for (byte value : header) {
+      checksum += Byte.toUnsignedInt(value);
+    }
+    writeAscii(header, CHECKSUM_OFFSET, String.format(Locale.ROOT, "%06o", checksum));
+    header[CHECKSUM_OFFSET + 6] = 0;
+    header[CHECKSUM_OFFSET + 7] = ' ';
+  }
+
+  private static byte[] bytes(int count) {
+    byte[] bytes = new byte[count];
+    Arrays.fill(bytes, (byte) 'A');
+    return bytes;
+  }
+}


### PR DESCRIPTION
## Summary
- add configurable per-file and total byte limits for pod copy extraction
- reject sparse tar entries before extraction
- preserve the existing 8-argument RequestConfig constructor and cover generated config fields

## Tests
- ./mvnw -pl kubernetes-client-api -Dtest=io.fabric8.kubernetes.client.SundrioConfigBuilderTest,io.fabric8.kubernetes.client.RequestConfigTest test
- ./mvnw -pl kubernetes-client -am -Dtest=io.fabric8.kubernetes.client.dsl.internal.core.v1.PodOperationsImplCopyLimitsTest -Dsurefire.failIfNoSpecifiedTests=false test
- ./mvnw -pl kubernetes-client-api,kubernetes-client -DskipTests spotless:check

## Notes
- Byte limits bound extracted file content bytes and sparse tar expansion. They do not bound entry count, directories, or zero-byte files; this matches existing behavior and is not a regression.