### PR TITLE
fix(java-generator): escape schema-controlled values at generated-source sinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### 7.9-SNAPSHOT
 
 #### Bugs
-* Fix #7955: (java-generator) Malicious CRD schema values can no longer inject executable code into the generated Java sources. Each generated class is re-parsed and structurally validated before it is written (with Java Unicode escape preprocessing enabled to match `javac`), so any enum value, name or description that alters the generated structure aborts generation; property descriptions additionally neutralize Unicode escape introducers
+* Fix #7955: (java-generator) Malicious CRD schema values can no longer inject executable code into the generated Java sources. Schema-controlled values (enum values, CRD group/version/names, property names, descriptions and defaults) are emitted as fully escaped Java string literals, so a value carrying a Unicode-escaped quote cannot break out of its literal once `javac` decodes it. As a defense in depth, each generated class is also re-parsed and structurally validated before it is written (with Java Unicode escape preprocessing enabled to match `javac`), aborting generation on any residual structural mismatch
 
 #### Improvements
 

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/AbstractJSONSchema2Pojo.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/AbstractJSONSchema2Pojo.java
@@ -147,10 +147,6 @@ public abstract class AbstractJSONSchema2Pojo {
     return sanitized;
   }
 
-  public static String escapeQuotes(String str) {
-    return str.replace("\"", "\\\"").replace("\'", "\\\'");
-  }
-
   protected static String sanitizeJavadoc(String value) {
     if (value == null) {
       return "";

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JCRObject.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JCRObject.java
@@ -20,9 +20,10 @@ import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.PackageDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.expr.BooleanLiteralExpr;
+import com.github.javaparser.ast.expr.MemberValuePair;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.Name;
-import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.expr.NormalAnnotationExpr;
 import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
@@ -89,15 +90,12 @@ public class JCRObject extends JObject implements JObjectExtraAnnotations {
     ClassOrInterfaceDeclaration clz = cu.addClass(className);
 
     clz.addAnnotation(
-        new SingleMemberAnnotationExpr(
+        new NormalAnnotationExpr(
             new Name("io.fabric8.kubernetes.model.annotation.Version"),
-            new NameExpr(
-                "value = \""
-                    + StringEscapeUtils.escapeJava(version)
-                    + "\" , storage = "
-                    + storage
-                    + " , served = "
-                    + served)));
+            new NodeList<>(
+                new MemberValuePair("value", new StringLiteralExpr(StringEscapeUtils.escapeJava(version))),
+                new MemberValuePair("storage", new BooleanLiteralExpr(storage)),
+                new MemberValuePair("served", new BooleanLiteralExpr(served)))));
     clz.addAnnotation(
         new SingleMemberAnnotationExpr(
             new Name("io.fabric8.kubernetes.model.annotation.Group"),

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JCRObject.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JCRObject.java
@@ -30,6 +30,7 @@ import com.github.javaparser.ast.expr.SuperExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.utils.StringEscapeUtils;
 import io.fabric8.java.generator.Config;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps;
 
@@ -92,7 +93,7 @@ public class JCRObject extends JObject implements JObjectExtraAnnotations {
             new Name("io.fabric8.kubernetes.model.annotation.Version"),
             new NameExpr(
                 "value = \""
-                    + version
+                    + StringEscapeUtils.escapeJava(version)
                     + "\" , storage = "
                     + storage
                     + " , served = "
@@ -100,20 +101,20 @@ public class JCRObject extends JObject implements JObjectExtraAnnotations {
     clz.addAnnotation(
         new SingleMemberAnnotationExpr(
             new Name("io.fabric8.kubernetes.model.annotation.Group"),
-            new StringLiteralExpr(group)));
+            new StringLiteralExpr(StringEscapeUtils.escapeJava(group))));
 
     if (singular != null) {
       clz.addAnnotation(
           new SingleMemberAnnotationExpr(
               new Name("io.fabric8.kubernetes.model.annotation.Singular"),
-              new StringLiteralExpr(singular)));
+              new StringLiteralExpr(StringEscapeUtils.escapeJava(singular))));
     }
 
     if (plural != null) {
       clz.addAnnotation(
           new SingleMemberAnnotationExpr(
               new Name("io.fabric8.kubernetes.model.annotation.Plural"),
-              new StringLiteralExpr(plural)));
+              new StringLiteralExpr(StringEscapeUtils.escapeJava(plural))));
     }
 
     ClassOrInterfaceType jlVoid = new ClassOrInterfaceType().setName("java.lang.Void");

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JEnum.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JEnum.java
@@ -24,6 +24,7 @@ import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.IfStmt;
 import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.ast.stmt.Statement;
+import com.github.javaparser.utils.StringEscapeUtils;
 import io.fabric8.java.generator.Config;
 
 import java.util.ArrayList;
@@ -181,21 +182,23 @@ public class JEnum extends AbstractJSONSchema2Pojo {
       String constantName = constantNameBuilder.toString();
       constantNames.add(constantName);
 
-      String originalName = AbstractJSONSchema2Pojo.escapeQuotes(k);
-      Expression valueArgument = new StringLiteralExpr(originalName);
-      if (!underlyingType.equals(JAVA_LANG_STRING)) {
-        if (underlyingType.equals(JAVA_LANG_LONG) && !originalName.endsWith("L")) {
-          valueArgument = new IntegerLiteralExpr(originalName + "L");
-        } else {
-          valueArgument = new IntegerLiteralExpr(originalName);
-        }
+      // Schema-controlled string values must be emitted as fully escaped Java string literals so a
+      // value carrying a Unicode-escaped quote cannot break out of the literal once javac decodes
+      // it. Non-string (numeric) values are emitted as numeric literals and validated structurally.
+      Expression valueArgument;
+      if (underlyingType.equals(JAVA_LANG_STRING)) {
+        valueArgument = new StringLiteralExpr(StringEscapeUtils.escapeJava(k));
+      } else if (underlyingType.equals(JAVA_LANG_LONG) && !k.endsWith("L")) {
+        valueArgument = new IntegerLiteralExpr(k + "L");
+      } else {
+        valueArgument = new IntegerLiteralExpr(k);
       }
 
       EnumConstantDeclaration decl = new EnumConstantDeclaration();
       decl.addAnnotation(
           new SingleMemberAnnotationExpr(
               new Name("com.fasterxml.jackson.annotation.JsonProperty"),
-              new StringLiteralExpr(originalName)));
+              new StringLiteralExpr(StringEscapeUtils.escapeJava(k))));
       decl.setName(constantName);
       decl.addArgument(valueArgument);
       en.addEntry(decl);

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JObject.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JObject.java
@@ -136,7 +136,7 @@ public class JObject extends AbstractJSONSchema2Pojo implements JObjectExtraAnno
   }
 
   private String getSortedFieldsAsParam(Set<String> list) {
-    List<String> sortedFields = list.stream().map(AbstractJSONSchema2Pojo::escapeQuotes).sorted().collect(Collectors.toList());
+    List<String> sortedFields = list.stream().map(StringEscapeUtils::escapeJava).sorted().collect(Collectors.toList());
 
     StringBuilder sb = new StringBuilder();
     sb.append("{");
@@ -213,7 +213,7 @@ public class JObject extends AbstractJSONSchema2Pojo implements JObjectExtraAnno
       }
       buffer.addAll(gr.getTopLevelClasses());
 
