### PR TITLE
fix(java-generator): detect code injection in generated source via structural validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 7.9-SNAPSHOT
 
 #### Bugs
+* Fix #7955: (java-generator) Malicious CRD schema values can no longer inject executable code into the generated Java sources. Each generated class is re-parsed and structurally validated before it is written (with Java Unicode escape preprocessing enabled to match `javac`), so any enum value, name or description that alters the generated structure aborts generation; property descriptions additionally neutralize Unicode escape introducers
 
 #### Improvements
 

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/AbstractJSONSchema2Pojo.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/AbstractJSONSchema2Pojo.java
@@ -151,6 +151,18 @@ public abstract class AbstractJSONSchema2Pojo {
     return str.replace("\"", "\\\"").replace("\'", "\\\'");
   }
 
+  protected static String sanitizeJavadoc(String value) {
+    if (value == null) {
+      return "";
+    }
+    return value
+        .replace("&", "&amp;")
+        .replace("\\u", "&#92;u")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("*/", "&#042;&#047;");
+  }
+
   private static String getRefinedIntegerType(String format) {
     if (format == null || format.equals(INT64_CRD_TYPE)) {
       return INT64_CRD_TYPE;

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/GeneratorResult.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/GeneratorResult.java
@@ -15,7 +15,9 @@
  */
 package io.fabric8.java.generator.nodes;
 
-import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseResult;
+import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.PackageDeclaration;
 import com.github.javaparser.ast.body.BodyDeclaration;
@@ -46,13 +48,20 @@ public class GeneratorResult {
     }
 
     private static void assertStructuralIntegrity(CompilationUnit original, String javaSource) {
-      CompilationUnit reparsed;
+      final ParseResult<CompilationUnit> result;
       try {
-        reparsed = StaticJavaParser.parse(javaSource);
+        // Mirror javac, which decodes Java Unicode escapes before lexing. Without this, a schema
+        // value carrying such an escape round-trips as an inert string literal while re-parsing
+        // but breaks out of it at compile time, slipping past the structural checks below.
+        result = new JavaParser(new ParserConfiguration().setPreprocessUnicodeEscapes(true))
+            .parse(javaSource);
       } catch (Exception e) {
         throw new JavaGeneratorException(
             "Generated source failed to re-parse, possible code injection in CRD schema values", e);
       }
+      CompilationUnit reparsed = result.getResult()
+          .orElseThrow(() -> new JavaGeneratorException(
+              "Generated source failed to re-parse, possible code injection in CRD schema values"));
       List<TypeDeclaration<?>> originalTypes = original.getTypes();
       List<TypeDeclaration<?>> reparsedTypes = reparsed.getTypes();
       if (originalTypes.size() != reparsedTypes.size()) {

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/GeneratorResult.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/GeneratorResult.java
@@ -15,10 +15,17 @@
  */
 package io.fabric8.java.generator.nodes;
 
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.PackageDeclaration;
+import com.github.javaparser.ast.body.BodyDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.EnumConstantDeclaration;
 import com.github.javaparser.ast.body.EnumDeclaration;
+import com.github.javaparser.ast.body.TypeDeclaration;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.LiteralExpr;
+import io.fabric8.java.generator.exceptions.JavaGeneratorException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,6 +42,98 @@ public class GeneratorResult {
       this.name = name;
       this.cu = cu;
       this.javaSource = cu.toString();
+      assertStructuralIntegrity(cu, this.javaSource);
+    }
+
+    private static void assertStructuralIntegrity(CompilationUnit original, String javaSource) {
+      CompilationUnit reparsed;
+      try {
+        reparsed = StaticJavaParser.parse(javaSource);
+      } catch (Exception e) {
+        throw new JavaGeneratorException(
+            "Generated source failed to re-parse, possible code injection in CRD schema values", e);
+      }
+      List<TypeDeclaration<?>> originalTypes = original.getTypes();
+      List<TypeDeclaration<?>> reparsedTypes = reparsed.getTypes();
+      if (originalTypes.size() != reparsedTypes.size()) {
+        throw new JavaGeneratorException(
+            "Generated source structural mismatch: expected " + originalTypes.size()
+                + " type(s) but re-parsed " + reparsedTypes.size()
+                + ". CRD schema values may contain injected code.");
+      }
+      for (int i = 0; i < originalTypes.size(); i++) {
+        assertTypeIntegrity(originalTypes.get(i), reparsedTypes.get(i));
+      }
+    }
+
+    private static void assertTypeIntegrity(TypeDeclaration<?> original, TypeDeclaration<?> reparsed) {
+      List<BodyDeclaration<?>> origMembers = original.getMembers();
+      List<BodyDeclaration<?>> reparsedMembers = reparsed.getMembers();
+      if (origMembers.size() != reparsedMembers.size()) {
+        throw new JavaGeneratorException(
+            "Generated source structural mismatch in type '" + original.getNameAsString()
+                + "': expected " + origMembers.size() + " member(s) but re-parsed "
+                + reparsedMembers.size()
+                + ". CRD schema values may contain injected code.");
+      }
+      for (int i = 0; i < origMembers.size(); i++) {
+        if (!origMembers.get(i).getClass().equals(reparsedMembers.get(i).getClass())) {
+          throw new JavaGeneratorException(
+              "Generated source structural mismatch in type '" + original.getNameAsString()
+                  + "': member " + i + " expected " + origMembers.get(i).getClass().getSimpleName()
+                  + " but re-parsed " + reparsedMembers.get(i).getClass().getSimpleName()
+                  + ". CRD schema values may contain injected code.");
+        }
+        if (origMembers.get(i) instanceof TypeDeclaration && reparsedMembers.get(i) instanceof TypeDeclaration) {
+          assertTypeIntegrity((TypeDeclaration<?>) origMembers.get(i), (TypeDeclaration<?>) reparsedMembers.get(i));
+        }
+      }
+      if (original instanceof EnumDeclaration && reparsed instanceof EnumDeclaration) {
+        assertEnumEntriesIntegrity(
+            (EnumDeclaration) original, (EnumDeclaration) reparsed);
+      }
+    }
+
+    private static void assertEnumEntriesIntegrity(EnumDeclaration original, EnumDeclaration reparsed) {
+      List<EnumConstantDeclaration> origEntries = original.getEntries();
+      List<EnumConstantDeclaration> reparsedEntries = reparsed.getEntries();
+      if (origEntries.size() != reparsedEntries.size()) {
+        throw new JavaGeneratorException(
+            "Generated source structural mismatch in enum '" + original.getNameAsString()
+                + "': expected " + origEntries.size() + " constant(s) but re-parsed "
+                + reparsedEntries.size()
+                + ". CRD schema values may contain injected code.");
+      }
+      for (int i = 0; i < origEntries.size(); i++) {
+        assertEnumConstantIntegrity(origEntries.get(i), reparsedEntries.get(i), original.getNameAsString());
+      }
+    }
+
+    private static void assertEnumConstantIntegrity(
+        EnumConstantDeclaration original, EnumConstantDeclaration reparsed, String typeName) {
+      List<Expression> origArgs = original.getArguments();
+      List<Expression> reparsedArgs = reparsed.getArguments();
+      if (origArgs.size() != reparsedArgs.size()) {
+        throw new JavaGeneratorException(
+            "Generated source structural mismatch in enum constant '"
+                + original.getNameAsString() + "' of type '" + typeName
+                + "': expected " + origArgs.size() + " argument(s) but re-parsed "
+                + reparsedArgs.size()
+                + ". CRD schema values may contain injected code.");
+      }
+      for (int i = 0; i < origArgs.size(); i++) {
+        assertExpressionIntegrity(origArgs.get(i), reparsedArgs.get(i), typeName);
+      }
+    }
+
+    private static void assertExpressionIntegrity(Expression original, Expression reparsed, String typeName) {
+      if (original instanceof LiteralExpr && !(reparsed instanceof LiteralExpr)) {
+        throw new JavaGeneratorException(
+            "Generated source structural mismatch in type '" + typeName
+                + "': expected a literal expression but re-parsed "
+                + reparsed.getClass().getSimpleName()
+                + ". CRD schema values may contain injected code.");
+      }
     }
 
     public String getName() {

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JObject.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JObject.java
@@ -260,11 +260,7 @@ public class JObject extends AbstractJSONSchema2Pojo implements JObjectExtraAnno
         }
 
         if (Utils.isNotNullOrEmpty(prop.getDescription())) {
-          objField.setJavadocComment(prop.getDescription()
-              .replace("&", "&amp;")
-              .replace("<", "&lt;")
-              .replace(">", "&gt;")
-              .replace("*/", "&#042;&#047;"));
+          objField.setJavadocComment(sanitizeJavadoc(prop.getDescription()));
 
           objField.addAnnotation(
               new SingleMemberAnnotationExpr(

--- a/java-generator/core/src/test/java/io/fabric8/java/generator/CompilationTest.java
+++ b/java-generator/core/src/test/java/io/fabric8/java/generator/CompilationTest.java
@@ -133,6 +133,35 @@ class CompilationTest {
         "The current CRD should not compile since it contains duplicate fields which are not marked as deprecated");
   }
 
+  @Test
+  void rejectsInjectedCodeInNumericEnumFromCrd() throws Exception {
+    // Arrange
+    File crd = getCRD("malicious-numeric-enum-crd.yml");
+
+    // Act & Assert
+    JavaGeneratorException exception = assertThrows(
+        JavaGeneratorException.class,
+        () -> new FileJavaGenerator(config, crd).run(tempDir));
+
+    assertTrue(exception.getMessage().contains("structural mismatch"));
+    assertTrue(getSources(tempDir).isEmpty(), "Rejected CRDs must not emit Java source files");
+  }
+
+  @Test
+  void rejectsExpressionInjectionInNumericEnumFromCrd() throws Exception {
+    // Arrange
+    File crd = getCRD("malicious-expression-enum-crd.yml");
+
+    // Act & Assert
+    JavaGeneratorException exception = assertThrows(
+        JavaGeneratorException.class,
+        () -> new FileJavaGenerator(config, crd).run(tempDir));
+
+    String msg = exception.getMessage();
+    assertTrue(msg.contains("structural mismatch") || msg.contains("code injection"),
+        "Expected injection detection message but got: " + msg);
+  }
+
   static List<JavaFileObject> getSources(File basePath) throws IOException {
     List<JavaFileObject> sources = new ArrayList<JavaFileObject>();
     for (Path f : Files.list(basePath.toPath()).collect(Collectors.toList())) {

--- a/java-generator/core/src/test/java/io/fabric8/java/generator/CompilationTest.java
+++ b/java-generator/core/src/test/java/io/fabric8/java/generator/CompilationTest.java
@@ -162,6 +162,21 @@ class CompilationTest {
         "Expected injection detection message but got: " + msg);
   }
 
+  @Test
+  void rejectsUnicodeEscapeInjectionInGeneratedSource() throws Exception {
+    // Arrange: a CRD whose `names.singular` smuggles a Java Unicode escape that re-parses as an
+    // inert string literal but breaks out of the generated @Singular literal once javac decodes it.
+    File crd = getCRD("malicious-unicode-escape-crd.yml");
+
+    // Act & Assert
+    JavaGeneratorException exception = assertThrows(
+        JavaGeneratorException.class,
+        () -> new FileJavaGenerator(config, crd).run(tempDir));
+
+    assertTrue(exception.getMessage().contains("structural mismatch"));
+    assertTrue(getSources(tempDir).isEmpty(), "Rejected CRDs must not emit Java source files");
+  }
+
   static List<JavaFileObject> getSources(File basePath) throws IOException {
     List<JavaFileObject> sources = new ArrayList<JavaFileObject>();
     for (Path f : Files.list(basePath.toPath()).collect(Collectors.toList())) {

--- a/java-generator/core/src/test/java/io/fabric8/java/generator/GeneratorTest.java
+++ b/java-generator/core/src/test/java/io/fabric8/java/generator/GeneratorTest.java
@@ -1144,6 +1144,32 @@ class GeneratorTest {
   }
 
   @Test
+  void testFieldDescriptionWithUnicodeEscapeIsNeutralized() {
+    // Arrange
+    Map<String, JSONSchemaProps> props = new HashMap<>();
+    JSONSchemaProps field = new JSONSchemaProps();
+    field.setType("string");
+    field.setDescription("Use HKEY\\Path & keep \\t but block \\u002a/");
+    props.put("myField", field);
+
+    JObject obj = new JObject(null, "t", props, null, false, defaultConfig, null, Boolean.FALSE, null);
+
+    // Act
+    GeneratorResult res = obj.generateJava();
+
+    // Assert
+    Optional<ClassOrInterfaceDeclaration> clzT = res.getTopLevelClasses().get(0).getClassByName("T");
+    assertTrue(clzT.isPresent());
+    FieldDeclaration fieldDecl = clzT.get().getFieldByName("myField").get();
+    String javadoc = fieldDecl.getJavadocComment().get().getContent();
+    assertThat(javadoc).contains("HKEY\\Path");
+    assertThat(javadoc).contains("&amp;");
+    assertThat(javadoc).contains("\\t");
+    assertThat(javadoc).contains("&#92;u002a/");
+    assertThat(javadoc).doesNotContain("&amp;#92;");
+  }
+
+  @Test
   void testFieldDescriptionWithCommentTerminatorIsEscapedInJavadoc() {
     // Arrange
     Map<String, JSONSchemaProps> props = new HashMap<>();

--- a/java-generator/core/src/test/resources/malicious-expression-enum-crd.yml
+++ b/java-generator/core/src/test/resources/malicious-expression-enum-crd.yml
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: expressionenums.example.com
+spec:
+  group: example.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                mode:
+                  type: integer
+                  format: int32
+                  enum:
+                    - "1 + 0*System.getProperties().size()"
+  scope: Namespaced
+  names:
+    plural: expressionenums
+    singular: expressionenum
+    kind: ExpressionEnum

--- a/java-generator/core/src/test/resources/malicious-numeric-enum-crd.yml
+++ b/java-generator/core/src/test/resources/malicious-numeric-enum-crd.yml
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: numericenums.example.com
+spec:
+  group: example.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                mode:
+                  type: integer
+                  enum:
+                    - "1L); static { int injected = 0; } //"
+  scope: Namespaced
+  names:
+    plural: numericenums
+    singular: numericenum
+    kind: NumericEnum

--- a/java-generator/core/src/test/resources/malicious-unicode-escape-crd.yml
+++ b/java-generator/core/src/test/resources/malicious-unicode-escape-crd.yml
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# The `singular` name smuggles a Java Unicode escape (\u0022) that re-parses as an inert
+# string literal but, once javac decodes the escape before lexing, closes the @Singular string
+# literal and injects an extra top-level class with a static initializer into the generated source.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: foos.example.com
+spec:
+  group: example.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                field:
+                  type: string
+  scope: Namespaced
+  names:
+    plural: foos
+    singular: '\u0022) class Pwned { static { java.lang.Runtime.getRuntime(); } } @SuppressWarnings(\u0022'
+    kind: Foo


### PR DESCRIPTION
Supersedes and closes #7955.

Detects code injection in the generated Java sources via structural validation: every generated class is re-parsed (with Java Unicode escape preprocessing enabled so it matches what `javac` sees) and a structural mismatch aborts generation before any source is written. Property descriptions additionally neutralize Unicode escape introducers.

Happy to hear feedback!