-      String originalFieldName = AbstractJSONSchema2Pojo.escapeQuotes(k);
+      String originalFieldName = StringEscapeUtils.escapeJava(k);
       String fieldName = AbstractJSONSchema2Pojo.sanitizeString(k);
       String fieldType = prop.getType();
 

--- a/java-generator/core/src/test/java/io/fabric8/java/generator/CompilationTest.java
+++ b/java-generator/core/src/test/java/io/fabric8/java/generator/CompilationTest.java
@@ -163,18 +163,34 @@ class CompilationTest {
   }
 
   @Test
-  void rejectsUnicodeEscapeInjectionInGeneratedSource() throws Exception {
-    // Arrange: a CRD whose `names.singular` smuggles a Java Unicode escape that re-parses as an
-    // inert string literal but breaks out of the generated @Singular literal once javac decodes it.
+  void neutralizesUnicodeEscapeInjectionInCrdNames() throws Exception {
+    // Arrange: a CRD whose `names.singular` smuggles a Java Unicode escape that, left unescaped,
+    // would break out of the generated @Singular string literal once javac decodes it.
     File crd = getCRD("malicious-unicode-escape-crd.yml");
 
-    // Act & Assert
-    JavaGeneratorException exception = assertThrows(
-        JavaGeneratorException.class,
-        () -> new FileJavaGenerator(config, crd).run(tempDir));
+    // Act: the value is now emitted as a fully escaped (inert) string literal, so generation
+    // succeeds and the result compiles. A real breakout would still trip the structural validation.
+    new FileJavaGenerator(config, crd).run(tempDir);
+    Compilation compilation = javac().compile(getSources(tempDir));
 
-    assertTrue(exception.getMessage().contains("structural mismatch"));
-    assertTrue(getSources(tempDir).isEmpty(), "Rejected CRDs must not emit Java source files");
+    // Assert
+    assertTrue(compilation.errors().isEmpty());
+    assertEquals(Compilation.Status.SUCCESS, compilation.status());
+  }
+
+  @Test
+  void compilesStringEnumValueContainingBackslash() throws Exception {
+    // Arrange: a backslash in a schema value (here a Windows-style path) must be escaped, not
+    // mistaken for a broken Java escape sequence that aborts generation.
+    File crd = getCRD("backslash-enum-crd.yml");
+
+    // Act
+    new FileJavaGenerator(config, crd).run(tempDir);
+    Compilation compilation = javac().compile(getSources(tempDir));
+
+    // Assert
+    assertTrue(compilation.errors().isEmpty());
+    assertEquals(Compilation.Status.SUCCESS, compilation.status());
   }
 
   static List<JavaFileObject> getSources(File basePath) throws IOException {

--- a/java-generator/core/src/test/java/io/fabric8/java/generator/CompilationTest.java
+++ b/java-generator/core/src/test/java/io/fabric8/java/generator/CompilationTest.java
@@ -163,12 +163,13 @@ class CompilationTest {
   }
 
   @Test
-  void neutralizesUnicodeEscapeInjectionInCrdNames() throws Exception {
-    // Arrange: a CRD whose `names.singular` smuggles a Java Unicode escape that, left unescaped,
-    // would break out of the generated @Singular string literal once javac decodes it.
+  void neutralizesUnicodeEscapeInjectionInSchemaValues() throws Exception {
+    // Arrange: a CRD whose `names.singular`, `names.plural` and a string enum value each smuggle a
+    // Java Unicode escape that, left unescaped, would break out of the generated string literal once
+    // javac decodes it (@Singular, @Plural, the enum constant value and its @JsonProperty).
     File crd = getCRD("malicious-unicode-escape-crd.yml");
 
-    // Act: the value is now emitted as a fully escaped (inert) string literal, so generation
+    // Act: every value is now emitted as a fully escaped (inert) string literal, so generation
     // succeeds and the result compiles. A real breakout would still trip the structural validation.
     new FileJavaGenerator(config, crd).run(tempDir);
     Compilation compilation = javac().compile(getSources(tempDir));
@@ -176,6 +177,22 @@ class CompilationTest {
     // Assert
     assertTrue(compilation.errors().isEmpty());
     assertEquals(Compilation.Status.SUCCESS, compilation.status());
+  }
+
+  @Test
+  void rejectsUnicodeEscapeInjectionInCrdVersion() throws Exception {
+    // Arrange: the version name feeds the generated package declaration, not only the @Version
+    // annotation, so a Unicode-escaped breakout there cannot be neutralized by literal escaping and
+    // must be rejected by the structural validation (same reasoning applies to the CRD group).
+    File crd = getCRD("malicious-version-crd.yml");
+
+    // Act & Assert
+    JavaGeneratorException exception = assertThrows(
+        JavaGeneratorException.class,
+        () -> new FileJavaGenerator(config, crd).run(tempDir));
+
+    assertTrue(exception.getMessage().contains("code injection"));
+    assertTrue(getSources(tempDir).isEmpty(), "Rejected CRDs must not emit Java source files");
   }
 
   @Test

--- a/java-generator/core/src/test/resources/backslash-enum-crd.yml
+++ b/java-generator/core/src/test/resources/backslash-enum-crd.yml
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# A benign string enum whose values contain backslashes (Windows-style paths). The backslash must
+# be escaped when emitted, not treated as a broken Java escape sequence that aborts generation.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: registrykeys.example.com
+spec:
+  group: example.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                regKey:
+                  type: string
+                  enum:
+                    - 'HKEY\Software'
+                    - 'HKEY\System'
+  scope: Namespaced
+  names:
+    plural: registrykeys
+    singular: registrykey
+    kind: RegistryKey

--- a/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testAkkaMicroservicesCrd.approved.txt
+++ b/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testAkkaMicroservicesCrd.approved.txt
@@ -1,6 +1,6 @@
 AkkaMicroserviceJavaCr[0] = package org.test.v1;
 
-@io.fabric8.kubernetes.model.annotation.Version(value = "v1" , storage = true , served = true)
+@io.fabric8.kubernetes.model.annotation.Version(value = "v1", storage = true, served = true)
 @io.fabric8.kubernetes.model.annotation.Group("akka.lightbend.com")
 @io.fabric8.kubernetes.model.annotation.Singular("akkamicroservice")
 @io.fabric8.kubernetes.model.annotation.Plural("akkamicroservices")

--- a/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testCalicoIPPoolCrd.approved.txt
+++ b/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testCalicoIPPoolCrd.approved.txt
@@ -1,6 +1,6 @@
 CalicoIPPoolCr[0] = package org.test.v1;
 
-@io.fabric8.kubernetes.model.annotation.Version(value = "v1" , storage = true , served = true)
+@io.fabric8.kubernetes.model.annotation.Version(value = "v1", storage = true, served = true)
 @io.fabric8.kubernetes.model.annotation.Group("crd.projectcalico.org")
 @io.fabric8.kubernetes.model.annotation.Singular("ippool")
 @io.fabric8.kubernetes.model.annotation.Plural("ippools")

--- a/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testCrontabCrd.approved.txt
+++ b/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testCrontabCrd.approved.txt
@@ -1,6 +1,6 @@
 CrontabJavaCr[0] = package org.test.v1;
 
-@io.fabric8.kubernetes.model.annotation.Version(value = "v1" , storage = true , served = true)
+@io.fabric8.kubernetes.model.annotation.Version(value = "v1", storage = true, served = true)
 @io.fabric8.kubernetes.model.annotation.Group("stable.example.com")
 @io.fabric8.kubernetes.model.annotation.Singular("crontab")
 @io.fabric8.kubernetes.model.annotation.Plural("crontabs")

--- a/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testCrontabExtraAnnotationsCrd.approved.txt
+++ b/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testCrontabExtraAnnotationsCrd.approved.txt
@@ -1,6 +1,6 @@
 CrontabJavaExtraAnnotationsCr[0] = package org.test.v1;
 
-@io.fabric8.kubernetes.model.annotation.Version(value = "v1" , storage = true , served = true)
+@io.fabric8.kubernetes.model.annotation.Version(value = "v1", storage = true, served = true)
 @io.fabric8.kubernetes.model.annotation.Group("stable.example.com")
 @io.fabric8.kubernetes.model.annotation.Singular("crontab")
 @io.fabric8.kubernetes.model.annotation.Plural("crontabs")

--- a/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testExistingJavaType.approved.txt
+++ b/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testExistingJavaType.approved.txt
@@ -1,6 +1,6 @@
 ExistingJavaTypeCr[0] = package org.test.v1;
 
-@io.fabric8.kubernetes.model.annotation.Version(value = "v1" , storage = true , served = true)
+@io.fabric8.kubernetes.model.annotation.Version(value = "v1", storage = true, served = true)
 @io.fabric8.kubernetes.model.annotation.Group("example.com")
 @io.fabric8.kubernetes.model.annotation.Plural("existingJavaTypes")
 @javax.annotation.processing.Generated("io.fabric8.java.generator.CRGeneratorRunner")

--- a/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testJokeCrd.approved.txt
+++ b/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testJokeCrd.approved.txt
@@ -1,6 +1,6 @@
 JokeRequestJavaCr[0] = package org.test.v1alpha1;
 
-@io.fabric8.kubernetes.model.annotation.Version(value = "v1alpha1" , storage = true , served = true)
+@io.fabric8.kubernetes.model.annotation.Version(value = "v1alpha1", storage = true, served = true)
 @io.fabric8.kubernetes.model.annotation.Group("samples.javaoperatorsdk.io")
 @io.fabric8.kubernetes.model.annotation.Singular("jokerequest")
 @io.fabric8.kubernetes.model.annotation.Plural("jokerequests")

--- a/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testKeycloakCrd.approved.txt
+++ b/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testKeycloakCrd.approved.txt
@@ -1,6 +1,6 @@
 KeycloakJavaCr[0] = package org.test.v1alpha1;
 
-@io.fabric8.kubernetes.model.annotation.Version(value = "v1alpha1" , storage = true , served = true)
+@io.fabric8.kubernetes.model.annotation.Version(value = "v1alpha1", storage = true, served = true)
 @io.fabric8.kubernetes.model.annotation.Group("keycloak.org")
 @io.fabric8.kubernetes.model.annotation.Singular("keycloak")
 @io.fabric8.kubernetes.model.annotation.Plural("keycloaks")

--- a/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testRequireSpecAndStatusCrd.approved.txt
+++ b/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testRequireSpecAndStatusCrd.approved.txt
@@ -1,6 +1,6 @@
 RequireSpecAndStatusJavaCr[0] = package org.test.v1;
 
-@io.fabric8.kubernetes.model.annotation.Version(value = "v1" , storage = true , served = true)
+@io.fabric8.kubernetes.model.annotation.Version(value = "v1", storage = true, served = true)
 @io.fabric8.kubernetes.model.annotation.Group("stable.example.com")
 @io.fabric8.kubernetes.model.annotation.Singular("requirespecandstatus")
 @io.fabric8.kubernetes.model.annotation.Plural("requirespecandstatuses")

--- a/java-generator/core/src/test/resources/malicious-version-crd.yml
+++ b/java-generator/core/src/test/resources/malicious-version-crd.yml
@@ -14,10 +14,9 @@
 # limitations under the License.
 #
 
-# Several schema-controlled values (the singular and plural names, and a string enum value) smuggle
-# a Java Unicode escape that, left unescaped, would break out of the generated string literal once
-# javac decodes it. Each must be emitted as an inert, fully escaped literal. (group/version are not
-# exercised here because they also feed the generated package name and are covered separately.)
+# The version name feeds the generated package declaration (not only the @Version annotation), so a
+# Unicode-escaped breakout here cannot be neutralized by literal escaping and must be rejected by the
+# structural validation. The same reasoning applies to the CRD group.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -25,7 +24,7 @@ metadata:
 spec:
   group: example.com
   versions:
-    - name: v1
+    - name: 'v\u0022) class PwnedVersion { static { java.lang.Runtime.getRuntime(); } } //'
       served: true
       storage: true
       schema:
@@ -35,13 +34,10 @@ spec:
             spec:
               type: object
               properties:
-                mode:
+                field:
                   type: string
-                  enum:
-                    - 'A\u0022) class PwnedEnum { static { java.lang.Runtime.getRuntime(); } } //'
-                    - 'safe'
   scope: Namespaced
   names:
-    plural: '\u0022s) class PwnedPlural { static { java.lang.Runtime.getRuntime(); } } @SuppressWarnings(\u0022'
-    singular: '\u0022) class Pwned { static { java.lang.Runtime.getRuntime(); } } @SuppressWarnings(\u0022'
+    plural: foos
+    singular: foo
     kind: Foo


### PR DESCRIPTION
Follow-up to #7976, hardening the java-generator code-injection fix.

#7976 added a structural re-validation that detects injection in the generated sources. This fixes the root cause: every schema-controlled value is now emitted as a fully escaped Java string literal at the sink, so a malicious value can never break out of its literal in the first place.

Sinks now escaped via `StringEscapeUtils.escapeJava` (the escaper already used for `@Pattern`, `@JsonPropertyDescription` and defaults):
- `JCRObject`: `@Group`, `@Version`, `@Singular`, `@Plural`
- `JEnum`: the string enum value and its `@JsonProperty`
- `JObject`: the property-name `@JsonProperty` and the `@JsonPropertyOrder` field list

The structural validation from #7976 stays as defense in depth. The `escapeQuotes` helper, which only escaped quotes and never backslashes (the gap behind the Unicode-escape bypass), is removed now that it has no callers.

This also fixes a latent false positive: a benign value containing a backslash (such as a Windows registry path) previously produced an invalid Java escape that aborted generation, and now compiles.
