### PR TITLE
feat(kubernetes-model-batch): commit sundrio Builders to VCS, skip APT in default build (#5622)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
 # eol style
 *.sh    text eol=lf
 *.bat   text eol=crlf
+
+# Generated source trees (openapi POJOs + sundrio Builders/Fluents): collapse diffs in PR review
+**/src/generated/java/** linguist-generated=true
+**/src/generated-builders/java/** linguist-generated=true

--- a/.github/workflows/generate-model.yml
+++ b/.github/workflows/generate-model.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           git add .
           IGNORED_PATTERNS="validation-schema.json"
-          INCLUDE_PATTERNS="kube-schema.json\|src/generated/java\|src/generated/resources\|openapi/schemas/"
+          INCLUDE_PATTERNS="kube-schema.json\|src/generated/java\|src/generated-builders/java\|src/generated/resources\|openapi/schemas/"
           MODIFIED_FILES_COUNT=$(git status | grep -v "$IGNORED_PATTERNS" | grep "$INCLUDE_PATTERNS" | wc -l)
           if [ $MODIFIED_FILES_COUNT -eq "0" ]; then
             echo "No Schema files modified. Build Success.";

--- a/kubernetes-model-generator/kubernetes-model-batch/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-batch/pom.xml
@@ -43,6 +43,50 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-generated-builders-source</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${project.basedir}/src/generated-builders/java</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!-- Default build: run only Lombok (keep equals/hashCode/toString); sundrio APT is
+               disabled so the committed Builders/Fluents in src/generated-builders/java are
+               compiled as plain source instead of being regenerated.
+               FOLLOW-UP (#5622): these processor class names are Lombok internals coupled to the
+               pinned ${lombok.version}; a rename on a version bump fails loudly (processor-not-found),
+               not silently. A less brittle alternative for THIS (default) build is to drop the named
+               processors and instead restrict <annotationProcessorPaths> to the lombok artifact only
+               (javac auto-discovers it via Lombok's META-INF/services, sundrio is simply not on the
+               path so it never runs). The named-processors-on-classpath approach is only strictly
+               required by the generate profile (so sundrio resolves referenced Builders from
+               dependency jars). Evaluate when lifting this config to the model parent pom. -->
+          <annotationProcessors>
+            <annotationProcessor>lombok.launch.AnnotationProcessorHider$AnnotationProcessor</annotationProcessor>
+            <annotationProcessor>lombok.launch.AnnotationProcessorHider$ClaimingProcessor</annotationProcessor>
+          </annotationProcessors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>generate</id>
@@ -64,6 +108,25 @@
                   <includeGenerationRegex>^io\.k8s\.api\.batch\..*$</includeGenerationRegex>
                 </includeGenerationRegexes>
               </settings>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <!-- Regeneration: sundrio APT writes Builders/Fluents straight into the committed
+                   src/generated-builders/java (a dedicated source root, kept separate from the
+                   POJOs so the compiler's pre-APT wipe of generatedSourcesDirectory only clears
+                   the Builders). Processors are named (not put on a separate processor path) so
+                   sundrio resolves referenced Builders from the compile classpath (dependency
+                   jars) instead of re-emitting shallow copies of them. -->
+              <generatedSourcesDirectory>${project.basedir}/src/generated-builders/java</generatedSourcesDirectory>
+              <annotationProcessors combine.self="override">
+                <annotationProcessor>lombok.launch.AnnotationProcessorHider$AnnotationProcessor</annotationProcessor>
+                <annotationProcessor>lombok.launch.AnnotationProcessorHider$ClaimingProcessor</annotationProcessor>
+                <annotationProcessor>io.sundr.builder.internal.processor.BuildableProcessor</annotationProcessor>
+                <annotationProcessor>io.sundr.builder.internal.processor.ExternalBuildableProcessor</annotationProcessor>
+              </annotationProcessors>
             </configuration>
           </plugin>
         </plugins>

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/CronJobBuilder.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/CronJobBuilder.java
@@ -1,0 +1,33 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
+import java.lang.Object;
+public class CronJobBuilder extends CronJobFluent<CronJobBuilder> implements VisitableBuilder<CronJob,CronJobBuilder>{
+
+  CronJobFluent<?> fluent;
+
+  public CronJobBuilder() {
+    this(new CronJob());
+  }
+  
+  public CronJobBuilder(CronJobFluent<?> fluent) {
+    this(fluent, new CronJob());
+  }
+  
+  public CronJobBuilder(CronJob instance) {
+    this.fluent = this;
+    this.copyInstance(instance);
+  }
+  
+  public CronJobBuilder(CronJobFluent<?> fluent,CronJob instance) {
+    this.fluent = fluent;
+    fluent.copyInstance(instance);
+  }
+
+  public CronJob build() {
+    CronJob buildable = new CronJob(fluent.getApiVersion(), fluent.getKind(), fluent.buildMetadata(), fluent.buildSpec(), fluent.buildStatus());
+    buildable.setAdditionalProperties(fluent.getAdditionalProperties());
+    return buildable;
+  }
+  
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/CronJobFluent.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/CronJobFluent.java
@@ -1,0 +1,378 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.BaseFluent;
+import io.fabric8.kubernetes.api.builder.Nested;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMetaFluent;
+import java.lang.Object;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.lang.SuppressWarnings;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Generated
+ */
+@SuppressWarnings("unchecked")
+public class CronJobFluent<A extends io.fabric8.kubernetes.api.model.batch.v1.CronJobFluent<A>> extends BaseFluent<A>{
+
+  private Map<String,Object> additionalProperties;
+  private String apiVersion;
+  private String kind;
+  private ObjectMetaBuilder metadata;
+  private CronJobSpecBuilder spec;
+  private CronJobStatusBuilder status;
+
+  public CronJobFluent() {
+  }
+  
+  public CronJobFluent(CronJob instance) {
+    this.copyInstance(instance);
+  }
+
+  public A addToAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null && map != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (map != null) {
+      this.additionalProperties.putAll(map);
+    }
+    return (A) this;
+  }
+  
+  public A addToAdditionalProperties(String key,Object value) {
+    if (this.additionalProperties == null && key != null && value != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (key != null && value != null) {
+      this.additionalProperties.put(key, value);
+    }
+    return (A) this;
+  }
+  
+  public ObjectMeta buildMetadata() {
+    return this.metadata != null ? this.metadata.build() : null;
+  }
+  
+  public CronJobSpec buildSpec() {
+    return this.spec != null ? this.spec.build() : null;
+  }
+  
+  public CronJobStatus buildStatus() {
+    return this.status != null ? this.status.build() : null;
+  }
+  
+  protected void copyInstance(CronJob instance) {
+    instance = instance != null ? instance : new CronJob();
+    if (instance != null) {
+        this.withApiVersion(instance.getApiVersion());
+        this.withKind(instance.getKind());
+        this.withMetadata(instance.getMetadata());
+        this.withSpec(instance.getSpec());
+        this.withStatus(instance.getStatus());
+        this.withAdditionalProperties(instance.getAdditionalProperties());
+    }
+  }
+  
+  public MetadataNested<A> editMetadata() {
+    return this.withNewMetadataLike(Optional.ofNullable(this.buildMetadata()).orElse(null));
+  }
+  
+  public MetadataNested<A> editOrNewMetadata() {
+    return this.withNewMetadataLike(Optional.ofNullable(this.buildMetadata()).orElse(new ObjectMetaBuilder().build()));
+  }
+  
+  public MetadataNested<A> editOrNewMetadataLike(ObjectMeta item) {
+    return this.withNewMetadataLike(Optional.ofNullable(this.buildMetadata()).orElse(item));
+  }
+  
+  public SpecNested<A> editOrNewSpec() {
+    return this.withNewSpecLike(Optional.ofNullable(this.buildSpec()).orElse(new CronJobSpecBuilder().build()));
+  }
+  
+  public SpecNested<A> editOrNewSpecLike(CronJobSpec item) {
+    return this.withNewSpecLike(Optional.ofNullable(this.buildSpec()).orElse(item));
+  }
+  
+  public StatusNested<A> editOrNewStatus() {
+    return this.withNewStatusLike(Optional.ofNullable(this.buildStatus()).orElse(new CronJobStatusBuilder().build()));
+  }
+  
+  public StatusNested<A> editOrNewStatusLike(CronJobStatus item) {
+    return this.withNewStatusLike(Optional.ofNullable(this.buildStatus()).orElse(item));
+  }
+  
+  public SpecNested<A> editSpec() {
+    return this.withNewSpecLike(Optional.ofNullable(this.buildSpec()).orElse(null));
+  }
+  
+  public StatusNested<A> editStatus() {
+    return this.withNewStatusLike(Optional.ofNullable(this.buildStatus()).orElse(null));
+  }
+  
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || this.getClass() != o.getClass()) {
+      return false;
+    }
+    if (!(super.equals(o))) {
+      return false;
+    }
+    CronJobFluent that = (CronJobFluent) o;
+    if (!(Objects.equals(apiVersion, that.apiVersion))) {
+      return false;
+    }
+    if (!(Objects.equals(kind, that.kind))) {
+      return false;
+    }
+    if (!(Objects.equals(metadata, that.metadata))) {
+      return false;
+    }
+    if (!(Objects.equals(spec, that.spec))) {
+      return false;
+    }
+    if (!(Objects.equals(status, that.status))) {
+      return false;
+    }
+    if (!(Objects.equals(additionalProperties, that.additionalProperties))) {
+      return false;
+    }
+    return true;
+  }
+  
+  public Map<String,Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
+  
+  public String getApiVersion() {
+    return this.apiVersion;
+  }
+  
+  public String getKind() {
+    return this.kind;
+  }
+  
+  public boolean hasAdditionalProperties() {
+    return this.additionalProperties != null;
+  }
+  
+  public boolean hasApiVersion() {
+    return this.apiVersion != null;
+  }
+  
+  public boolean hasKind() {
+    return this.kind != null;
+  }
+  
+  public boolean hasMetadata() {
+    return this.metadata != null;
+  }
+  
+  public boolean hasSpec() {
+    return this.spec != null;
+  }
+  
+  public boolean hasStatus() {
+    return this.status != null;
+  }
+  
+  public int hashCode() {
+    return Objects.hash(apiVersion, kind, metadata, spec, status, additionalProperties);
+  }
+  
+  public A removeFromAdditionalProperties(String key) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (key != null && this.additionalProperties != null) {
+      this.additionalProperties.remove(key);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (map != null) {
+      for (Object key : map.keySet()) {
+        if (this.additionalProperties != null) {
+          this.additionalProperties.remove(key);
+        }
+      }
+    }
+    return (A) this;
+  }
+  
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+    if (!(apiVersion == null)) {
+        sb.append("apiVersion:");
+        sb.append(apiVersion);
+        sb.append(",");
+    }
+    if (!(kind == null)) {
+        sb.append("kind:");
+        sb.append(kind);
+        sb.append(",");
+    }
+    if (!(metadata == null)) {
+        sb.append("metadata:");
+        sb.append(metadata);
+        sb.append(",");
+    }
+    if (!(spec == null)) {
+        sb.append("spec:");
+        sb.append(spec);
+        sb.append(",");
+    }
+    if (!(status == null)) {
+        sb.append("status:");
+        sb.append(status);
+        sb.append(",");
+    }
+    if (!(additionalProperties == null) && !(additionalProperties.isEmpty())) {
+        sb.append("additionalProperties:");
+        sb.append(additionalProperties);
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+  
+  public <K,V>A withAdditionalProperties(Map<String,Object> additionalProperties) {
+    if (additionalProperties == null) {
+      this.additionalProperties = null;
+    } else {
+      this.additionalProperties = new LinkedHashMap(additionalProperties);
+    }
+    return (A) this;
+  }
+  
+  public A withApiVersion(String apiVersion) {
+    this.apiVersion = apiVersion;
+    return (A) this;
+  }
+  
+  public A withKind(String kind) {
+    this.kind = kind;
+    return (A) this;
+  }
+  
+  public A withMetadata(ObjectMeta metadata) {
+    this._visitables.remove("metadata");
+    if (metadata != null) {
+        this.metadata = new ObjectMetaBuilder(metadata);
+        this._visitables.get("metadata").add(this.metadata);
+    } else {
+        this.metadata = null;
+        this._visitables.get("metadata").remove(this.metadata);
+    }
+    return (A) this;
+  }
+  
+  public MetadataNested<A> withNewMetadata() {
+    return new MetadataNested(null);
+  }
+  
+  public MetadataNested<A> withNewMetadataLike(ObjectMeta item) {
+    return new MetadataNested(item);
+  }
+  
+  public SpecNested<A> withNewSpec() {
+    return new SpecNested(null);
+  }
+  
+  public SpecNested<A> withNewSpecLike(CronJobSpec item) {
+    return new SpecNested(item);
+  }
+  
+  public StatusNested<A> withNewStatus() {
+    return new StatusNested(null);
+  }
+  
+  public StatusNested<A> withNewStatusLike(CronJobStatus item) {
+    return new StatusNested(item);
+  }
+  
+  public A withSpec(CronJobSpec spec) {
+    this._visitables.remove("spec");
+    if (spec != null) {
+        this.spec = new CronJobSpecBuilder(spec);
+        this._visitables.get("spec").add(this.spec);
+    } else {
+        this.spec = null;
+        this._visitables.get("spec").remove(this.spec);
+    }
+    return (A) this;
+  }
+  
+  public A withStatus(CronJobStatus status) {
+    this._visitables.remove("status");
+    if (status != null) {
+        this.status = new CronJobStatusBuilder(status);
+        this._visitables.get("status").add(this.status);
+    } else {
+        this.status = null;
+        this._visitables.get("status").remove(this.status);
+    }
+    return (A) this;
+  }
+  public class MetadataNested<N> extends ObjectMetaFluent<MetadataNested<N>> implements Nested<N>{
+  
+    ObjectMetaBuilder builder;
+  
+    MetadataNested(ObjectMeta item) {
+      this.builder = new ObjectMetaBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) CronJobFluent.this.withMetadata(builder.build());
+    }
+    
+    public N endMetadata() {
+      return and();
+    }
+    
+  }
+  public class SpecNested<N> extends CronJobSpecFluent<SpecNested<N>> implements Nested<N>{
+  
+    CronJobSpecBuilder builder;
+  
+    SpecNested(CronJobSpec item) {
+      this.builder = new CronJobSpecBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) CronJobFluent.this.withSpec(builder.build());
+    }
+    
+    public N endSpec() {
+      return and();
+    }
+    
+  }
+  public class StatusNested<N> extends CronJobStatusFluent<StatusNested<N>> implements Nested<N>{
+  
+    CronJobStatusBuilder builder;
+  
+    StatusNested(CronJobStatus item) {
+      this.builder = new CronJobStatusBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) CronJobFluent.this.withStatus(builder.build());
+    }
+    
+    public N endStatus() {
+      return and();
+    }
+    
+  }
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/CronJobListBuilder.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/CronJobListBuilder.java
@@ -1,0 +1,33 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
+import java.lang.Object;
+public class CronJobListBuilder extends CronJobListFluent<CronJobListBuilder> implements VisitableBuilder<CronJobList,CronJobListBuilder>{
+
+  CronJobListFluent<?> fluent;
+
+  public CronJobListBuilder() {
+    this(new CronJobList());
+  }
+  
+  public CronJobListBuilder(CronJobListFluent<?> fluent) {
+    this(fluent, new CronJobList());
+  }
+  
+  public CronJobListBuilder(CronJobList instance) {
+    this.fluent = this;
+    this.copyInstance(instance);
+  }
+  
+  public CronJobListBuilder(CronJobListFluent<?> fluent,CronJobList instance) {
+    this.fluent = fluent;
+    fluent.copyInstance(instance);
+  }
+
+  public CronJobList build() {
+    CronJobList buildable = new CronJobList(fluent.getApiVersion(), fluent.buildItems(), fluent.getKind(), fluent.getMetadata());
+    buildable.setAdditionalProperties(fluent.getAdditionalProperties());
+    return buildable;
+  }
+  
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/CronJobListFluent.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/CronJobListFluent.java
@@ -1,0 +1,440 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.BaseFluent;
+import io.fabric8.kubernetes.api.builder.Nested;
+import io.fabric8.kubernetes.api.model.ListMeta;
+import java.lang.Object;
+import java.lang.RuntimeException;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.lang.SuppressWarnings;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * Generated
+ */
+@SuppressWarnings("unchecked")
+public class CronJobListFluent<A extends io.fabric8.kubernetes.api.model.batch.v1.CronJobListFluent<A>> extends BaseFluent<A>{
+
+  private Map<String,Object> additionalProperties;
+  private String apiVersion;
+  private ArrayList<CronJobBuilder> items = new ArrayList<CronJobBuilder>();
+  private String kind;
+  private ListMeta metadata;
+
+  public CronJobListFluent() {
+  }
+  
+  public CronJobListFluent(CronJobList instance) {
+    this.copyInstance(instance);
+  }
+
+  public A addAllToItems(Collection<CronJob> items) {
+    if (this.items == null) {
+      this.items = new ArrayList();
+    }
+    for (CronJob item : items) {
+        CronJobBuilder builder = new CronJobBuilder(item);
+        _visitables.get("items").add(builder);
+        this.items.add(builder);
+    }
+    return (A) this;
+  }
+  
+  public ItemsNested<A> addNewItem() {
+    return new ItemsNested(-1, null);
+  }
+  
+  public ItemsNested<A> addNewItemLike(CronJob item) {
+    return new ItemsNested(-1, item);
+  }
+  
+  public A addToAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null && map != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (map != null) {
+      this.additionalProperties.putAll(map);
+    }
+    return (A) this;
+  }
+  
+  public A addToAdditionalProperties(String key,Object value) {
+    if (this.additionalProperties == null && key != null && value != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (key != null && value != null) {
+      this.additionalProperties.put(key, value);
+    }
+    return (A) this;
+  }
+  
+  public A addToItems(CronJob... items) {
+    if (this.items == null) {
+      this.items = new ArrayList();
+    }
+    for (CronJob item : items) {
+        CronJobBuilder builder = new CronJobBuilder(item);
+        _visitables.get("items").add(builder);
+        this.items.add(builder);
+    }
+    return (A) this;
+  }
+  
+  public A addToItems(int index,CronJob item) {
+    if (this.items == null) {
+      this.items = new ArrayList();
+    }
+    CronJobBuilder builder = new CronJobBuilder(item);
+    if (index < 0 || index >= items.size()) {
+        _visitables.get("items").add(builder);
+        items.add(builder);
+    } else {
+        _visitables.get("items").add(builder);
+        items.add(index, builder);
+    }
+    return (A) this;
+  }
+  
+  public CronJob buildFirstItem() {
+    return this.items.get(0).build();
+  }
+  
+  public CronJob buildItem(int index) {
+    return this.items.get(index).build();
+  }
+  
+  public List<CronJob> buildItems() {
+    return this.items != null ? build(items) : null;
+  }
+  
+  public CronJob buildLastItem() {
+    return this.items.get(items.size() - 1).build();
+  }
+  
+  public CronJob buildMatchingItem(Predicate<CronJobBuilder> predicate) {
+      for (CronJobBuilder item : items) {
+        if (predicate.test(item)) {
+          return item.build();
+        }
+      }
+      return null;
+  }
+  
+  protected void copyInstance(CronJobList instance) {
+    instance = instance != null ? instance : new CronJobList();
+    if (instance != null) {
+        this.withApiVersion(instance.getApiVersion());
+        this.withItems(instance.getItems());
+        this.withKind(instance.getKind());
+        this.withMetadata(instance.getMetadata());
+        this.withAdditionalProperties(instance.getAdditionalProperties());
+    }
+  }
+  
+  public ItemsNested<A> editFirstItem() {
+    if (items.size() == 0) {
+      throw new RuntimeException(String.format("Can't edit first %s. The list is empty.", "items"));
+    }
+    return this.setNewItemLike(0, this.buildItem(0));
+  }
+  
+  public ItemsNested<A> editItem(int index) {
+    if (items.size() <= index) {
+      throw new RuntimeException(String.format("Can't edit %s. Index exceeds size.", "items"));
+    }
+    return this.setNewItemLike(index, this.buildItem(index));
+  }
+  
+  public ItemsNested<A> editLastItem() {
+    int index = items.size() - 1;
+    if (index < 0) {
+      throw new RuntimeException(String.format("Can't edit last %s. The list is empty.", "items"));
+    }
+    return this.setNewItemLike(index, this.buildItem(index));
+  }
+  
+  public ItemsNested<A> editMatchingItem(Predicate<CronJobBuilder> predicate) {
+    int index = -1;
+    for (int i = 0;i < items.size();i++) {
+      if (predicate.test(items.get(i))) {
+          index = i;
+          break;
+      }
+    }
+    if (index < 0) {
+      throw new RuntimeException(String.format("Can't edit matching %s. No match found.", "items"));
+    }
+    return this.setNewItemLike(index, this.buildItem(index));
+  }
+  
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || this.getClass() != o.getClass()) {
+      return false;
+    }
+    if (!(super.equals(o))) {
+      return false;
+    }
+    CronJobListFluent that = (CronJobListFluent) o;
+    if (!(Objects.equals(apiVersion, that.apiVersion))) {
+      return false;
+    }
+    if (!(Objects.equals(items, that.items))) {
+      return false;
+    }
+    if (!(Objects.equals(kind, that.kind))) {
+      return false;
+    }
+    if (!(Objects.equals(metadata, that.metadata))) {
+      return false;
+    }
+    if (!(Objects.equals(additionalProperties, that.additionalProperties))) {
+      return false;
+    }
+    return true;
+  }
+  
+  public Map<String,Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
+  
+  public String getApiVersion() {
+    return this.apiVersion;
+  }
+  
+  public String getKind() {
+    return this.kind;
+  }
+  
+  public ListMeta getMetadata() {
+    return this.metadata;
+  }
+  
+  public boolean hasAdditionalProperties() {
+    return this.additionalProperties != null;
+  }
+  
+  public boolean hasApiVersion() {
+    return this.apiVersion != null;
+  }
+  
+  public boolean hasItems() {
+    return this.items != null && !(this.items.isEmpty());
+  }
+  
+  public boolean hasKind() {
+    return this.kind != null;
+  }
+  
+  public boolean hasMatchingItem(Predicate<CronJobBuilder> predicate) {
+      for (CronJobBuilder item : items) {
+        if (predicate.test(item)) {
+          return true;
+        }
+      }
+      return false;
+  }
+  
+  public boolean hasMetadata() {
+    return this.metadata != null;
+  }
+  
+  public int hashCode() {
+    return Objects.hash(apiVersion, items, kind, metadata, additionalProperties);
+  }
+  
+  public A removeAllFromItems(Collection<CronJob> items) {
+    if (this.items == null) {
+      return (A) this;
+    }
+    for (CronJob item : items) {
+        CronJobBuilder builder = new CronJobBuilder(item);
+        _visitables.get("items").remove(builder);
+        this.items.remove(builder);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(String key) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (key != null && this.additionalProperties != null) {
+      this.additionalProperties.remove(key);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (map != null) {
+      for (Object key : map.keySet()) {
+        if (this.additionalProperties != null) {
+          this.additionalProperties.remove(key);
+        }
+      }
+    }
+    return (A) this;
+  }
+  
+  public A removeFromItems(CronJob... items) {
+    if (this.items == null) {
+      return (A) this;
+    }
+    for (CronJob item : items) {
+        CronJobBuilder builder = new CronJobBuilder(item);
+        _visitables.get("items").remove(builder);
+        this.items.remove(builder);
+    }
+    return (A) this;
+  }
+  
+  public A removeMatchingFromItems(Predicate<CronJobBuilder> predicate) {
+    if (items == null) {
+      return (A) this;
+    }
+    Iterator<CronJobBuilder> each = items.iterator();
+    List visitables = _visitables.get("items");
+    while (each.hasNext()) {
+        CronJobBuilder builder = each.next();
+        if (predicate.test(builder)) {
+            visitables.remove(builder);
+            each.remove();
+        }
+    }
+    return (A) this;
+  }
+  
+  public ItemsNested<A> setNewItemLike(int index,CronJob item) {
+    return new ItemsNested(index, item);
+  }
+  
+  public A setToItems(int index,CronJob item) {
+    if (this.items == null) {
+      this.items = new ArrayList();
+    }
+    CronJobBuilder builder = new CronJobBuilder(item);
+    if (index < 0 || index >= items.size()) {
+        _visitables.get("items").add(builder);
+        items.add(builder);
+    } else {
+        _visitables.get("items").add(builder);
+        items.set(index, builder);
+    }
+    return (A) this;
+  }
+  
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+    if (!(apiVersion == null)) {
+        sb.append("apiVersion:");
+        sb.append(apiVersion);
+        sb.append(",");
+    }
+    if (!(items == null) && !(items.isEmpty())) {
+        sb.append("items:");
+        sb.append(items);
+        sb.append(",");
+    }
+    if (!(kind == null)) {
+        sb.append("kind:");
+        sb.append(kind);
+        sb.append(",");
+    }
+    if (!(metadata == null)) {
+        sb.append("metadata:");
+        sb.append(metadata);
+        sb.append(",");
+    }
+    if (!(additionalProperties == null) && !(additionalProperties.isEmpty())) {
+        sb.append("additionalProperties:");
+        sb.append(additionalProperties);
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+  
+  public <K,V>A withAdditionalProperties(Map<String,Object> additionalProperties) {
+    if (additionalProperties == null) {
+      this.additionalProperties = null;
+    } else {
+      this.additionalProperties = new LinkedHashMap(additionalProperties);
+    }
+    return (A) this;
+  }
+  
+  public A withApiVersion(String apiVersion) {
+    this.apiVersion = apiVersion;
+    return (A) this;
+  }
+  
+  public A withItems(List<CronJob> items) {
+    if (this.items != null) {
+      this._visitables.get("items").clear();
+    }
+    if (items != null) {
+        this.items = new ArrayList();
+        for (CronJob item : items) {
+          this.addToItems(item);
+        }
+    } else {
+      this.items = null;
+    }
+    return (A) this;
+  }
+  
+  public A withItems(CronJob... items) {
+    if (this.items != null) {
+        this.items.clear();
+        _visitables.remove("items");
+    }
+    if (items != null) {
+      for (CronJob item : items) {
+        this.addToItems(item);
+      }
+    }
+    return (A) this;
+  }
+  
+  public A withKind(String kind) {
+    this.kind = kind;
+    return (A) this;
+  }
+  
+  public A withMetadata(ListMeta metadata) {
+    this.metadata = metadata;
+    return (A) this;
+  }
+  public class ItemsNested<N> extends CronJobFluent<ItemsNested<N>> implements Nested<N>{
+  
+    CronJobBuilder builder;
+    int index;
+  
+    ItemsNested(int index,CronJob item) {
+      this.index = index;
+      this.builder = new CronJobBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) CronJobListFluent.this.setToItems(index, builder.build());
+    }
+    
+    public N endItem() {
+      return and();
+    }
+    
+  }
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/CronJobSpecBuilder.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/CronJobSpecBuilder.java
@@ -1,0 +1,33 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
+import java.lang.Object;
+public class CronJobSpecBuilder extends CronJobSpecFluent<CronJobSpecBuilder> implements VisitableBuilder<CronJobSpec,CronJobSpecBuilder>{
+
+  CronJobSpecFluent<?> fluent;
+
+  public CronJobSpecBuilder() {
+    this(new CronJobSpec());
+  }
+  
+  public CronJobSpecBuilder(CronJobSpecFluent<?> fluent) {
+    this(fluent, new CronJobSpec());
+  }
+  
+  public CronJobSpecBuilder(CronJobSpec instance) {
+    this.fluent = this;
+    this.copyInstance(instance);
+  }
+  
+  public CronJobSpecBuilder(CronJobSpecFluent<?> fluent,CronJobSpec instance) {
+    this.fluent = fluent;
+    fluent.copyInstance(instance);
+  }
+
+  public CronJobSpec build() {
+    CronJobSpec buildable = new CronJobSpec(fluent.getConcurrencyPolicy(), fluent.getFailedJobsHistoryLimit(), fluent.buildJobTemplate(), fluent.getSchedule(), fluent.getStartingDeadlineSeconds(), fluent.getSuccessfulJobsHistoryLimit(), fluent.getSuspend(), fluent.getTimeZone());
+    buildable.setAdditionalProperties(fluent.getAdditionalProperties());
+    return buildable;
+  }
+  
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/CronJobSpecFluent.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/CronJobSpecFluent.java
@@ -1,0 +1,363 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.BaseFluent;
+import io.fabric8.kubernetes.api.builder.Nested;
+import java.lang.Boolean;
+import java.lang.Integer;
+import java.lang.Long;
+import java.lang.Object;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.lang.SuppressWarnings;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Generated
+ */
+@SuppressWarnings("unchecked")
+public class CronJobSpecFluent<A extends io.fabric8.kubernetes.api.model.batch.v1.CronJobSpecFluent<A>> extends BaseFluent<A>{
+
+  private Map<String,Object> additionalProperties;
+  private String concurrencyPolicy;
+  private Integer failedJobsHistoryLimit;
+  private JobTemplateSpecBuilder jobTemplate;
+  private String schedule;
+  private Long startingDeadlineSeconds;
+  private Integer successfulJobsHistoryLimit;
+  private Boolean suspend;
+  private String timeZone;
+
+  public CronJobSpecFluent() {
+  }
+  
+  public CronJobSpecFluent(CronJobSpec instance) {
+    this.copyInstance(instance);
+  }
+
+  public A addToAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null && map != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (map != null) {
+      this.additionalProperties.putAll(map);
+    }
+    return (A) this;
+  }
+  
+  public A addToAdditionalProperties(String key,Object value) {
+    if (this.additionalProperties == null && key != null && value != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (key != null && value != null) {
+      this.additionalProperties.put(key, value);
+    }
+    return (A) this;
+  }
+  
+  public JobTemplateSpec buildJobTemplate() {
+    return this.jobTemplate != null ? this.jobTemplate.build() : null;
+  }
+  
+  protected void copyInstance(CronJobSpec instance) {
+    instance = instance != null ? instance : new CronJobSpec();
+    if (instance != null) {
+        this.withConcurrencyPolicy(instance.getConcurrencyPolicy());
+        this.withFailedJobsHistoryLimit(instance.getFailedJobsHistoryLimit());
+        this.withJobTemplate(instance.getJobTemplate());
+        this.withSchedule(instance.getSchedule());
+        this.withStartingDeadlineSeconds(instance.getStartingDeadlineSeconds());
+        this.withSuccessfulJobsHistoryLimit(instance.getSuccessfulJobsHistoryLimit());
+        this.withSuspend(instance.getSuspend());
+        this.withTimeZone(instance.getTimeZone());
+        this.withAdditionalProperties(instance.getAdditionalProperties());
+    }
+  }
+  
+  public JobTemplateNested<A> editJobTemplate() {
+    return this.withNewJobTemplateLike(Optional.ofNullable(this.buildJobTemplate()).orElse(null));
+  }
+  
+  public JobTemplateNested<A> editOrNewJobTemplate() {
+    return this.withNewJobTemplateLike(Optional.ofNullable(this.buildJobTemplate()).orElse(new JobTemplateSpecBuilder().build()));
+  }
+  
+  public JobTemplateNested<A> editOrNewJobTemplateLike(JobTemplateSpec item) {
+    return this.withNewJobTemplateLike(Optional.ofNullable(this.buildJobTemplate()).orElse(item));
+  }
+  
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || this.getClass() != o.getClass()) {
+      return false;
+    }
+    if (!(super.equals(o))) {
+      return false;
+    }
+    CronJobSpecFluent that = (CronJobSpecFluent) o;
+    if (!(Objects.equals(concurrencyPolicy, that.concurrencyPolicy))) {
+      return false;
+    }
+    if (!(Objects.equals(failedJobsHistoryLimit, that.failedJobsHistoryLimit))) {
+      return false;
+    }
+    if (!(Objects.equals(jobTemplate, that.jobTemplate))) {
+      return false;
+    }
+    if (!(Objects.equals(schedule, that.schedule))) {
+      return false;
+    }
+    if (!(Objects.equals(startingDeadlineSeconds, that.startingDeadlineSeconds))) {
+      return false;
+    }
+    if (!(Objects.equals(successfulJobsHistoryLimit, that.successfulJobsHistoryLimit))) {
+      return false;
+    }
+    if (!(Objects.equals(suspend, that.suspend))) {
+      return false;
+    }
+    if (!(Objects.equals(timeZone, that.timeZone))) {
+      return false;
+    }
+    if (!(Objects.equals(additionalProperties, that.additionalProperties))) {
+      return false;
+    }
+    return true;
+  }
+  
+  public Map<String,Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
+  
+  public String getConcurrencyPolicy() {
+    return this.concurrencyPolicy;
+  }
+  
+  public Integer getFailedJobsHistoryLimit() {
+    return this.failedJobsHistoryLimit;
+  }
+  
+  public String getSchedule() {
+    return this.schedule;
+  }
+  
+  public Long getStartingDeadlineSeconds() {
+    return this.startingDeadlineSeconds;
+  }
+  
+  public Integer getSuccessfulJobsHistoryLimit() {
+    return this.successfulJobsHistoryLimit;
+  }
+  
+  public Boolean getSuspend() {
+    return this.suspend;
+  }
+  
+  public String getTimeZone() {
+    return this.timeZone;
+  }
+  
+  public boolean hasAdditionalProperties() {
+    return this.additionalProperties != null;
+  }
+  
+  public boolean hasConcurrencyPolicy() {
+    return this.concurrencyPolicy != null;
+  }
+  
+  public boolean hasFailedJobsHistoryLimit() {
+    return this.failedJobsHistoryLimit != null;
+  }
+  
+  public boolean hasJobTemplate() {
+    return this.jobTemplate != null;
+  }
+  
+  public boolean hasSchedule() {
+    return this.schedule != null;
+  }
+  
+  public boolean hasStartingDeadlineSeconds() {
+    return this.startingDeadlineSeconds != null;
+  }
+  
+  public boolean hasSuccessfulJobsHistoryLimit() {
+    return this.successfulJobsHistoryLimit != null;
+  }
+  
+  public boolean hasSuspend() {
+    return this.suspend != null;
+  }
+  
+  public boolean hasTimeZone() {
+    return this.timeZone != null;
+  }
+  
+  public int hashCode() {
+    return Objects.hash(concurrencyPolicy, failedJobsHistoryLimit, jobTemplate, schedule, startingDeadlineSeconds, successfulJobsHistoryLimit, suspend, timeZone, additionalProperties);
+  }
+  
+  public A removeFromAdditionalProperties(String key) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (key != null && this.additionalProperties != null) {
+      this.additionalProperties.remove(key);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (map != null) {
+      for (Object key : map.keySet()) {
+        if (this.additionalProperties != null) {
+          this.additionalProperties.remove(key);
+        }
+      }
+    }
+    return (A) this;
+  }
+  
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+    if (!(concurrencyPolicy == null)) {
+        sb.append("concurrencyPolicy:");
+        sb.append(concurrencyPolicy);
+        sb.append(",");
+    }
+    if (!(failedJobsHistoryLimit == null)) {
+        sb.append("failedJobsHistoryLimit:");
+        sb.append(failedJobsHistoryLimit);
+        sb.append(",");
+    }
+    if (!(jobTemplate == null)) {
+        sb.append("jobTemplate:");
+        sb.append(jobTemplate);
+        sb.append(",");
+    }
+    if (!(schedule == null)) {
+        sb.append("schedule:");
+        sb.append(schedule);
+        sb.append(",");
+    }
+    if (!(startingDeadlineSeconds == null)) {
+        sb.append("startingDeadlineSeconds:");
+        sb.append(startingDeadlineSeconds);
+        sb.append(",");
+    }
+    if (!(successfulJobsHistoryLimit == null)) {
+        sb.append("successfulJobsHistoryLimit:");
+        sb.append(successfulJobsHistoryLimit);
+        sb.append(",");
+    }
+    if (!(suspend == null)) {
+        sb.append("suspend:");
+        sb.append(suspend);
+        sb.append(",");
+    }
+    if (!(timeZone == null)) {
+        sb.append("timeZone:");
+        sb.append(timeZone);
+        sb.append(",");
+    }
+    if (!(additionalProperties == null) && !(additionalProperties.isEmpty())) {
+        sb.append("additionalProperties:");
+        sb.append(additionalProperties);
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+  
+  public <K,V>A withAdditionalProperties(Map<String,Object> additionalProperties) {
+    if (additionalProperties == null) {
+      this.additionalProperties = null;
+    } else {
+      this.additionalProperties = new LinkedHashMap(additionalProperties);
+    }
+    return (A) this;
+  }
+  
+  public A withConcurrencyPolicy(String concurrencyPolicy) {
+    this.concurrencyPolicy = concurrencyPolicy;
+    return (A) this;
+  }
+  
+  public A withFailedJobsHistoryLimit(Integer failedJobsHistoryLimit) {
+    this.failedJobsHistoryLimit = failedJobsHistoryLimit;
+    return (A) this;
+  }
+  
+  public A withJobTemplate(JobTemplateSpec jobTemplate) {
+    this._visitables.remove("jobTemplate");
+    if (jobTemplate != null) {
+        this.jobTemplate = new JobTemplateSpecBuilder(jobTemplate);
+        this._visitables.get("jobTemplate").add(this.jobTemplate);
+    } else {
+        this.jobTemplate = null;
+        this._visitables.get("jobTemplate").remove(this.jobTemplate);
+    }
+    return (A) this;
+  }
+  
+  public JobTemplateNested<A> withNewJobTemplate() {
+    return new JobTemplateNested(null);
+  }
+  
+  public JobTemplateNested<A> withNewJobTemplateLike(JobTemplateSpec item) {
+    return new JobTemplateNested(item);
+  }
+  
+  public A withSchedule(String schedule) {
+    this.schedule = schedule;
+    return (A) this;
+  }
+  
+  public A withStartingDeadlineSeconds(Long startingDeadlineSeconds) {
+    this.startingDeadlineSeconds = startingDeadlineSeconds;
+    return (A) this;
+  }
+  
+  public A withSuccessfulJobsHistoryLimit(Integer successfulJobsHistoryLimit) {
+    this.successfulJobsHistoryLimit = successfulJobsHistoryLimit;
+    return (A) this;
+  }
+  
+  public A withSuspend() {
+    return withSuspend(true);
+  }
+  
+  public A withSuspend(Boolean suspend) {
+    this.suspend = suspend;
+    return (A) this;
+  }
+  
+  public A withTimeZone(String timeZone) {
+    this.timeZone = timeZone;
+    return (A) this;
+  }
+  public class JobTemplateNested<N> extends JobTemplateSpecFluent<JobTemplateNested<N>> implements Nested<N>{
+  
+    JobTemplateSpecBuilder builder;
+  
+    JobTemplateNested(JobTemplateSpec item) {
+      this.builder = new JobTemplateSpecBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) CronJobSpecFluent.this.withJobTemplate(builder.build());
+    }
+    
+    public N endJobTemplate() {
+      return and();
+    }
+    
+  }
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/CronJobStatusBuilder.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/CronJobStatusBuilder.java
@@ -1,0 +1,33 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
+import java.lang.Object;
+public class CronJobStatusBuilder extends CronJobStatusFluent<CronJobStatusBuilder> implements VisitableBuilder<CronJobStatus,CronJobStatusBuilder>{
+
+  CronJobStatusFluent<?> fluent;
+
+  public CronJobStatusBuilder() {
+    this(new CronJobStatus());
+  }
+  
+  public CronJobStatusBuilder(CronJobStatusFluent<?> fluent) {
+    this(fluent, new CronJobStatus());
+  }
+  
+  public CronJobStatusBuilder(CronJobStatus instance) {
+    this.fluent = this;
+    this.copyInstance(instance);
+  }
+  
+  public CronJobStatusBuilder(CronJobStatusFluent<?> fluent,CronJobStatus instance) {
+    this.fluent = fluent;
+    fluent.copyInstance(instance);
+  }
+
+  public CronJobStatus build() {
+    CronJobStatus buildable = new CronJobStatus(fluent.buildActive(), fluent.getLastScheduleTime(), fluent.getLastSuccessfulTime());
+    buildable.setAdditionalProperties(fluent.getAdditionalProperties());
+    return buildable;
+  }
+  
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/CronJobStatusFluent.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/CronJobStatusFluent.java
@@ -1,0 +1,419 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.BaseFluent;
+import io.fabric8.kubernetes.api.builder.Nested;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectReferenceBuilder;
+import io.fabric8.kubernetes.api.model.ObjectReferenceFluent;
+import java.lang.Object;
+import java.lang.RuntimeException;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.lang.SuppressWarnings;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * Generated
+ */
+@SuppressWarnings("unchecked")
+public class CronJobStatusFluent<A extends io.fabric8.kubernetes.api.model.batch.v1.CronJobStatusFluent<A>> extends BaseFluent<A>{
+
+  private ArrayList<ObjectReferenceBuilder> active = new ArrayList<ObjectReferenceBuilder>();
+  private Map<String,Object> additionalProperties;
+  private String lastScheduleTime;
+  private String lastSuccessfulTime;
+
+  public CronJobStatusFluent() {
+  }
+  
+  public CronJobStatusFluent(CronJobStatus instance) {
+    this.copyInstance(instance);
+  }
+
+  public A addAllToActive(Collection<ObjectReference> items) {
+    if (this.active == null) {
+      this.active = new ArrayList();
+    }
+    for (ObjectReference item : items) {
+        ObjectReferenceBuilder builder = new ObjectReferenceBuilder(item);
+        _visitables.get("active").add(builder);
+        this.active.add(builder);
+    }
+    return (A) this;
+  }
+  
+  public ActiveNested<A> addNewActive() {
+    return new ActiveNested(-1, null);
+  }
+  
+  public ActiveNested<A> addNewActiveLike(ObjectReference item) {
+    return new ActiveNested(-1, item);
+  }
+  
+  public A addToActive(ObjectReference... items) {
+    if (this.active == null) {
+      this.active = new ArrayList();
+    }
+    for (ObjectReference item : items) {
+        ObjectReferenceBuilder builder = new ObjectReferenceBuilder(item);
+        _visitables.get("active").add(builder);
+        this.active.add(builder);
+    }
+    return (A) this;
+  }
+  
+  public A addToActive(int index,ObjectReference item) {
+    if (this.active == null) {
+      this.active = new ArrayList();
+    }
+    ObjectReferenceBuilder builder = new ObjectReferenceBuilder(item);
+    if (index < 0 || index >= active.size()) {
+        _visitables.get("active").add(builder);
+        active.add(builder);
+    } else {
+        _visitables.get("active").add(builder);
+        active.add(index, builder);
+    }
+    return (A) this;
+  }
+  
+  public A addToAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null && map != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (map != null) {
+      this.additionalProperties.putAll(map);
+    }
+    return (A) this;
+  }
+  
+  public A addToAdditionalProperties(String key,Object value) {
+    if (this.additionalProperties == null && key != null && value != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (key != null && value != null) {
+      this.additionalProperties.put(key, value);
+    }
+    return (A) this;
+  }
+  
+  public List<ObjectReference> buildActive() {
+    return this.active != null ? build(active) : null;
+  }
+  
+  public ObjectReference buildActive(int index) {
+    return this.active.get(index).build();
+  }
+  
+  public ObjectReference buildFirstActive() {
+    return this.active.get(0).build();
+  }
+  
+  public ObjectReference buildLastActive() {
+    return this.active.get(active.size() - 1).build();
+  }
+  
+  public ObjectReference buildMatchingActive(Predicate<ObjectReferenceBuilder> predicate) {
+      for (ObjectReferenceBuilder item : active) {
+        if (predicate.test(item)) {
+          return item.build();
+        }
+      }
+      return null;
+  }
+  
+  protected void copyInstance(CronJobStatus instance) {
+    instance = instance != null ? instance : new CronJobStatus();
+    if (instance != null) {
+        this.withActive(instance.getActive());
+        this.withLastScheduleTime(instance.getLastScheduleTime());
+        this.withLastSuccessfulTime(instance.getLastSuccessfulTime());
+        this.withAdditionalProperties(instance.getAdditionalProperties());
+    }
+  }
+  
+  public ActiveNested<A> editActive(int index) {
+    if (active.size() <= index) {
+      throw new RuntimeException(String.format("Can't edit %s. Index exceeds size.", "active"));
+    }
+    return this.setNewActiveLike(index, this.buildActive(index));
+  }
+  
+  public ActiveNested<A> editFirstActive() {
+    if (active.size() == 0) {
+      throw new RuntimeException(String.format("Can't edit first %s. The list is empty.", "active"));
+    }
+    return this.setNewActiveLike(0, this.buildActive(0));
+  }
+  
+  public ActiveNested<A> editLastActive() {
+    int index = active.size() - 1;
+    if (index < 0) {
+      throw new RuntimeException(String.format("Can't edit last %s. The list is empty.", "active"));
+    }
+    return this.setNewActiveLike(index, this.buildActive(index));
+  }
+  
+  public ActiveNested<A> editMatchingActive(Predicate<ObjectReferenceBuilder> predicate) {
+    int index = -1;
+    for (int i = 0;i < active.size();i++) {
+      if (predicate.test(active.get(i))) {
+          index = i;
+          break;
+      }
+    }
+    if (index < 0) {
+      throw new RuntimeException(String.format("Can't edit matching %s. No match found.", "active"));
+    }
+    return this.setNewActiveLike(index, this.buildActive(index));
+  }
+  
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || this.getClass() != o.getClass()) {
+      return false;
+    }
+    if (!(super.equals(o))) {
+      return false;
+    }
+    CronJobStatusFluent that = (CronJobStatusFluent) o;
+    if (!(Objects.equals(active, that.active))) {
+      return false;
+    }
+    if (!(Objects.equals(lastScheduleTime, that.lastScheduleTime))) {
+      return false;
+    }
+    if (!(Objects.equals(lastSuccessfulTime, that.lastSuccessfulTime))) {
+      return false;
+    }
+    if (!(Objects.equals(additionalProperties, that.additionalProperties))) {
+      return false;
+    }
+    return true;
+  }
+  
+  public Map<String,Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
+  
+  public String getLastScheduleTime() {
+    return this.lastScheduleTime;
+  }
+  
+  public String getLastSuccessfulTime() {
+    return this.lastSuccessfulTime;
+  }
+  
+  public boolean hasActive() {
+    return this.active != null && !(this.active.isEmpty());
+  }
+  
+  public boolean hasAdditionalProperties() {
+    return this.additionalProperties != null;
+  }
+  
+  public boolean hasLastScheduleTime() {
+    return this.lastScheduleTime != null;
+  }
+  
+  public boolean hasLastSuccessfulTime() {
+    return this.lastSuccessfulTime != null;
+  }
+  
+  public boolean hasMatchingActive(Predicate<ObjectReferenceBuilder> predicate) {
+      for (ObjectReferenceBuilder item : active) {
+        if (predicate.test(item)) {
+          return true;
+        }
+      }
+      return false;
+  }
+  
+  public int hashCode() {
+    return Objects.hash(active, lastScheduleTime, lastSuccessfulTime, additionalProperties);
+  }
+  
+  public A removeAllFromActive(Collection<ObjectReference> items) {
+    if (this.active == null) {
+      return (A) this;
+    }
+    for (ObjectReference item : items) {
+        ObjectReferenceBuilder builder = new ObjectReferenceBuilder(item);
+        _visitables.get("active").remove(builder);
+        this.active.remove(builder);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromActive(ObjectReference... items) {
+    if (this.active == null) {
+      return (A) this;
+    }
+    for (ObjectReference item : items) {
+        ObjectReferenceBuilder builder = new ObjectReferenceBuilder(item);
+        _visitables.get("active").remove(builder);
+        this.active.remove(builder);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(String key) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (key != null && this.additionalProperties != null) {
+      this.additionalProperties.remove(key);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (map != null) {
+      for (Object key : map.keySet()) {
+        if (this.additionalProperties != null) {
+          this.additionalProperties.remove(key);
+        }
+      }
+    }
+    return (A) this;
+  }
+  
+  public A removeMatchingFromActive(Predicate<ObjectReferenceBuilder> predicate) {
+    if (active == null) {
+      return (A) this;
+    }
+    Iterator<ObjectReferenceBuilder> each = active.iterator();
+    List visitables = _visitables.get("active");
+    while (each.hasNext()) {
+        ObjectReferenceBuilder builder = each.next();
+        if (predicate.test(builder)) {
+            visitables.remove(builder);
+            each.remove();
+        }
+    }
+    return (A) this;
+  }
+  
+  public ActiveNested<A> setNewActiveLike(int index,ObjectReference item) {
+    return new ActiveNested(index, item);
+  }
+  
+  public A setToActive(int index,ObjectReference item) {
+    if (this.active == null) {
+      this.active = new ArrayList();
+    }
+    ObjectReferenceBuilder builder = new ObjectReferenceBuilder(item);
+    if (index < 0 || index >= active.size()) {
+        _visitables.get("active").add(builder);
+        active.add(builder);
+    } else {
+        _visitables.get("active").add(builder);
+        active.set(index, builder);
+    }
+    return (A) this;
+  }
+  
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+    if (!(active == null) && !(active.isEmpty())) {
+        sb.append("active:");
+        sb.append(active);
+        sb.append(",");
+    }
+    if (!(lastScheduleTime == null)) {
+        sb.append("lastScheduleTime:");
+        sb.append(lastScheduleTime);
+        sb.append(",");
+    }
+    if (!(lastSuccessfulTime == null)) {
+        sb.append("lastSuccessfulTime:");
+        sb.append(lastSuccessfulTime);
+        sb.append(",");
+    }
+    if (!(additionalProperties == null) && !(additionalProperties.isEmpty())) {
+        sb.append("additionalProperties:");
+        sb.append(additionalProperties);
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+  
+  public A withActive(List<ObjectReference> active) {
+    if (this.active != null) {
+      this._visitables.get("active").clear();
+    }
+    if (active != null) {
+        this.active = new ArrayList();
+        for (ObjectReference item : active) {
+          this.addToActive(item);
+        }
+    } else {
+      this.active = null;
+    }
+    return (A) this;
+  }
+  
+  public A withActive(ObjectReference... active) {
+    if (this.active != null) {
+        this.active.clear();
+        _visitables.remove("active");
+    }
+    if (active != null) {
+      for (ObjectReference item : active) {
+        this.addToActive(item);
+      }
+    }
+    return (A) this;
+  }
+  
+  public <K,V>A withAdditionalProperties(Map<String,Object> additionalProperties) {
+    if (additionalProperties == null) {
+      this.additionalProperties = null;
+    } else {
+      this.additionalProperties = new LinkedHashMap(additionalProperties);
+    }
+    return (A) this;
+  }
+  
+  public A withLastScheduleTime(String lastScheduleTime) {
+    this.lastScheduleTime = lastScheduleTime;
+    return (A) this;
+  }
+  
+  public A withLastSuccessfulTime(String lastSuccessfulTime) {
+    this.lastSuccessfulTime = lastSuccessfulTime;
+    return (A) this;
+  }
+  public class ActiveNested<N> extends ObjectReferenceFluent<ActiveNested<N>> implements Nested<N>{
+  
+    ObjectReferenceBuilder builder;
+    int index;
+  
+    ActiveNested(int index,ObjectReference item) {
+      this.index = index;
+      this.builder = new ObjectReferenceBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) CronJobStatusFluent.this.setToActive(index, builder.build());
+    }
+    
+    public N endActive() {
+      return and();
+    }
+    
+  }
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/JobBuilder.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/JobBuilder.java
@@ -1,0 +1,33 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
+import java.lang.Object;
+public class JobBuilder extends JobFluent<JobBuilder> implements VisitableBuilder<Job,JobBuilder>{
+
+  JobFluent<?> fluent;
+
+  public JobBuilder() {
+    this(new Job());
+  }
+  
+  public JobBuilder(JobFluent<?> fluent) {
+    this(fluent, new Job());
+  }
+  
+  public JobBuilder(Job instance) {
+    this.fluent = this;
+    this.copyInstance(instance);
+  }
+  
+  public JobBuilder(JobFluent<?> fluent,Job instance) {
+    this.fluent = fluent;
+    fluent.copyInstance(instance);
+  }
+
+  public Job build() {
+    Job buildable = new Job(fluent.getApiVersion(), fluent.getKind(), fluent.buildMetadata(), fluent.buildSpec(), fluent.buildStatus());
+    buildable.setAdditionalProperties(fluent.getAdditionalProperties());
+    return buildable;
+  }
+  
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/JobConditionBuilder.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/JobConditionBuilder.java
@@ -1,0 +1,33 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
+import java.lang.Object;
+public class JobConditionBuilder extends JobConditionFluent<JobConditionBuilder> implements VisitableBuilder<JobCondition,JobConditionBuilder>{
+
+  JobConditionFluent<?> fluent;
+
+  public JobConditionBuilder() {
+    this(new JobCondition());
+  }
+  
+  public JobConditionBuilder(JobConditionFluent<?> fluent) {
+    this(fluent, new JobCondition());
+  }
+  
+  public JobConditionBuilder(JobCondition instance) {
+    this.fluent = this;
+    this.copyInstance(instance);
+  }
+  
+  public JobConditionBuilder(JobConditionFluent<?> fluent,JobCondition instance) {
+    this.fluent = fluent;
+    fluent.copyInstance(instance);
+  }
+
+  public JobCondition build() {
+    JobCondition buildable = new JobCondition(fluent.getLastProbeTime(), fluent.getLastTransitionTime(), fluent.getMessage(), fluent.getReason(), fluent.getStatus(), fluent.getType());
+    buildable.setAdditionalProperties(fluent.getAdditionalProperties());
+    return buildable;
+  }
+  
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/JobConditionFluent.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/JobConditionFluent.java
@@ -1,0 +1,265 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.BaseFluent;
+import java.lang.Object;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.lang.SuppressWarnings;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Generated
+ */
+@SuppressWarnings("unchecked")
+public class JobConditionFluent<A extends io.fabric8.kubernetes.api.model.batch.v1.JobConditionFluent<A>> extends BaseFluent<A>{
+
+  private Map<String,Object> additionalProperties;
+  private String lastProbeTime;
+  private String lastTransitionTime;
+  private String message;
+  private String reason;
+  private String status;
+  private String type;
+
+  public JobConditionFluent() {
+  }
+  
+  public JobConditionFluent(JobCondition instance) {
+    this.copyInstance(instance);
+  }
+
+  public A addToAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null && map != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (map != null) {
+      this.additionalProperties.putAll(map);
+    }
+    return (A) this;
+  }
+  
+  public A addToAdditionalProperties(String key,Object value) {
+    if (this.additionalProperties == null && key != null && value != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (key != null && value != null) {
+      this.additionalProperties.put(key, value);
+    }
+    return (A) this;
+  }
+  
+  protected void copyInstance(JobCondition instance) {
+    instance = instance != null ? instance : new JobCondition();
+    if (instance != null) {
+        this.withLastProbeTime(instance.getLastProbeTime());
+        this.withLastTransitionTime(instance.getLastTransitionTime());
+        this.withMessage(instance.getMessage());
+        this.withReason(instance.getReason());
+        this.withStatus(instance.getStatus());
+        this.withType(instance.getType());
+        this.withAdditionalProperties(instance.getAdditionalProperties());
+    }
+  }
+  
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || this.getClass() != o.getClass()) {
+      return false;
+    }
+    if (!(super.equals(o))) {
+      return false;
+    }
+    JobConditionFluent that = (JobConditionFluent) o;
+    if (!(Objects.equals(lastProbeTime, that.lastProbeTime))) {
+      return false;
+    }
+    if (!(Objects.equals(lastTransitionTime, that.lastTransitionTime))) {
+      return false;
+    }
+    if (!(Objects.equals(message, that.message))) {
+      return false;
+    }
+    if (!(Objects.equals(reason, that.reason))) {
+      return false;
+    }
+    if (!(Objects.equals(status, that.status))) {
+      return false;
+    }
+    if (!(Objects.equals(type, that.type))) {
+      return false;
+    }
+    if (!(Objects.equals(additionalProperties, that.additionalProperties))) {
+      return false;
+    }
+    return true;
+  }
+  
+  public Map<String,Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
+  
+  public String getLastProbeTime() {
+    return this.lastProbeTime;
+  }
+  
+  public String getLastTransitionTime() {
+    return this.lastTransitionTime;
+  }
+  
+  public String getMessage() {
+    return this.message;
+  }
+  
+  public String getReason() {
+    return this.reason;
+  }
+  
+  public String getStatus() {
+    return this.status;
+  }
+  
+  public String getType() {
+    return this.type;
+  }
+  
+  public boolean hasAdditionalProperties() {
+    return this.additionalProperties != null;
+  }
+  
+  public boolean hasLastProbeTime() {
+    return this.lastProbeTime != null;
+  }
+  
+  public boolean hasLastTransitionTime() {
+    return this.lastTransitionTime != null;
+  }
+  
+  public boolean hasMessage() {
+    return this.message != null;
+  }
+  
+  public boolean hasReason() {
+    return this.reason != null;
+  }
+  
+  public boolean hasStatus() {
+    return this.status != null;
+  }
+  
+  public boolean hasType() {
+    return this.type != null;
+  }
+  
+  public int hashCode() {
+    return Objects.hash(lastProbeTime, lastTransitionTime, message, reason, status, type, additionalProperties);
+  }
+  
+  public A removeFromAdditionalProperties(String key) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (key != null && this.additionalProperties != null) {
+      this.additionalProperties.remove(key);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (map != null) {
+      for (Object key : map.keySet()) {
+        if (this.additionalProperties != null) {
+          this.additionalProperties.remove(key);
+        }
+      }
+    }
+    return (A) this;
+  }
+  
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+    if (!(lastProbeTime == null)) {
+        sb.append("lastProbeTime:");
+        sb.append(lastProbeTime);
+        sb.append(",");
+    }
+    if (!(lastTransitionTime == null)) {
+        sb.append("lastTransitionTime:");
+        sb.append(lastTransitionTime);
+        sb.append(",");
+    }
+    if (!(message == null)) {
+        sb.append("message:");
+        sb.append(message);
+        sb.append(",");
+    }
+    if (!(reason == null)) {
+        sb.append("reason:");
+        sb.append(reason);
+        sb.append(",");
+    }
+    if (!(status == null)) {
+        sb.append("status:");
+        sb.append(status);
+        sb.append(",");
+    }
+    if (!(type == null)) {
+        sb.append("type:");
+        sb.append(type);
+        sb.append(",");
+    }
+    if (!(additionalProperties == null) && !(additionalProperties.isEmpty())) {
+        sb.append("additionalProperties:");
+        sb.append(additionalProperties);
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+  
+  public <K,V>A withAdditionalProperties(Map<String,Object> additionalProperties) {
+    if (additionalProperties == null) {
+      this.additionalProperties = null;
+    } else {
+      this.additionalProperties = new LinkedHashMap(additionalProperties);
+    }
+    return (A) this;
+  }
+  
+  public A withLastProbeTime(String lastProbeTime) {
+    this.lastProbeTime = lastProbeTime;
+    return (A) this;
+  }
+  
+  public A withLastTransitionTime(String lastTransitionTime) {
+    this.lastTransitionTime = lastTransitionTime;
+    return (A) this;
+  }
+  
+  public A withMessage(String message) {
+    this.message = message;
+    return (A) this;
+  }
+  
+  public A withReason(String reason) {
+    this.reason = reason;
+    return (A) this;
+  }
+  
+  public A withStatus(String status) {
+    this.status = status;
+    return (A) this;
+  }
+  
+  public A withType(String type) {
+    this.type = type;
+    return (A) this;
+  }
+  
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/JobFluent.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/JobFluent.java
@@ -1,0 +1,378 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.BaseFluent;
+import io.fabric8.kubernetes.api.builder.Nested;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMetaFluent;
+import java.lang.Object;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.lang.SuppressWarnings;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Generated
+ */
+@SuppressWarnings("unchecked")
+public class JobFluent<A extends io.fabric8.kubernetes.api.model.batch.v1.JobFluent<A>> extends BaseFluent<A>{
+
+  private Map<String,Object> additionalProperties;
+  private String apiVersion;
+  private String kind;
+  private ObjectMetaBuilder metadata;
+  private JobSpecBuilder spec;
+  private JobStatusBuilder status;
+
+  public JobFluent() {
+  }
+  
+  public JobFluent(Job instance) {
+    this.copyInstance(instance);
+  }
+
+  public A addToAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null && map != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (map != null) {
+      this.additionalProperties.putAll(map);
+    }
+    return (A) this;
+  }
+  
+  public A addToAdditionalProperties(String key,Object value) {
+    if (this.additionalProperties == null && key != null && value != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (key != null && value != null) {
+      this.additionalProperties.put(key, value);
+    }
+    return (A) this;
+  }
+  
+  public ObjectMeta buildMetadata() {
+    return this.metadata != null ? this.metadata.build() : null;
+  }
+  
+  public JobSpec buildSpec() {
+    return this.spec != null ? this.spec.build() : null;
+  }
+  
+  public JobStatus buildStatus() {
+    return this.status != null ? this.status.build() : null;
+  }
+  
+  protected void copyInstance(Job instance) {
+    instance = instance != null ? instance : new Job();
+    if (instance != null) {
+        this.withApiVersion(instance.getApiVersion());
+        this.withKind(instance.getKind());
+        this.withMetadata(instance.getMetadata());
+        this.withSpec(instance.getSpec());
+        this.withStatus(instance.getStatus());
+        this.withAdditionalProperties(instance.getAdditionalProperties());
+    }
+  }
+  
+  public MetadataNested<A> editMetadata() {
+    return this.withNewMetadataLike(Optional.ofNullable(this.buildMetadata()).orElse(null));
+  }
+  
+  public MetadataNested<A> editOrNewMetadata() {
+    return this.withNewMetadataLike(Optional.ofNullable(this.buildMetadata()).orElse(new ObjectMetaBuilder().build()));
+  }
+  
+  public MetadataNested<A> editOrNewMetadataLike(ObjectMeta item) {
+    return this.withNewMetadataLike(Optional.ofNullable(this.buildMetadata()).orElse(item));
+  }
+  
+  public SpecNested<A> editOrNewSpec() {
+    return this.withNewSpecLike(Optional.ofNullable(this.buildSpec()).orElse(new JobSpecBuilder().build()));
+  }
+  
+  public SpecNested<A> editOrNewSpecLike(JobSpec item) {
+    return this.withNewSpecLike(Optional.ofNullable(this.buildSpec()).orElse(item));
+  }
+  
+  public StatusNested<A> editOrNewStatus() {
+    return this.withNewStatusLike(Optional.ofNullable(this.buildStatus()).orElse(new JobStatusBuilder().build()));
+  }
+  
+  public StatusNested<A> editOrNewStatusLike(JobStatus item) {
+    return this.withNewStatusLike(Optional.ofNullable(this.buildStatus()).orElse(item));
+  }
+  
+  public SpecNested<A> editSpec() {
+    return this.withNewSpecLike(Optional.ofNullable(this.buildSpec()).orElse(null));
+  }
+  
+  public StatusNested<A> editStatus() {
+    return this.withNewStatusLike(Optional.ofNullable(this.buildStatus()).orElse(null));
+  }
+  
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || this.getClass() != o.getClass()) {
+      return false;
+    }
+    if (!(super.equals(o))) {
+      return false;
+    }
+    JobFluent that = (JobFluent) o;
+    if (!(Objects.equals(apiVersion, that.apiVersion))) {
+      return false;
+    }
+    if (!(Objects.equals(kind, that.kind))) {
+      return false;
+    }
+    if (!(Objects.equals(metadata, that.metadata))) {
+      return false;
+    }
+    if (!(Objects.equals(spec, that.spec))) {
+      return false;
+    }
+    if (!(Objects.equals(status, that.status))) {
+      return false;
+    }
+    if (!(Objects.equals(additionalProperties, that.additionalProperties))) {
+      return false;
+    }
+    return true;
+  }
+  
+  public Map<String,Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
+  
+  public String getApiVersion() {
+    return this.apiVersion;
+  }
+  
+  public String getKind() {
+    return this.kind;
+  }
+  
+  public boolean hasAdditionalProperties() {
+    return this.additionalProperties != null;
+  }
+  
+  public boolean hasApiVersion() {
+    return this.apiVersion != null;
+  }
+  
+  public boolean hasKind() {
+    return this.kind != null;
+  }
+  
+  public boolean hasMetadata() {
+    return this.metadata != null;
+  }
+  
+  public boolean hasSpec() {
+    return this.spec != null;
+  }
+  
+  public boolean hasStatus() {
+    return this.status != null;
+  }
+  
+  public int hashCode() {
+    return Objects.hash(apiVersion, kind, metadata, spec, status, additionalProperties);
+  }
+  
+  public A removeFromAdditionalProperties(String key) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (key != null && this.additionalProperties != null) {
+      this.additionalProperties.remove(key);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (map != null) {
+      for (Object key : map.keySet()) {
+        if (this.additionalProperties != null) {
+          this.additionalProperties.remove(key);
+        }
+      }
+    }
+    return (A) this;
+  }
+  
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+    if (!(apiVersion == null)) {
+        sb.append("apiVersion:");
+        sb.append(apiVersion);
+        sb.append(",");
+    }
+    if (!(kind == null)) {
+        sb.append("kind:");
+        sb.append(kind);
+        sb.append(",");
+    }
+    if (!(metadata == null)) {
+        sb.append("metadata:");
+        sb.append(metadata);
+        sb.append(",");
+    }
+    if (!(spec == null)) {
+        sb.append("spec:");
+        sb.append(spec);
+        sb.append(",");
+    }
+    if (!(status == null)) {
+        sb.append("status:");
+        sb.append(status);
+        sb.append(",");
+    }
+    if (!(additionalProperties == null) && !(additionalProperties.isEmpty())) {
+        sb.append("additionalProperties:");
+        sb.append(additionalProperties);
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+  
+  public <K,V>A withAdditionalProperties(Map<String,Object> additionalProperties) {
+    if (additionalProperties == null) {
+      this.additionalProperties = null;
+    } else {
+      this.additionalProperties = new LinkedHashMap(additionalProperties);
+    }
+    return (A) this;
+  }
+  
+  public A withApiVersion(String apiVersion) {
+    this.apiVersion = apiVersion;
+    return (A) this;
+  }
+  
+  public A withKind(String kind) {
+    this.kind = kind;
+    return (A) this;
+  }
+  
+  public A withMetadata(ObjectMeta metadata) {
+    this._visitables.remove("metadata");
+    if (metadata != null) {
+        this.metadata = new ObjectMetaBuilder(metadata);
+        this._visitables.get("metadata").add(this.metadata);
+    } else {
+        this.metadata = null;
+        this._visitables.get("metadata").remove(this.metadata);
+    }
+    return (A) this;
+  }
+  
+  public MetadataNested<A> withNewMetadata() {
+    return new MetadataNested(null);
+  }
+  
+  public MetadataNested<A> withNewMetadataLike(ObjectMeta item) {
+    return new MetadataNested(item);
+  }
+  
+  public SpecNested<A> withNewSpec() {
+    return new SpecNested(null);
+  }
+  
+  public SpecNested<A> withNewSpecLike(JobSpec item) {
+    return new SpecNested(item);
+  }
+  
+  public StatusNested<A> withNewStatus() {
+    return new StatusNested(null);
+  }
+  
+  public StatusNested<A> withNewStatusLike(JobStatus item) {
+    return new StatusNested(item);
+  }
+  
+  public A withSpec(JobSpec spec) {
+    this._visitables.remove("spec");
+    if (spec != null) {
+        this.spec = new JobSpecBuilder(spec);
+        this._visitables.get("spec").add(this.spec);
+    } else {
+        this.spec = null;
+        this._visitables.get("spec").remove(this.spec);
+    }
+    return (A) this;
+  }
+  
+  public A withStatus(JobStatus status) {
+    this._visitables.remove("status");
+    if (status != null) {
+        this.status = new JobStatusBuilder(status);
+        this._visitables.get("status").add(this.status);
+    } else {
+        this.status = null;
+        this._visitables.get("status").remove(this.status);
+    }
+    return (A) this;
+  }
+  public class MetadataNested<N> extends ObjectMetaFluent<MetadataNested<N>> implements Nested<N>{
+  
+    ObjectMetaBuilder builder;
+  
+    MetadataNested(ObjectMeta item) {
+      this.builder = new ObjectMetaBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) JobFluent.this.withMetadata(builder.build());
+    }
+    
+    public N endMetadata() {
+      return and();
+    }
+    
+  }
+  public class SpecNested<N> extends JobSpecFluent<SpecNested<N>> implements Nested<N>{
+  
+    JobSpecBuilder builder;
+  
+    SpecNested(JobSpec item) {
+      this.builder = new JobSpecBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) JobFluent.this.withSpec(builder.build());
+    }
+    
+    public N endSpec() {
+      return and();
+    }
+    
+  }
+  public class StatusNested<N> extends JobStatusFluent<StatusNested<N>> implements Nested<N>{
+  
+    JobStatusBuilder builder;
+  
+    StatusNested(JobStatus item) {
+      this.builder = new JobStatusBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) JobFluent.this.withStatus(builder.build());
+    }
+    
+    public N endStatus() {
+      return and();
+    }
+    
+  }
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/JobListBuilder.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/JobListBuilder.java
@@ -1,0 +1,33 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
+import java.lang.Object;
+public class JobListBuilder extends JobListFluent<JobListBuilder> implements VisitableBuilder<JobList,JobListBuilder>{
+
+  JobListFluent<?> fluent;
+
+  public JobListBuilder() {
+    this(new JobList());
+  }
+  
+  public JobListBuilder(JobListFluent<?> fluent) {
+    this(fluent, new JobList());
+  }
+  
+  public JobListBuilder(JobList instance) {
+    this.fluent = this;
+    this.copyInstance(instance);
+  }
+  
+  public JobListBuilder(JobListFluent<?> fluent,JobList instance) {
+    this.fluent = fluent;
+    fluent.copyInstance(instance);
+  }
+
+  public JobList build() {
+    JobList buildable = new JobList(fluent.getApiVersion(), fluent.buildItems(), fluent.getKind(), fluent.getMetadata());
+    buildable.setAdditionalProperties(fluent.getAdditionalProperties());
+    return buildable;
+  }
+  
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/JobListFluent.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/JobListFluent.java
@@ -1,0 +1,440 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.BaseFluent;
+import io.fabric8.kubernetes.api.builder.Nested;
+import io.fabric8.kubernetes.api.model.ListMeta;
+import java.lang.Object;
+import java.lang.RuntimeException;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.lang.SuppressWarnings;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * Generated
+ */
+@SuppressWarnings("unchecked")
+public class JobListFluent<A extends io.fabric8.kubernetes.api.model.batch.v1.JobListFluent<A>> extends BaseFluent<A>{
+
+  private Map<String,Object> additionalProperties;
+  private String apiVersion;
+  private ArrayList<JobBuilder> items = new ArrayList<JobBuilder>();
+  private String kind;
+  private ListMeta metadata;
+
+  public JobListFluent() {
+  }
+  
+  public JobListFluent(JobList instance) {
+    this.copyInstance(instance);
+  }
+
+  public A addAllToItems(Collection<Job> items) {
+    if (this.items == null) {
+      this.items = new ArrayList();
+    }
+    for (Job item : items) {
+        JobBuilder builder = new JobBuilder(item);
+        _visitables.get("items").add(builder);
+        this.items.add(builder);
+    }
+    return (A) this;
+  }
+  
+  public ItemsNested<A> addNewItem() {
+    return new ItemsNested(-1, null);
+  }
+  
+  public ItemsNested<A> addNewItemLike(Job item) {
+    return new ItemsNested(-1, item);
+  }
+  
+  public A addToAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null && map != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (map != null) {
+      this.additionalProperties.putAll(map);
+    }
+    return (A) this;
+  }
+  
+  public A addToAdditionalProperties(String key,Object value) {
+    if (this.additionalProperties == null && key != null && value != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (key != null && value != null) {
+      this.additionalProperties.put(key, value);
+    }
+    return (A) this;
+  }
+  
+  public A addToItems(Job... items) {
+    if (this.items == null) {
+      this.items = new ArrayList();
+    }
+    for (Job item : items) {
+        JobBuilder builder = new JobBuilder(item);
+        _visitables.get("items").add(builder);
+        this.items.add(builder);
+    }
+    return (A) this;
+  }
+  
+  public A addToItems(int index,Job item) {
+    if (this.items == null) {
+      this.items = new ArrayList();
+    }
+    JobBuilder builder = new JobBuilder(item);
+    if (index < 0 || index >= items.size()) {
+        _visitables.get("items").add(builder);
+        items.add(builder);
+    } else {
+        _visitables.get("items").add(builder);
+        items.add(index, builder);
+    }
+    return (A) this;
+  }
+  
+  public Job buildFirstItem() {
+    return this.items.get(0).build();
+  }
+  
+  public Job buildItem(int index) {
+    return this.items.get(index).build();
+  }
+  
+  public List<Job> buildItems() {
+    return this.items != null ? build(items) : null;
+  }
+  
+  public Job buildLastItem() {
+    return this.items.get(items.size() - 1).build();
+  }
+  
+  public Job buildMatchingItem(Predicate<JobBuilder> predicate) {
+      for (JobBuilder item : items) {
+        if (predicate.test(item)) {
+          return item.build();
+        }
+      }
+      return null;
+  }
+  
+  protected void copyInstance(JobList instance) {
+    instance = instance != null ? instance : new JobList();
+    if (instance != null) {
+        this.withApiVersion(instance.getApiVersion());
+        this.withItems(instance.getItems());
+        this.withKind(instance.getKind());
+        this.withMetadata(instance.getMetadata());
+        this.withAdditionalProperties(instance.getAdditionalProperties());
+    }
+  }
+  
+  public ItemsNested<A> editFirstItem() {
+    if (items.size() == 0) {
+      throw new RuntimeException(String.format("Can't edit first %s. The list is empty.", "items"));
+    }
+    return this.setNewItemLike(0, this.buildItem(0));
+  }
+  
+  public ItemsNested<A> editItem(int index) {
+    if (items.size() <= index) {
+      throw new RuntimeException(String.format("Can't edit %s. Index exceeds size.", "items"));
+    }
+    return this.setNewItemLike(index, this.buildItem(index));
+  }
+  
+  public ItemsNested<A> editLastItem() {
+    int index = items.size() - 1;
+    if (index < 0) {
+      throw new RuntimeException(String.format("Can't edit last %s. The list is empty.", "items"));
+    }
+    return this.setNewItemLike(index, this.buildItem(index));
+  }
+  
+  public ItemsNested<A> editMatchingItem(Predicate<JobBuilder> predicate) {
+    int index = -1;
+    for (int i = 0;i < items.size();i++) {
+      if (predicate.test(items.get(i))) {
+          index = i;
+          break;
+      }
+    }
+    if (index < 0) {
+      throw new RuntimeException(String.format("Can't edit matching %s. No match found.", "items"));
+    }
+    return this.setNewItemLike(index, this.buildItem(index));
+  }
+  
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || this.getClass() != o.getClass()) {
+      return false;
+    }
+    if (!(super.equals(o))) {
+      return false;
+    }
+    JobListFluent that = (JobListFluent) o;
+    if (!(Objects.equals(apiVersion, that.apiVersion))) {
+      return false;
+    }
+    if (!(Objects.equals(items, that.items))) {
+      return false;
+    }
+    if (!(Objects.equals(kind, that.kind))) {
+      return false;
+    }
+    if (!(Objects.equals(metadata, that.metadata))) {
+      return false;
+    }
+    if (!(Objects.equals(additionalProperties, that.additionalProperties))) {
+      return false;
+    }
+    return true;
+  }
+  
+  public Map<String,Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
+  
+  public String getApiVersion() {
+    return this.apiVersion;
+  }
+  
+  public String getKind() {
+    return this.kind;
+  }
+  
+  public ListMeta getMetadata() {
+    return this.metadata;
+  }
+  
+  public boolean hasAdditionalProperties() {
+    return this.additionalProperties != null;
+  }
+  
+  public boolean hasApiVersion() {
+    return this.apiVersion != null;
+  }
+  
+  public boolean hasItems() {
+    return this.items != null && !(this.items.isEmpty());
+  }
+  
+  public boolean hasKind() {
+    return this.kind != null;
+  }
+  
+  public boolean hasMatchingItem(Predicate<JobBuilder> predicate) {
+      for (JobBuilder item : items) {
+        if (predicate.test(item)) {
+          return true;
+        }
+      }
+      return false;
+  }
+  
+  public boolean hasMetadata() {
+    return this.metadata != null;
+  }
+  
+  public int hashCode() {
+    return Objects.hash(apiVersion, items, kind, metadata, additionalProperties);
+  }
+  
+  public A removeAllFromItems(Collection<Job> items) {
+    if (this.items == null) {
+      return (A) this;
+    }
+    for (Job item : items) {
+        JobBuilder builder = new JobBuilder(item);
+        _visitables.get("items").remove(builder);
+        this.items.remove(builder);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(String key) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (key != null && this.additionalProperties != null) {
+      this.additionalProperties.remove(key);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (map != null) {
+      for (Object key : map.keySet()) {
+        if (this.additionalProperties != null) {
+          this.additionalProperties.remove(key);
+        }
+      }
+    }
+    return (A) this;
+  }
+  
+  public A removeFromItems(Job... items) {
+    if (this.items == null) {
+      return (A) this;
+    }
+    for (Job item : items) {
+        JobBuilder builder = new JobBuilder(item);
+        _visitables.get("items").remove(builder);
+        this.items.remove(builder);
+    }
+    return (A) this;
+  }
+  
+  public A removeMatchingFromItems(Predicate<JobBuilder> predicate) {
+    if (items == null) {
+      return (A) this;
+    }
+    Iterator<JobBuilder> each = items.iterator();
+    List visitables = _visitables.get("items");
+    while (each.hasNext()) {
+        JobBuilder builder = each.next();
+        if (predicate.test(builder)) {
+            visitables.remove(builder);
+            each.remove();
+        }
+    }
+    return (A) this;
+  }
+  
+  public ItemsNested<A> setNewItemLike(int index,Job item) {
+    return new ItemsNested(index, item);
+  }
+  
+  public A setToItems(int index,Job item) {
+    if (this.items == null) {
+      this.items = new ArrayList();
+    }
+    JobBuilder builder = new JobBuilder(item);
+    if (index < 0 || index >= items.size()) {
+        _visitables.get("items").add(builder);
+        items.add(builder);
+    } else {
+        _visitables.get("items").add(builder);
+        items.set(index, builder);
+    }
+    return (A) this;
+  }
+  
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+    if (!(apiVersion == null)) {
+        sb.append("apiVersion:");
+        sb.append(apiVersion);
+        sb.append(",");
+    }
+    if (!(items == null) && !(items.isEmpty())) {
+        sb.append("items:");
+        sb.append(items);
+        sb.append(",");
+    }
+    if (!(kind == null)) {
+        sb.append("kind:");
+        sb.append(kind);
+        sb.append(",");
+    }
+    if (!(metadata == null)) {
+        sb.append("metadata:");
+        sb.append(metadata);
+        sb.append(",");
+    }
+    if (!(additionalProperties == null) && !(additionalProperties.isEmpty())) {
+        sb.append("additionalProperties:");
+        sb.append(additionalProperties);
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+  
+  public <K,V>A withAdditionalProperties(Map<String,Object> additionalProperties) {
+    if (additionalProperties == null) {
+      this.additionalProperties = null;
+    } else {
+      this.additionalProperties = new LinkedHashMap(additionalProperties);
+    }
+    return (A) this;
+  }
+  
+  public A withApiVersion(String apiVersion) {
+    this.apiVersion = apiVersion;
+    return (A) this;
+  }
+  
+  public A withItems(List<Job> items) {
+    if (this.items != null) {
+      this._visitables.get("items").clear();
+    }
+    if (items != null) {
+        this.items = new ArrayList();
+        for (Job item : items) {
+          this.addToItems(item);
+        }
+    } else {
+      this.items = null;
+    }
+    return (A) this;
+  }
+  
+  public A withItems(Job... items) {
+    if (this.items != null) {
+        this.items.clear();
+        _visitables.remove("items");
+    }
+    if (items != null) {
+      for (Job item : items) {
+        this.addToItems(item);
+      }
+    }
+    return (A) this;
+  }
+  
+  public A withKind(String kind) {
+    this.kind = kind;
+    return (A) this;
+  }
+  
+  public A withMetadata(ListMeta metadata) {
+    this.metadata = metadata;
+    return (A) this;
+  }
+  public class ItemsNested<N> extends JobFluent<ItemsNested<N>> implements Nested<N>{
+  
+    JobBuilder builder;
+    int index;
+  
+    ItemsNested(int index,Job item) {
+      this.index = index;
+      this.builder = new JobBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) JobListFluent.this.setToItems(index, builder.build());
+    }
+    
+    public N endItem() {
+      return and();
+    }
+    
+  }
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/JobSpecBuilder.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/JobSpecBuilder.java
@@ -1,0 +1,33 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
+import java.lang.Object;
+public class JobSpecBuilder extends JobSpecFluent<JobSpecBuilder> implements VisitableBuilder<JobSpec,JobSpecBuilder>{
+
+  JobSpecFluent<?> fluent;
+
+  public JobSpecBuilder() {
+    this(new JobSpec());
+  }
+  
+  public JobSpecBuilder(JobSpecFluent<?> fluent) {
+    this(fluent, new JobSpec());
+  }
+  
+  public JobSpecBuilder(JobSpec instance) {
+    this.fluent = this;
+    this.copyInstance(instance);
+  }
+  
+  public JobSpecBuilder(JobSpecFluent<?> fluent,JobSpec instance) {
+    this.fluent = fluent;
+    fluent.copyInstance(instance);
+  }
+
+  public JobSpec build() {
+    JobSpec buildable = new JobSpec(fluent.getActiveDeadlineSeconds(), fluent.getBackoffLimit(), fluent.getBackoffLimitPerIndex(), fluent.getCompletionMode(), fluent.getCompletions(), fluent.getManagedBy(), fluent.getManualSelector(), fluent.getMaxFailedIndexes(), fluent.getParallelism(), fluent.buildPodFailurePolicy(), fluent.getPodReplacementPolicy(), fluent.buildSelector(), fluent.buildSuccessPolicy(), fluent.getSuspend(), fluent.buildTemplate(), fluent.getTtlSecondsAfterFinished());
+    buildable.setAdditionalProperties(fluent.getAdditionalProperties());
+    return buildable;
+  }
+  
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/JobSpecFluent.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/JobSpecFluent.java
@@ -1,0 +1,689 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.BaseFluent;
+import io.fabric8.kubernetes.api.builder.Nested;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
+import io.fabric8.kubernetes.api.model.LabelSelectorFluent;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.PodTemplateSpecBuilder;
+import io.fabric8.kubernetes.api.model.PodTemplateSpecFluent;
+import java.lang.Boolean;
+import java.lang.Integer;
+import java.lang.Long;
+import java.lang.Object;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.lang.SuppressWarnings;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Generated
+ */
+@SuppressWarnings("unchecked")
+public class JobSpecFluent<A extends io.fabric8.kubernetes.api.model.batch.v1.JobSpecFluent<A>> extends BaseFluent<A>{
+
+  private Long activeDeadlineSeconds;
+  private Map<String,Object> additionalProperties;
+  private Integer backoffLimit;
+  private Integer backoffLimitPerIndex;
+  private String completionMode;
+  private Integer completions;
+  private String managedBy;
+  private Boolean manualSelector;
+  private Integer maxFailedIndexes;
+  private Integer parallelism;
+  private PodFailurePolicyBuilder podFailurePolicy;
+  private String podReplacementPolicy;
+  private LabelSelectorBuilder selector;
+  private SuccessPolicyBuilder successPolicy;
+  private Boolean suspend;
+  private PodTemplateSpecBuilder template;
+  private Integer ttlSecondsAfterFinished;
+
+  public JobSpecFluent() {
+  }
+  
+  public JobSpecFluent(JobSpec instance) {
+    this.copyInstance(instance);
+  }
+
+  public A addToAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null && map != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (map != null) {
+      this.additionalProperties.putAll(map);
+    }
+    return (A) this;
+  }
+  
+  public A addToAdditionalProperties(String key,Object value) {
+    if (this.additionalProperties == null && key != null && value != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (key != null && value != null) {
+      this.additionalProperties.put(key, value);
+    }
+    return (A) this;
+  }
+  
+  public PodFailurePolicy buildPodFailurePolicy() {
+    return this.podFailurePolicy != null ? this.podFailurePolicy.build() : null;
+  }
+  
+  public LabelSelector buildSelector() {
+    return this.selector != null ? this.selector.build() : null;
+  }
+  
+  public SuccessPolicy buildSuccessPolicy() {
+    return this.successPolicy != null ? this.successPolicy.build() : null;
+  }
+  
+  public PodTemplateSpec buildTemplate() {
+    return this.template != null ? this.template.build() : null;
+  }
+  
+  protected void copyInstance(JobSpec instance) {
+    instance = instance != null ? instance : new JobSpec();
+    if (instance != null) {
+        this.withActiveDeadlineSeconds(instance.getActiveDeadlineSeconds());
+        this.withBackoffLimit(instance.getBackoffLimit());
+        this.withBackoffLimitPerIndex(instance.getBackoffLimitPerIndex());
+        this.withCompletionMode(instance.getCompletionMode());
+        this.withCompletions(instance.getCompletions());
+        this.withManagedBy(instance.getManagedBy());
+        this.withManualSelector(instance.getManualSelector());
+        this.withMaxFailedIndexes(instance.getMaxFailedIndexes());
+        this.withParallelism(instance.getParallelism());
+        this.withPodFailurePolicy(instance.getPodFailurePolicy());
+        this.withPodReplacementPolicy(instance.getPodReplacementPolicy());
+        this.withSelector(instance.getSelector());
+        this.withSuccessPolicy(instance.getSuccessPolicy());
+        this.withSuspend(instance.getSuspend());
+        this.withTemplate(instance.getTemplate());
+        this.withTtlSecondsAfterFinished(instance.getTtlSecondsAfterFinished());
+        this.withAdditionalProperties(instance.getAdditionalProperties());
+    }
+  }
+  
+  public PodFailurePolicyNested<A> editOrNewPodFailurePolicy() {
+    return this.withNewPodFailurePolicyLike(Optional.ofNullable(this.buildPodFailurePolicy()).orElse(new PodFailurePolicyBuilder().build()));
+  }
+  
+  public PodFailurePolicyNested<A> editOrNewPodFailurePolicyLike(PodFailurePolicy item) {
+    return this.withNewPodFailurePolicyLike(Optional.ofNullable(this.buildPodFailurePolicy()).orElse(item));
+  }
+  
+  public SelectorNested<A> editOrNewSelector() {
+    return this.withNewSelectorLike(Optional.ofNullable(this.buildSelector()).orElse(new LabelSelectorBuilder().build()));
+  }
+  
+  public SelectorNested<A> editOrNewSelectorLike(LabelSelector item) {
+    return this.withNewSelectorLike(Optional.ofNullable(this.buildSelector()).orElse(item));
+  }
+  
+  public SuccessPolicyNested<A> editOrNewSuccessPolicy() {
+    return this.withNewSuccessPolicyLike(Optional.ofNullable(this.buildSuccessPolicy()).orElse(new SuccessPolicyBuilder().build()));
+  }
+  
+  public SuccessPolicyNested<A> editOrNewSuccessPolicyLike(SuccessPolicy item) {
+    return this.withNewSuccessPolicyLike(Optional.ofNullable(this.buildSuccessPolicy()).orElse(item));
+  }
+  
+  public TemplateNested<A> editOrNewTemplate() {
+    return this.withNewTemplateLike(Optional.ofNullable(this.buildTemplate()).orElse(new PodTemplateSpecBuilder().build()));
+  }
+  
+  public TemplateNested<A> editOrNewTemplateLike(PodTemplateSpec item) {
+    return this.withNewTemplateLike(Optional.ofNullable(this.buildTemplate()).orElse(item));
+  }
+  
+  public PodFailurePolicyNested<A> editPodFailurePolicy() {
+    return this.withNewPodFailurePolicyLike(Optional.ofNullable(this.buildPodFailurePolicy()).orElse(null));
+  }
+  
+  public SelectorNested<A> editSelector() {
+    return this.withNewSelectorLike(Optional.ofNullable(this.buildSelector()).orElse(null));
+  }
+  
+  public SuccessPolicyNested<A> editSuccessPolicy() {
+    return this.withNewSuccessPolicyLike(Optional.ofNullable(this.buildSuccessPolicy()).orElse(null));
+  }
+  
+  public TemplateNested<A> editTemplate() {
+    return this.withNewTemplateLike(Optional.ofNullable(this.buildTemplate()).orElse(null));
+  }
+  
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || this.getClass() != o.getClass()) {
+      return false;
+    }
+    if (!(super.equals(o))) {
+      return false;
+    }
+    JobSpecFluent that = (JobSpecFluent) o;
+    if (!(Objects.equals(activeDeadlineSeconds, that.activeDeadlineSeconds))) {
+      return false;
+    }
+    if (!(Objects.equals(backoffLimit, that.backoffLimit))) {
+      return false;
+    }
+    if (!(Objects.equals(backoffLimitPerIndex, that.backoffLimitPerIndex))) {
+      return false;
+    }
+    if (!(Objects.equals(completionMode, that.completionMode))) {
+      return false;
+    }
+    if (!(Objects.equals(completions, that.completions))) {
+      return false;
+    }
+    if (!(Objects.equals(managedBy, that.managedBy))) {
+      return false;
+    }
+    if (!(Objects.equals(manualSelector, that.manualSelector))) {
+      return false;
+    }
+    if (!(Objects.equals(maxFailedIndexes, that.maxFailedIndexes))) {
+      return false;
+    }
+    if (!(Objects.equals(parallelism, that.parallelism))) {
+      return false;
+    }
+    if (!(Objects.equals(podFailurePolicy, that.podFailurePolicy))) {
+      return false;
+    }
+    if (!(Objects.equals(podReplacementPolicy, that.podReplacementPolicy))) {
+      return false;
+    }
+    if (!(Objects.equals(selector, that.selector))) {
+      return false;
+    }
+    if (!(Objects.equals(successPolicy, that.successPolicy))) {
+      return false;
+    }
+    if (!(Objects.equals(suspend, that.suspend))) {
+      return false;
+    }
+    if (!(Objects.equals(template, that.template))) {
+      return false;
+    }
+    if (!(Objects.equals(ttlSecondsAfterFinished, that.ttlSecondsAfterFinished))) {
+      return false;
+    }
+    if (!(Objects.equals(additionalProperties, that.additionalProperties))) {
+      return false;
+    }
+    return true;
+  }
+  
+  public Long getActiveDeadlineSeconds() {
+    return this.activeDeadlineSeconds;
+  }
+  
+  public Map<String,Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
+  
+  public Integer getBackoffLimit() {
+    return this.backoffLimit;
+  }
+  
+  public Integer getBackoffLimitPerIndex() {
+    return this.backoffLimitPerIndex;
+  }
+  
+  public String getCompletionMode() {
+    return this.completionMode;
+  }
+  
+  public Integer getCompletions() {
+    return this.completions;
+  }
+  
+  public String getManagedBy() {
+    return this.managedBy;
+  }
+  
+  public Boolean getManualSelector() {
+    return this.manualSelector;
+  }
+  
+  public Integer getMaxFailedIndexes() {
+    return this.maxFailedIndexes;
+  }
+  
+  public Integer getParallelism() {
+    return this.parallelism;
+  }
+  
+  public String getPodReplacementPolicy() {
+    return this.podReplacementPolicy;
+  }
+  
+  public Boolean getSuspend() {
+    return this.suspend;
+  }
+  
+  public Integer getTtlSecondsAfterFinished() {
+    return this.ttlSecondsAfterFinished;
+  }
+  
+  public boolean hasActiveDeadlineSeconds() {
+    return this.activeDeadlineSeconds != null;
+  }
+  
+  public boolean hasAdditionalProperties() {
+    return this.additionalProperties != null;
+  }
+  
+  public boolean hasBackoffLimit() {
+    return this.backoffLimit != null;
+  }
+  
+  public boolean hasBackoffLimitPerIndex() {
+    return this.backoffLimitPerIndex != null;
+  }
+  
+  public boolean hasCompletionMode() {
+    return this.completionMode != null;
+  }
+  
+  public boolean hasCompletions() {
+    return this.completions != null;
+  }
+  
+  public boolean hasManagedBy() {
+    return this.managedBy != null;
+  }
+  
+  public boolean hasManualSelector() {
+    return this.manualSelector != null;
+  }
+  
+  public boolean hasMaxFailedIndexes() {
+    return this.maxFailedIndexes != null;
+  }
+  
+  public boolean hasParallelism() {
+    return this.parallelism != null;
+  }
+  
+  public boolean hasPodFailurePolicy() {
+    return this.podFailurePolicy != null;
+  }
+  
+  public boolean hasPodReplacementPolicy() {
+    return this.podReplacementPolicy != null;
+  }
+  
+  public boolean hasSelector() {
+    return this.selector != null;
+  }
+  
+  public boolean hasSuccessPolicy() {
+    return this.successPolicy != null;
+  }
+  
+  public boolean hasSuspend() {
+    return this.suspend != null;
+  }
+  
+  public boolean hasTemplate() {
+    return this.template != null;
+  }
+  
+  public boolean hasTtlSecondsAfterFinished() {
+    return this.ttlSecondsAfterFinished != null;
+  }
+  
+  public int hashCode() {
+    return Objects.hash(activeDeadlineSeconds, backoffLimit, backoffLimitPerIndex, completionMode, completions, managedBy, manualSelector, maxFailedIndexes, parallelism, podFailurePolicy, podReplacementPolicy, selector, successPolicy, suspend, template, ttlSecondsAfterFinished, additionalProperties);
+  }
+  
+  public A removeFromAdditionalProperties(String key) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (key != null && this.additionalProperties != null) {
+      this.additionalProperties.remove(key);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (map != null) {
+      for (Object key : map.keySet()) {
+        if (this.additionalProperties != null) {
+          this.additionalProperties.remove(key);
+        }
+      }
+    }
+    return (A) this;
+  }
+  
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+    if (!(activeDeadlineSeconds == null)) {
+        sb.append("activeDeadlineSeconds:");
+        sb.append(activeDeadlineSeconds);
+        sb.append(",");
+    }
+    if (!(backoffLimit == null)) {
+        sb.append("backoffLimit:");
+        sb.append(backoffLimit);
+        sb.append(",");
+    }
+    if (!(backoffLimitPerIndex == null)) {
+        sb.append("backoffLimitPerIndex:");
+        sb.append(backoffLimitPerIndex);
+        sb.append(",");
+    }
+    if (!(completionMode == null)) {
+        sb.append("completionMode:");
+        sb.append(completionMode);
+        sb.append(",");
+    }
+    if (!(completions == null)) {
+        sb.append("completions:");
+        sb.append(completions);
+        sb.append(",");
+    }
+    if (!(managedBy == null)) {
+        sb.append("managedBy:");
+        sb.append(managedBy);
+        sb.append(",");
+    }
+    if (!(manualSelector == null)) {
+        sb.append("manualSelector:");
+        sb.append(manualSelector);
+        sb.append(",");
+    }
+    if (!(maxFailedIndexes == null)) {
+        sb.append("maxFailedIndexes:");
+        sb.append(maxFailedIndexes);
+        sb.append(",");
+    }
+    if (!(parallelism == null)) {
+        sb.append("parallelism:");
+        sb.append(parallelism);
+        sb.append(",");
+    }
+    if (!(podFailurePolicy == null)) {
+        sb.append("podFailurePolicy:");
+        sb.append(podFailurePolicy);
+        sb.append(",");
+    }
+    if (!(podReplacementPolicy == null)) {
+        sb.append("podReplacementPolicy:");
+        sb.append(podReplacementPolicy);
+        sb.append(",");
+    }
+    if (!(selector == null)) {
+        sb.append("selector:");
+        sb.append(selector);
+        sb.append(",");
+    }
+    if (!(successPolicy == null)) {
+        sb.append("successPolicy:");
+        sb.append(successPolicy);
+        sb.append(",");
+    }
+    if (!(suspend == null)) {
+        sb.append("suspend:");
+        sb.append(suspend);
+        sb.append(",");
+    }
+    if (!(template == null)) {
+        sb.append("template:");
+        sb.append(template);
+        sb.append(",");
+    }
+    if (!(ttlSecondsAfterFinished == null)) {
+        sb.append("ttlSecondsAfterFinished:");
+        sb.append(ttlSecondsAfterFinished);
+        sb.append(",");
+    }
+    if (!(additionalProperties == null) && !(additionalProperties.isEmpty())) {
+        sb.append("additionalProperties:");
+        sb.append(additionalProperties);
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+  
+  public A withActiveDeadlineSeconds(Long activeDeadlineSeconds) {
+    this.activeDeadlineSeconds = activeDeadlineSeconds;
+    return (A) this;
+  }
+  
+  public <K,V>A withAdditionalProperties(Map<String,Object> additionalProperties) {
+    if (additionalProperties == null) {
+      this.additionalProperties = null;
+    } else {
+      this.additionalProperties = new LinkedHashMap(additionalProperties);
+    }
+    return (A) this;
+  }
+  
+  public A withBackoffLimit(Integer backoffLimit) {
+    this.backoffLimit = backoffLimit;
+    return (A) this;
+  }
+  
+  public A withBackoffLimitPerIndex(Integer backoffLimitPerIndex) {
+    this.backoffLimitPerIndex = backoffLimitPerIndex;
+    return (A) this;
+  }
+  
+  public A withCompletionMode(String completionMode) {
+    this.completionMode = completionMode;
+    return (A) this;
+  }
+  
+  public A withCompletions(Integer completions) {
+    this.completions = completions;
+    return (A) this;
+  }
+  
+  public A withManagedBy(String managedBy) {
+    this.managedBy = managedBy;
+    return (A) this;
+  }
+  
+  public A withManualSelector() {
+    return withManualSelector(true);
+  }
+  
+  public A withManualSelector(Boolean manualSelector) {
+    this.manualSelector = manualSelector;
+    return (A) this;
+  }
+  
+  public A withMaxFailedIndexes(Integer maxFailedIndexes) {
+    this.maxFailedIndexes = maxFailedIndexes;
+    return (A) this;
+  }
+  
+  public PodFailurePolicyNested<A> withNewPodFailurePolicy() {
+    return new PodFailurePolicyNested(null);
+  }
+  
+  public PodFailurePolicyNested<A> withNewPodFailurePolicyLike(PodFailurePolicy item) {
+    return new PodFailurePolicyNested(item);
+  }
+  
+  public SelectorNested<A> withNewSelector() {
+    return new SelectorNested(null);
+  }
+  
+  public SelectorNested<A> withNewSelectorLike(LabelSelector item) {
+    return new SelectorNested(item);
+  }
+  
+  public SuccessPolicyNested<A> withNewSuccessPolicy() {
+    return new SuccessPolicyNested(null);
+  }
+  
+  public SuccessPolicyNested<A> withNewSuccessPolicyLike(SuccessPolicy item) {
+    return new SuccessPolicyNested(item);
+  }
+  
+  public TemplateNested<A> withNewTemplate() {
+    return new TemplateNested(null);
+  }
+  
+  public TemplateNested<A> withNewTemplateLike(PodTemplateSpec item) {
+    return new TemplateNested(item);
+  }
+  
+  public A withParallelism(Integer parallelism) {
+    this.parallelism = parallelism;
+    return (A) this;
+  }
+  
+  public A withPodFailurePolicy(PodFailurePolicy podFailurePolicy) {
+    this._visitables.remove("podFailurePolicy");
+    if (podFailurePolicy != null) {
+        this.podFailurePolicy = new PodFailurePolicyBuilder(podFailurePolicy);
+        this._visitables.get("podFailurePolicy").add(this.podFailurePolicy);
+    } else {
+        this.podFailurePolicy = null;
+        this._visitables.get("podFailurePolicy").remove(this.podFailurePolicy);
+    }
+    return (A) this;
+  }
+  
+  public A withPodReplacementPolicy(String podReplacementPolicy) {
+    this.podReplacementPolicy = podReplacementPolicy;
+    return (A) this;
+  }
+  
+  public A withSelector(LabelSelector selector) {
+    this._visitables.remove("selector");
+    if (selector != null) {
+        this.selector = new LabelSelectorBuilder(selector);
+        this._visitables.get("selector").add(this.selector);
+    } else {
+        this.selector = null;
+        this._visitables.get("selector").remove(this.selector);
+    }
+    return (A) this;
+  }
+  
+  public A withSuccessPolicy(SuccessPolicy successPolicy) {
+    this._visitables.remove("successPolicy");
+    if (successPolicy != null) {
+        this.successPolicy = new SuccessPolicyBuilder(successPolicy);
+        this._visitables.get("successPolicy").add(this.successPolicy);
+    } else {
+        this.successPolicy = null;
+        this._visitables.get("successPolicy").remove(this.successPolicy);
+    }
+    return (A) this;
+  }
+  
+  public A withSuspend() {
+    return withSuspend(true);
+  }
+  
+  public A withSuspend(Boolean suspend) {
+    this.suspend = suspend;
+    return (A) this;
+  }
+  
+  public A withTemplate(PodTemplateSpec template) {
+    this._visitables.remove("template");
+    if (template != null) {
+        this.template = new PodTemplateSpecBuilder(template);
+        this._visitables.get("template").add(this.template);
+    } else {
+        this.template = null;
+        this._visitables.get("template").remove(this.template);
+    }
+    return (A) this;
+  }
+  
+  public A withTtlSecondsAfterFinished(Integer ttlSecondsAfterFinished) {
+    this.ttlSecondsAfterFinished = ttlSecondsAfterFinished;
+    return (A) this;
+  }
+  public class PodFailurePolicyNested<N> extends PodFailurePolicyFluent<PodFailurePolicyNested<N>> implements Nested<N>{
+  
+    PodFailurePolicyBuilder builder;
+  
+    PodFailurePolicyNested(PodFailurePolicy item) {
+      this.builder = new PodFailurePolicyBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) JobSpecFluent.this.withPodFailurePolicy(builder.build());
+    }
+    
+    public N endPodFailurePolicy() {
+      return and();
+    }
+    
+  }
+  public class SelectorNested<N> extends LabelSelectorFluent<SelectorNested<N>> implements Nested<N>{
+  
+    LabelSelectorBuilder builder;
+  
+    SelectorNested(LabelSelector item) {
+      this.builder = new LabelSelectorBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) JobSpecFluent.this.withSelector(builder.build());
+    }
+    
+    public N endSelector() {
+      return and();
+    }
+    
+  }
+  public class SuccessPolicyNested<N> extends SuccessPolicyFluent<SuccessPolicyNested<N>> implements Nested<N>{
+  
+    SuccessPolicyBuilder builder;
+  
+    SuccessPolicyNested(SuccessPolicy item) {
+      this.builder = new SuccessPolicyBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) JobSpecFluent.this.withSuccessPolicy(builder.build());
+    }
+    
+    public N endSuccessPolicy() {
+      return and();
+    }
+    
+  }
+  public class TemplateNested<N> extends PodTemplateSpecFluent<TemplateNested<N>> implements Nested<N>{
+  
+    PodTemplateSpecBuilder builder;
+  
+    TemplateNested(PodTemplateSpec item) {
+      this.builder = new PodTemplateSpecBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) JobSpecFluent.this.withTemplate(builder.build());
+    }
+    
+    public N endTemplate() {
+      return and();
+    }
+    
+  }
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/JobStatusBuilder.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/JobStatusBuilder.java
@@ -1,0 +1,33 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
+import java.lang.Object;
+public class JobStatusBuilder extends JobStatusFluent<JobStatusBuilder> implements VisitableBuilder<JobStatus,JobStatusBuilder>{
+
+  JobStatusFluent<?> fluent;
+
+  public JobStatusBuilder() {
+    this(new JobStatus());
+  }
+  
+  public JobStatusBuilder(JobStatusFluent<?> fluent) {
+    this(fluent, new JobStatus());
+  }
+  
+  public JobStatusBuilder(JobStatus instance) {
+    this.fluent = this;
+    this.copyInstance(instance);
+  }
+  
+  public JobStatusBuilder(JobStatusFluent<?> fluent,JobStatus instance) {
+    this.fluent = fluent;
+    fluent.copyInstance(instance);
+  }
+
+  public JobStatus build() {
+    JobStatus buildable = new JobStatus(fluent.getActive(), fluent.getCompletedIndexes(), fluent.getCompletionTime(), fluent.buildConditions(), fluent.getFailed(), fluent.getFailedIndexes(), fluent.getReady(), fluent.getStartTime(), fluent.getSucceeded(), fluent.getTerminating(), fluent.buildUncountedTerminatedPods());
+    buildable.setAdditionalProperties(fluent.getAdditionalProperties());
+    return buildable;
+  }
+  
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/JobStatusFluent.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/JobStatusFluent.java
@@ -1,0 +1,646 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.BaseFluent;
+import io.fabric8.kubernetes.api.builder.Nested;
+import java.lang.Integer;
+import java.lang.Object;
+import java.lang.RuntimeException;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.lang.SuppressWarnings;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+/**
+ * Generated
+ */
+@SuppressWarnings("unchecked")
+public class JobStatusFluent<A extends io.fabric8.kubernetes.api.model.batch.v1.JobStatusFluent<A>> extends BaseFluent<A>{
+
+  private Integer active;
+  private Map<String,Object> additionalProperties;
+  private String completedIndexes;
+  private String completionTime;
+  private ArrayList<JobConditionBuilder> conditions = new ArrayList<JobConditionBuilder>();
+  private Integer failed;
+  private String failedIndexes;
+  private Integer ready;
+  private String startTime;
+  private Integer succeeded;
+  private Integer terminating;
+  private UncountedTerminatedPodsBuilder uncountedTerminatedPods;
+
+  public JobStatusFluent() {
+  }
+  
+  public JobStatusFluent(JobStatus instance) {
+    this.copyInstance(instance);
+  }
+
+  public A addAllToConditions(Collection<JobCondition> items) {
+    if (this.conditions == null) {
+      this.conditions = new ArrayList();
+    }
+    for (JobCondition item : items) {
+        JobConditionBuilder builder = new JobConditionBuilder(item);
+        _visitables.get("conditions").add(builder);
+        this.conditions.add(builder);
+    }
+    return (A) this;
+  }
+  
+  public ConditionsNested<A> addNewCondition() {
+    return new ConditionsNested(-1, null);
+  }
+  
+  public ConditionsNested<A> addNewConditionLike(JobCondition item) {
+    return new ConditionsNested(-1, item);
+  }
+  
+  public A addToAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null && map != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (map != null) {
+      this.additionalProperties.putAll(map);
+    }
+    return (A) this;
+  }
+  
+  public A addToAdditionalProperties(String key,Object value) {
+    if (this.additionalProperties == null && key != null && value != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (key != null && value != null) {
+      this.additionalProperties.put(key, value);
+    }
+    return (A) this;
+  }
+  
+  public A addToConditions(JobCondition... items) {
+    if (this.conditions == null) {
+      this.conditions = new ArrayList();
+    }
+    for (JobCondition item : items) {
+        JobConditionBuilder builder = new JobConditionBuilder(item);
+        _visitables.get("conditions").add(builder);
+        this.conditions.add(builder);
+    }
+    return (A) this;
+  }
+  
+  public A addToConditions(int index,JobCondition item) {
+    if (this.conditions == null) {
+      this.conditions = new ArrayList();
+    }
+    JobConditionBuilder builder = new JobConditionBuilder(item);
+    if (index < 0 || index >= conditions.size()) {
+        _visitables.get("conditions").add(builder);
+        conditions.add(builder);
+    } else {
+        _visitables.get("conditions").add(builder);
+        conditions.add(index, builder);
+    }
+    return (A) this;
+  }
+  
+  public JobCondition buildCondition(int index) {
+    return this.conditions.get(index).build();
+  }
+  
+  public List<JobCondition> buildConditions() {
+    return this.conditions != null ? build(conditions) : null;
+  }
+  
+  public JobCondition buildFirstCondition() {
+    return this.conditions.get(0).build();
+  }
+  
+  public JobCondition buildLastCondition() {
+    return this.conditions.get(conditions.size() - 1).build();
+  }
+  
+  public JobCondition buildMatchingCondition(Predicate<JobConditionBuilder> predicate) {
+      for (JobConditionBuilder item : conditions) {
+        if (predicate.test(item)) {
+          return item.build();
+        }
+      }
+      return null;
+  }
+  
+  public UncountedTerminatedPods buildUncountedTerminatedPods() {
+    return this.uncountedTerminatedPods != null ? this.uncountedTerminatedPods.build() : null;
+  }
+  
+  protected void copyInstance(JobStatus instance) {
+    instance = instance != null ? instance : new JobStatus();
+    if (instance != null) {
+        this.withActive(instance.getActive());
+        this.withCompletedIndexes(instance.getCompletedIndexes());
+        this.withCompletionTime(instance.getCompletionTime());
+        this.withConditions(instance.getConditions());
+        this.withFailed(instance.getFailed());
+        this.withFailedIndexes(instance.getFailedIndexes());
+        this.withReady(instance.getReady());
+        this.withStartTime(instance.getStartTime());
+        this.withSucceeded(instance.getSucceeded());
+        this.withTerminating(instance.getTerminating());
+        this.withUncountedTerminatedPods(instance.getUncountedTerminatedPods());
+        this.withAdditionalProperties(instance.getAdditionalProperties());
+    }
+  }
+  
+  public ConditionsNested<A> editCondition(int index) {
+    if (conditions.size() <= index) {
+      throw new RuntimeException(String.format("Can't edit %s. Index exceeds size.", "conditions"));
+    }
+    return this.setNewConditionLike(index, this.buildCondition(index));
+  }
+  
+  public ConditionsNested<A> editFirstCondition() {
+    if (conditions.size() == 0) {
+      throw new RuntimeException(String.format("Can't edit first %s. The list is empty.", "conditions"));
+    }
+    return this.setNewConditionLike(0, this.buildCondition(0));
+  }
+  
+  public ConditionsNested<A> editLastCondition() {
+    int index = conditions.size() - 1;
+    if (index < 0) {
+      throw new RuntimeException(String.format("Can't edit last %s. The list is empty.", "conditions"));
+    }
+    return this.setNewConditionLike(index, this.buildCondition(index));
+  }
+  
+  public ConditionsNested<A> editMatchingCondition(Predicate<JobConditionBuilder> predicate) {
+    int index = -1;
+    for (int i = 0;i < conditions.size();i++) {
+      if (predicate.test(conditions.get(i))) {
+          index = i;
+          break;
+      }
+    }
+    if (index < 0) {
+      throw new RuntimeException(String.format("Can't edit matching %s. No match found.", "conditions"));
+    }
+    return this.setNewConditionLike(index, this.buildCondition(index));
+  }
+  
+  public UncountedTerminatedPodsNested<A> editOrNewUncountedTerminatedPods() {
+    return this.withNewUncountedTerminatedPodsLike(Optional.ofNullable(this.buildUncountedTerminatedPods()).orElse(new UncountedTerminatedPodsBuilder().build()));
+  }
+  
+  public UncountedTerminatedPodsNested<A> editOrNewUncountedTerminatedPodsLike(UncountedTerminatedPods item) {
+    return this.withNewUncountedTerminatedPodsLike(Optional.ofNullable(this.buildUncountedTerminatedPods()).orElse(item));
+  }
+  
+  public UncountedTerminatedPodsNested<A> editUncountedTerminatedPods() {
+    return this.withNewUncountedTerminatedPodsLike(Optional.ofNullable(this.buildUncountedTerminatedPods()).orElse(null));
+  }
+  
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || this.getClass() != o.getClass()) {
+      return false;
+    }
+    if (!(super.equals(o))) {
+      return false;
+    }
+    JobStatusFluent that = (JobStatusFluent) o;
+    if (!(Objects.equals(active, that.active))) {
+      return false;
+    }
+    if (!(Objects.equals(completedIndexes, that.completedIndexes))) {
+      return false;
+    }
+    if (!(Objects.equals(completionTime, that.completionTime))) {
+      return false;
+    }
+    if (!(Objects.equals(conditions, that.conditions))) {
+      return false;
+    }
+    if (!(Objects.equals(failed, that.failed))) {
+      return false;
+    }
+    if (!(Objects.equals(failedIndexes, that.failedIndexes))) {
+      return false;
+    }
+    if (!(Objects.equals(ready, that.ready))) {
+      return false;
+    }
+    if (!(Objects.equals(startTime, that.startTime))) {
+      return false;
+    }
+    if (!(Objects.equals(succeeded, that.succeeded))) {
+      return false;
+    }
+    if (!(Objects.equals(terminating, that.terminating))) {
+      return false;
+    }
+    if (!(Objects.equals(uncountedTerminatedPods, that.uncountedTerminatedPods))) {
+      return false;
+    }
+    if (!(Objects.equals(additionalProperties, that.additionalProperties))) {
+      return false;
+    }
+    return true;
+  }
+  
+  public Integer getActive() {
+    return this.active;
+  }
+  
+  public Map<String,Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
+  
+  public String getCompletedIndexes() {
+    return this.completedIndexes;
+  }
+  
+  public String getCompletionTime() {
+    return this.completionTime;
+  }
+  
+  public Integer getFailed() {
+    return this.failed;
+  }
+  
+  public String getFailedIndexes() {
+    return this.failedIndexes;
+  }
+  
+  public Integer getReady() {
+    return this.ready;
+  }
+  
+  public String getStartTime() {
+    return this.startTime;
+  }
+  
+  public Integer getSucceeded() {
+    return this.succeeded;
+  }
+  
+  public Integer getTerminating() {
+    return this.terminating;
+  }
+  
+  public boolean hasActive() {
+    return this.active != null;
+  }
+  
+  public boolean hasAdditionalProperties() {
+    return this.additionalProperties != null;
+  }
+  
+  public boolean hasCompletedIndexes() {
+    return this.completedIndexes != null;
+  }
+  
+  public boolean hasCompletionTime() {
+    return this.completionTime != null;
+  }
+  
+  public boolean hasConditions() {
+    return this.conditions != null && !(this.conditions.isEmpty());
+  }
+  
+  public boolean hasFailed() {
+    return this.failed != null;
+  }
+  
+  public boolean hasFailedIndexes() {
+    return this.failedIndexes != null;
+  }
+  
+  public boolean hasMatchingCondition(Predicate<JobConditionBuilder> predicate) {
+      for (JobConditionBuilder item : conditions) {
+        if (predicate.test(item)) {
+          return true;
+        }
+      }
+      return false;
+  }
+  
+  public boolean hasReady() {
+    return this.ready != null;
+  }
+  
+  public boolean hasStartTime() {
+    return this.startTime != null;
+  }
+  
+  public boolean hasSucceeded() {
+    return this.succeeded != null;
+  }
+  
+  public boolean hasTerminating() {
+    return this.terminating != null;
+  }
+  
+  public boolean hasUncountedTerminatedPods() {
+    return this.uncountedTerminatedPods != null;
+  }
+  
+  public int hashCode() {
+    return Objects.hash(active, completedIndexes, completionTime, conditions, failed, failedIndexes, ready, startTime, succeeded, terminating, uncountedTerminatedPods, additionalProperties);
+  }
+  
+  public A removeAllFromConditions(Collection<JobCondition> items) {
+    if (this.conditions == null) {
+      return (A) this;
+    }
+    for (JobCondition item : items) {
+        JobConditionBuilder builder = new JobConditionBuilder(item);
+        _visitables.get("conditions").remove(builder);
+        this.conditions.remove(builder);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(String key) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (key != null && this.additionalProperties != null) {
+      this.additionalProperties.remove(key);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (map != null) {
+      for (Object key : map.keySet()) {
+        if (this.additionalProperties != null) {
+          this.additionalProperties.remove(key);
+        }
+      }
+    }
+    return (A) this;
+  }
+  
+  public A removeFromConditions(JobCondition... items) {
+    if (this.conditions == null) {
+      return (A) this;
+    }
+    for (JobCondition item : items) {
+        JobConditionBuilder builder = new JobConditionBuilder(item);
+        _visitables.get("conditions").remove(builder);
+        this.conditions.remove(builder);
+    }
+    return (A) this;
+  }
+  
+  public A removeMatchingFromConditions(Predicate<JobConditionBuilder> predicate) {
+    if (conditions == null) {
+      return (A) this;
+    }
+    Iterator<JobConditionBuilder> each = conditions.iterator();
+    List visitables = _visitables.get("conditions");
+    while (each.hasNext()) {
+        JobConditionBuilder builder = each.next();
+        if (predicate.test(builder)) {
+            visitables.remove(builder);
+            each.remove();
+        }
+    }
+    return (A) this;
+  }
+  
+  public ConditionsNested<A> setNewConditionLike(int index,JobCondition item) {
+    return new ConditionsNested(index, item);
+  }
+  
+  public A setToConditions(int index,JobCondition item) {
+    if (this.conditions == null) {
+      this.conditions = new ArrayList();
+    }
+    JobConditionBuilder builder = new JobConditionBuilder(item);
+    if (index < 0 || index >= conditions.size()) {
+        _visitables.get("conditions").add(builder);
+        conditions.add(builder);
+    } else {
+        _visitables.get("conditions").add(builder);
+        conditions.set(index, builder);
+    }
+    return (A) this;
+  }
+  
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+    if (!(active == null)) {
+        sb.append("active:");
+        sb.append(active);
+        sb.append(",");
+    }
+    if (!(completedIndexes == null)) {
+        sb.append("completedIndexes:");
+        sb.append(completedIndexes);
+        sb.append(",");
+    }
+    if (!(completionTime == null)) {
+        sb.append("completionTime:");
+        sb.append(completionTime);
+        sb.append(",");
+    }
+    if (!(conditions == null) && !(conditions.isEmpty())) {
+        sb.append("conditions:");
+        sb.append(conditions);
+        sb.append(",");
+    }
+    if (!(failed == null)) {
+        sb.append("failed:");
+        sb.append(failed);
+        sb.append(",");
+    }
+    if (!(failedIndexes == null)) {
+        sb.append("failedIndexes:");
+        sb.append(failedIndexes);
+        sb.append(",");
+    }
+    if (!(ready == null)) {
+        sb.append("ready:");
+        sb.append(ready);
+        sb.append(",");
+    }
+    if (!(startTime == null)) {
+        sb.append("startTime:");
+        sb.append(startTime);
+        sb.append(",");
+    }
+    if (!(succeeded == null)) {
+        sb.append("succeeded:");
+        sb.append(succeeded);
+        sb.append(",");
+    }
+    if (!(terminating == null)) {
+        sb.append("terminating:");
+        sb.append(terminating);
+        sb.append(",");
+    }
+    if (!(uncountedTerminatedPods == null)) {
+        sb.append("uncountedTerminatedPods:");
+        sb.append(uncountedTerminatedPods);
+        sb.append(",");
+    }
+    if (!(additionalProperties == null) && !(additionalProperties.isEmpty())) {
+        sb.append("additionalProperties:");
+        sb.append(additionalProperties);
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+  
+  public A withActive(Integer active) {
+    this.active = active;
+    return (A) this;
+  }
+  
+  public <K,V>A withAdditionalProperties(Map<String,Object> additionalProperties) {
+    if (additionalProperties == null) {
+      this.additionalProperties = null;
+    } else {
+      this.additionalProperties = new LinkedHashMap(additionalProperties);
+    }
+    return (A) this;
+  }
+  
+  public A withCompletedIndexes(String completedIndexes) {
+    this.completedIndexes = completedIndexes;
+    return (A) this;
+  }
+  
+  public A withCompletionTime(String completionTime) {
+    this.completionTime = completionTime;
+    return (A) this;
+  }
+  
+  public A withConditions(List<JobCondition> conditions) {
+    if (this.conditions != null) {
+      this._visitables.get("conditions").clear();
+    }
+    if (conditions != null) {
+        this.conditions = new ArrayList();
+        for (JobCondition item : conditions) {
+          this.addToConditions(item);
+        }
+    } else {
+      this.conditions = null;
+    }
+    return (A) this;
+  }
+  
+  public A withConditions(JobCondition... conditions) {
+    if (this.conditions != null) {
+        this.conditions.clear();
+        _visitables.remove("conditions");
+    }
+    if (conditions != null) {
+      for (JobCondition item : conditions) {
+        this.addToConditions(item);
+      }
+    }
+    return (A) this;
+  }
+  
+  public A withFailed(Integer failed) {
+    this.failed = failed;
+    return (A) this;
+  }
+  
+  public A withFailedIndexes(String failedIndexes) {
+    this.failedIndexes = failedIndexes;
+    return (A) this;
+  }
+  
+  public UncountedTerminatedPodsNested<A> withNewUncountedTerminatedPods() {
+    return new UncountedTerminatedPodsNested(null);
+  }
+  
+  public UncountedTerminatedPodsNested<A> withNewUncountedTerminatedPodsLike(UncountedTerminatedPods item) {
+    return new UncountedTerminatedPodsNested(item);
+  }
+  
+  public A withReady(Integer ready) {
+    this.ready = ready;
+    return (A) this;
+  }
+  
+  public A withStartTime(String startTime) {
+    this.startTime = startTime;
+    return (A) this;
+  }
+  
+  public A withSucceeded(Integer succeeded) {
+    this.succeeded = succeeded;
+    return (A) this;
+  }
+  
+  public A withTerminating(Integer terminating) {
+    this.terminating = terminating;
+    return (A) this;
+  }
+  
+  public A withUncountedTerminatedPods(UncountedTerminatedPods uncountedTerminatedPods) {
+    this._visitables.remove("uncountedTerminatedPods");
+    if (uncountedTerminatedPods != null) {
+        this.uncountedTerminatedPods = new UncountedTerminatedPodsBuilder(uncountedTerminatedPods);
+        this._visitables.get("uncountedTerminatedPods").add(this.uncountedTerminatedPods);
+    } else {
+        this.uncountedTerminatedPods = null;
+        this._visitables.get("uncountedTerminatedPods").remove(this.uncountedTerminatedPods);
+    }
+    return (A) this;
+  }
+  public class ConditionsNested<N> extends JobConditionFluent<ConditionsNested<N>> implements Nested<N>{
+  
+    JobConditionBuilder builder;
+    int index;
+  
+    ConditionsNested(int index,JobCondition item) {
+      this.index = index;
+      this.builder = new JobConditionBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) JobStatusFluent.this.setToConditions(index, builder.build());
+    }
+    
+    public N endCondition() {
+      return and();
+    }
+    
+  }
+  public class UncountedTerminatedPodsNested<N> extends UncountedTerminatedPodsFluent<UncountedTerminatedPodsNested<N>> implements Nested<N>{
+  
+    UncountedTerminatedPodsBuilder builder;
+  
+    UncountedTerminatedPodsNested(UncountedTerminatedPods item) {
+      this.builder = new UncountedTerminatedPodsBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) JobStatusFluent.this.withUncountedTerminatedPods(builder.build());
+    }
+    
+    public N endUncountedTerminatedPods() {
+      return and();
+    }
+    
+  }
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/JobTemplateSpecBuilder.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/JobTemplateSpecBuilder.java
@@ -1,0 +1,33 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
+import java.lang.Object;
+public class JobTemplateSpecBuilder extends JobTemplateSpecFluent<JobTemplateSpecBuilder> implements VisitableBuilder<JobTemplateSpec,JobTemplateSpecBuilder>{
+
+  JobTemplateSpecFluent<?> fluent;
+
+  public JobTemplateSpecBuilder() {
+    this(new JobTemplateSpec());
+  }
+  
+  public JobTemplateSpecBuilder(JobTemplateSpecFluent<?> fluent) {
+    this(fluent, new JobTemplateSpec());
+  }
+  
+  public JobTemplateSpecBuilder(JobTemplateSpec instance) {
+    this.fluent = this;
+    this.copyInstance(instance);
+  }
+  
+  public JobTemplateSpecBuilder(JobTemplateSpecFluent<?> fluent,JobTemplateSpec instance) {
+    this.fluent = fluent;
+    fluent.copyInstance(instance);
+  }
+
+  public JobTemplateSpec build() {
+    JobTemplateSpec buildable = new JobTemplateSpec(fluent.buildMetadata(), fluent.buildSpec());
+    buildable.setAdditionalProperties(fluent.getAdditionalProperties());
+    return buildable;
+  }
+  
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/JobTemplateSpecFluent.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/JobTemplateSpecFluent.java
@@ -1,0 +1,265 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.BaseFluent;
+import io.fabric8.kubernetes.api.builder.Nested;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMetaFluent;
+import java.lang.Object;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.lang.SuppressWarnings;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Generated
+ */
+@SuppressWarnings("unchecked")
+public class JobTemplateSpecFluent<A extends io.fabric8.kubernetes.api.model.batch.v1.JobTemplateSpecFluent<A>> extends BaseFluent<A>{
+
+  private Map<String,Object> additionalProperties;
+  private ObjectMetaBuilder metadata;
+  private JobSpecBuilder spec;
+
+  public JobTemplateSpecFluent() {
+  }
+  
+  public JobTemplateSpecFluent(JobTemplateSpec instance) {
+    this.copyInstance(instance);
+  }
+
+  public A addToAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null && map != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (map != null) {
+      this.additionalProperties.putAll(map);
+    }
+    return (A) this;
+  }
+  
+  public A addToAdditionalProperties(String key,Object value) {
+    if (this.additionalProperties == null && key != null && value != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (key != null && value != null) {
+      this.additionalProperties.put(key, value);
+    }
+    return (A) this;
+  }
+  
+  public ObjectMeta buildMetadata() {
+    return this.metadata != null ? this.metadata.build() : null;
+  }
+  
+  public JobSpec buildSpec() {
+    return this.spec != null ? this.spec.build() : null;
+  }
+  
+  protected void copyInstance(JobTemplateSpec instance) {
+    instance = instance != null ? instance : new JobTemplateSpec();
+    if (instance != null) {
+        this.withMetadata(instance.getMetadata());
+        this.withSpec(instance.getSpec());
+        this.withAdditionalProperties(instance.getAdditionalProperties());
+    }
+  }
+  
+  public MetadataNested<A> editMetadata() {
+    return this.withNewMetadataLike(Optional.ofNullable(this.buildMetadata()).orElse(null));
+  }
+  
+  public MetadataNested<A> editOrNewMetadata() {
+    return this.withNewMetadataLike(Optional.ofNullable(this.buildMetadata()).orElse(new ObjectMetaBuilder().build()));
+  }
+  
+  public MetadataNested<A> editOrNewMetadataLike(ObjectMeta item) {
+    return this.withNewMetadataLike(Optional.ofNullable(this.buildMetadata()).orElse(item));
+  }
+  
+  public SpecNested<A> editOrNewSpec() {
+    return this.withNewSpecLike(Optional.ofNullable(this.buildSpec()).orElse(new JobSpecBuilder().build()));
+  }
+  
+  public SpecNested<A> editOrNewSpecLike(JobSpec item) {
+    return this.withNewSpecLike(Optional.ofNullable(this.buildSpec()).orElse(item));
+  }
+  
+  public SpecNested<A> editSpec() {
+    return this.withNewSpecLike(Optional.ofNullable(this.buildSpec()).orElse(null));
+  }
+  
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || this.getClass() != o.getClass()) {
+      return false;
+    }
+    if (!(super.equals(o))) {
+      return false;
+    }
+    JobTemplateSpecFluent that = (JobTemplateSpecFluent) o;
+    if (!(Objects.equals(metadata, that.metadata))) {
+      return false;
+    }
+    if (!(Objects.equals(spec, that.spec))) {
+      return false;
+    }
+    if (!(Objects.equals(additionalProperties, that.additionalProperties))) {
+      return false;
+    }
+    return true;
+  }
+  
+  public Map<String,Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
+  
+  public boolean hasAdditionalProperties() {
+    return this.additionalProperties != null;
+  }
+  
+  public boolean hasMetadata() {
+    return this.metadata != null;
+  }
+  
+  public boolean hasSpec() {
+    return this.spec != null;
+  }
+  
+  public int hashCode() {
+    return Objects.hash(metadata, spec, additionalProperties);
+  }
+  
+  public A removeFromAdditionalProperties(String key) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (key != null && this.additionalProperties != null) {
+      this.additionalProperties.remove(key);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (map != null) {
+      for (Object key : map.keySet()) {
+        if (this.additionalProperties != null) {
+          this.additionalProperties.remove(key);
+        }
+      }
+    }
+    return (A) this;
+  }
+  
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+    if (!(metadata == null)) {
+        sb.append("metadata:");
+        sb.append(metadata);
+        sb.append(",");
+    }
+    if (!(spec == null)) {
+        sb.append("spec:");
+        sb.append(spec);
+        sb.append(",");
+    }
+    if (!(additionalProperties == null) && !(additionalProperties.isEmpty())) {
+        sb.append("additionalProperties:");
+        sb.append(additionalProperties);
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+  
+  public <K,V>A withAdditionalProperties(Map<String,Object> additionalProperties) {
+    if (additionalProperties == null) {
+      this.additionalProperties = null;
+    } else {
+      this.additionalProperties = new LinkedHashMap(additionalProperties);
+    }
+    return (A) this;
+  }
+  
+  public A withMetadata(ObjectMeta metadata) {
+    this._visitables.remove("metadata");
+    if (metadata != null) {
+        this.metadata = new ObjectMetaBuilder(metadata);
+        this._visitables.get("metadata").add(this.metadata);
+    } else {
+        this.metadata = null;
+        this._visitables.get("metadata").remove(this.metadata);
+    }
+    return (A) this;
+  }
+  
+  public MetadataNested<A> withNewMetadata() {
+    return new MetadataNested(null);
+  }
+  
+  public MetadataNested<A> withNewMetadataLike(ObjectMeta item) {
+    return new MetadataNested(item);
+  }
+  
+  public SpecNested<A> withNewSpec() {
+    return new SpecNested(null);
+  }
+  
+  public SpecNested<A> withNewSpecLike(JobSpec item) {
+    return new SpecNested(item);
+  }
+  
+  public A withSpec(JobSpec spec) {
+    this._visitables.remove("spec");
+    if (spec != null) {
+        this.spec = new JobSpecBuilder(spec);
+        this._visitables.get("spec").add(this.spec);
+    } else {
+        this.spec = null;
+        this._visitables.get("spec").remove(this.spec);
+    }
+    return (A) this;
+  }
+  public class MetadataNested<N> extends ObjectMetaFluent<MetadataNested<N>> implements Nested<N>{
+  
+    ObjectMetaBuilder builder;
+  
+    MetadataNested(ObjectMeta item) {
+      this.builder = new ObjectMetaBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) JobTemplateSpecFluent.this.withMetadata(builder.build());
+    }
+    
+    public N endMetadata() {
+      return and();
+    }
+    
+  }
+  public class SpecNested<N> extends JobSpecFluent<SpecNested<N>> implements Nested<N>{
+  
+    JobSpecBuilder builder;
+  
+    SpecNested(JobSpec item) {
+      this.builder = new JobSpecBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) JobTemplateSpecFluent.this.withSpec(builder.build());
+    }
+    
+    public N endSpec() {
+      return and();
+    }
+    
+  }
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/PodFailurePolicyBuilder.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/PodFailurePolicyBuilder.java
@@ -1,0 +1,33 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
+import java.lang.Object;
+public class PodFailurePolicyBuilder extends PodFailurePolicyFluent<PodFailurePolicyBuilder> implements VisitableBuilder<PodFailurePolicy,PodFailurePolicyBuilder>{
+
+  PodFailurePolicyFluent<?> fluent;
+
+  public PodFailurePolicyBuilder() {
+    this(new PodFailurePolicy());
+  }
+  
+  public PodFailurePolicyBuilder(PodFailurePolicyFluent<?> fluent) {
+    this(fluent, new PodFailurePolicy());
+  }
+  
+  public PodFailurePolicyBuilder(PodFailurePolicy instance) {
+    this.fluent = this;
+    this.copyInstance(instance);
+  }
+  
+  public PodFailurePolicyBuilder(PodFailurePolicyFluent<?> fluent,PodFailurePolicy instance) {
+    this.fluent = fluent;
+    fluent.copyInstance(instance);
+  }
+
+  public PodFailurePolicy build() {
+    PodFailurePolicy buildable = new PodFailurePolicy(fluent.buildRules());
+    buildable.setAdditionalProperties(fluent.getAdditionalProperties());
+    return buildable;
+  }
+  
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/PodFailurePolicyFluent.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/PodFailurePolicyFluent.java
@@ -1,0 +1,370 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.BaseFluent;
+import io.fabric8.kubernetes.api.builder.Nested;
+import java.lang.Object;
+import java.lang.RuntimeException;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.lang.SuppressWarnings;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * Generated
+ */
+@SuppressWarnings("unchecked")
+public class PodFailurePolicyFluent<A extends io.fabric8.kubernetes.api.model.batch.v1.PodFailurePolicyFluent<A>> extends BaseFluent<A>{
+
+  private Map<String,Object> additionalProperties;
+  private ArrayList<PodFailurePolicyRuleBuilder> rules = new ArrayList<PodFailurePolicyRuleBuilder>();
+
+  public PodFailurePolicyFluent() {
+  }
+  
+  public PodFailurePolicyFluent(PodFailurePolicy instance) {
+    this.copyInstance(instance);
+  }
+
+  public A addAllToRules(Collection<PodFailurePolicyRule> items) {
+    if (this.rules == null) {
+      this.rules = new ArrayList();
+    }
+    for (PodFailurePolicyRule item : items) {
+        PodFailurePolicyRuleBuilder builder = new PodFailurePolicyRuleBuilder(item);
+        _visitables.get("rules").add(builder);
+        this.rules.add(builder);
+    }
+    return (A) this;
+  }
+  
+  public RulesNested<A> addNewRule() {
+    return new RulesNested(-1, null);
+  }
+  
+  public RulesNested<A> addNewRuleLike(PodFailurePolicyRule item) {
+    return new RulesNested(-1, item);
+  }
+  
+  public A addToAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null && map != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (map != null) {
+      this.additionalProperties.putAll(map);
+    }
+    return (A) this;
+  }
+  
+  public A addToAdditionalProperties(String key,Object value) {
+    if (this.additionalProperties == null && key != null && value != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (key != null && value != null) {
+      this.additionalProperties.put(key, value);
+    }
+    return (A) this;
+  }
+  
+  public A addToRules(PodFailurePolicyRule... items) {
+    if (this.rules == null) {
+      this.rules = new ArrayList();
+    }
+    for (PodFailurePolicyRule item : items) {
+        PodFailurePolicyRuleBuilder builder = new PodFailurePolicyRuleBuilder(item);
+        _visitables.get("rules").add(builder);
+        this.rules.add(builder);
+    }
+    return (A) this;
+  }
+  
+  public A addToRules(int index,PodFailurePolicyRule item) {
+    if (this.rules == null) {
+      this.rules = new ArrayList();
+    }
+    PodFailurePolicyRuleBuilder builder = new PodFailurePolicyRuleBuilder(item);
+    if (index < 0 || index >= rules.size()) {
+        _visitables.get("rules").add(builder);
+        rules.add(builder);
+    } else {
+        _visitables.get("rules").add(builder);
+        rules.add(index, builder);
+    }
+    return (A) this;
+  }
+  
+  public PodFailurePolicyRule buildFirstRule() {
+    return this.rules.get(0).build();
+  }
+  
+  public PodFailurePolicyRule buildLastRule() {
+    return this.rules.get(rules.size() - 1).build();
+  }
+  
+  public PodFailurePolicyRule buildMatchingRule(Predicate<PodFailurePolicyRuleBuilder> predicate) {
+      for (PodFailurePolicyRuleBuilder item : rules) {
+        if (predicate.test(item)) {
+          return item.build();
+        }
+      }
+      return null;
+  }
+  
+  public PodFailurePolicyRule buildRule(int index) {
+    return this.rules.get(index).build();
+  }
+  
+  public List<PodFailurePolicyRule> buildRules() {
+    return this.rules != null ? build(rules) : null;
+  }
+  
+  protected void copyInstance(PodFailurePolicy instance) {
+    instance = instance != null ? instance : new PodFailurePolicy();
+    if (instance != null) {
+        this.withRules(instance.getRules());
+        this.withAdditionalProperties(instance.getAdditionalProperties());
+    }
+  }
+  
+  public RulesNested<A> editFirstRule() {
+    if (rules.size() == 0) {
+      throw new RuntimeException(String.format("Can't edit first %s. The list is empty.", "rules"));
+    }
+    return this.setNewRuleLike(0, this.buildRule(0));
+  }
+  
+  public RulesNested<A> editLastRule() {
+    int index = rules.size() - 1;
+    if (index < 0) {
+      throw new RuntimeException(String.format("Can't edit last %s. The list is empty.", "rules"));
+    }
+    return this.setNewRuleLike(index, this.buildRule(index));
+  }
+  
+  public RulesNested<A> editMatchingRule(Predicate<PodFailurePolicyRuleBuilder> predicate) {
+    int index = -1;
+    for (int i = 0;i < rules.size();i++) {
+      if (predicate.test(rules.get(i))) {
+          index = i;
+          break;
+      }
+    }
+    if (index < 0) {
+      throw new RuntimeException(String.format("Can't edit matching %s. No match found.", "rules"));
+    }
+    return this.setNewRuleLike(index, this.buildRule(index));
+  }
+  
+  public RulesNested<A> editRule(int index) {
+    if (rules.size() <= index) {
+      throw new RuntimeException(String.format("Can't edit %s. Index exceeds size.", "rules"));
+    }
+    return this.setNewRuleLike(index, this.buildRule(index));
+  }
+  
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || this.getClass() != o.getClass()) {
+      return false;
+    }
+    if (!(super.equals(o))) {
+      return false;
+    }
+    PodFailurePolicyFluent that = (PodFailurePolicyFluent) o;
+    if (!(Objects.equals(rules, that.rules))) {
+      return false;
+    }
+    if (!(Objects.equals(additionalProperties, that.additionalProperties))) {
+      return false;
+    }
+    return true;
+  }
+  
+  public Map<String,Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
+  
+  public boolean hasAdditionalProperties() {
+    return this.additionalProperties != null;
+  }
+  
+  public boolean hasMatchingRule(Predicate<PodFailurePolicyRuleBuilder> predicate) {
+      for (PodFailurePolicyRuleBuilder item : rules) {
+        if (predicate.test(item)) {
+          return true;
+        }
+      }
+      return false;
+  }
+  
+  public boolean hasRules() {
+    return this.rules != null && !(this.rules.isEmpty());
+  }
+  
+  public int hashCode() {
+    return Objects.hash(rules, additionalProperties);
+  }
+  
+  public A removeAllFromRules(Collection<PodFailurePolicyRule> items) {
+    if (this.rules == null) {
+      return (A) this;
+    }
+    for (PodFailurePolicyRule item : items) {
+        PodFailurePolicyRuleBuilder builder = new PodFailurePolicyRuleBuilder(item);
+        _visitables.get("rules").remove(builder);
+        this.rules.remove(builder);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(String key) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (key != null && this.additionalProperties != null) {
+      this.additionalProperties.remove(key);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (map != null) {
+      for (Object key : map.keySet()) {
+        if (this.additionalProperties != null) {
+          this.additionalProperties.remove(key);
+        }
+      }
+    }
+    return (A) this;
+  }
+  
+  public A removeFromRules(PodFailurePolicyRule... items) {
+    if (this.rules == null) {
+      return (A) this;
+    }
+    for (PodFailurePolicyRule item : items) {
+        PodFailurePolicyRuleBuilder builder = new PodFailurePolicyRuleBuilder(item);
+        _visitables.get("rules").remove(builder);
+        this.rules.remove(builder);
+    }
+    return (A) this;
+  }
+  
+  public A removeMatchingFromRules(Predicate<PodFailurePolicyRuleBuilder> predicate) {
+    if (rules == null) {
+      return (A) this;
+    }
+    Iterator<PodFailurePolicyRuleBuilder> each = rules.iterator();
+    List visitables = _visitables.get("rules");
+    while (each.hasNext()) {
+        PodFailurePolicyRuleBuilder builder = each.next();
+        if (predicate.test(builder)) {
+            visitables.remove(builder);
+            each.remove();
+        }
+    }
+    return (A) this;
+  }
+  
+  public RulesNested<A> setNewRuleLike(int index,PodFailurePolicyRule item) {
+    return new RulesNested(index, item);
+  }
+  
+  public A setToRules(int index,PodFailurePolicyRule item) {
+    if (this.rules == null) {
+      this.rules = new ArrayList();
+    }
+    PodFailurePolicyRuleBuilder builder = new PodFailurePolicyRuleBuilder(item);
+    if (index < 0 || index >= rules.size()) {
+        _visitables.get("rules").add(builder);
+        rules.add(builder);
+    } else {
+        _visitables.get("rules").add(builder);
+        rules.set(index, builder);
+    }
+    return (A) this;
+  }
+  
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+    if (!(rules == null) && !(rules.isEmpty())) {
+        sb.append("rules:");
+        sb.append(rules);
+        sb.append(",");
+    }
+    if (!(additionalProperties == null) && !(additionalProperties.isEmpty())) {
+        sb.append("additionalProperties:");
+        sb.append(additionalProperties);
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+  
+  public <K,V>A withAdditionalProperties(Map<String,Object> additionalProperties) {
+    if (additionalProperties == null) {
+      this.additionalProperties = null;
+    } else {
+      this.additionalProperties = new LinkedHashMap(additionalProperties);
+    }
+    return (A) this;
+  }
+  
+  public A withRules(List<PodFailurePolicyRule> rules) {
+    if (this.rules != null) {
+      this._visitables.get("rules").clear();
+    }
+    if (rules != null) {
+        this.rules = new ArrayList();
+        for (PodFailurePolicyRule item : rules) {
+          this.addToRules(item);
+        }
+    } else {
+      this.rules = null;
+    }
+    return (A) this;
+  }
+  
+  public A withRules(PodFailurePolicyRule... rules) {
+    if (this.rules != null) {
+        this.rules.clear();
+        _visitables.remove("rules");
+    }
+    if (rules != null) {
+      for (PodFailurePolicyRule item : rules) {
+        this.addToRules(item);
+      }
+    }
+    return (A) this;
+  }
+  public class RulesNested<N> extends PodFailurePolicyRuleFluent<RulesNested<N>> implements Nested<N>{
+  
+    PodFailurePolicyRuleBuilder builder;
+    int index;
+  
+    RulesNested(int index,PodFailurePolicyRule item) {
+      this.index = index;
+      this.builder = new PodFailurePolicyRuleBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) PodFailurePolicyFluent.this.setToRules(index, builder.build());
+    }
+    
+    public N endRule() {
+      return and();
+    }
+    
+  }
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/PodFailurePolicyOnExitCodesRequirementBuilder.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/PodFailurePolicyOnExitCodesRequirementBuilder.java
@@ -1,0 +1,33 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
+import java.lang.Object;
+public class PodFailurePolicyOnExitCodesRequirementBuilder extends PodFailurePolicyOnExitCodesRequirementFluent<PodFailurePolicyOnExitCodesRequirementBuilder> implements VisitableBuilder<PodFailurePolicyOnExitCodesRequirement,PodFailurePolicyOnExitCodesRequirementBuilder>{
+
+  PodFailurePolicyOnExitCodesRequirementFluent<?> fluent;
+
+  public PodFailurePolicyOnExitCodesRequirementBuilder() {
+    this(new PodFailurePolicyOnExitCodesRequirement());
+  }
+  
+  public PodFailurePolicyOnExitCodesRequirementBuilder(PodFailurePolicyOnExitCodesRequirementFluent<?> fluent) {
+    this(fluent, new PodFailurePolicyOnExitCodesRequirement());
+  }
+  
+  public PodFailurePolicyOnExitCodesRequirementBuilder(PodFailurePolicyOnExitCodesRequirement instance) {
+    this.fluent = this;
+    this.copyInstance(instance);
+  }
+  
+  public PodFailurePolicyOnExitCodesRequirementBuilder(PodFailurePolicyOnExitCodesRequirementFluent<?> fluent,PodFailurePolicyOnExitCodesRequirement instance) {
+    this.fluent = fluent;
+    fluent.copyInstance(instance);
+  }
+
+  public PodFailurePolicyOnExitCodesRequirement build() {
+    PodFailurePolicyOnExitCodesRequirement buildable = new PodFailurePolicyOnExitCodesRequirement(fluent.getContainerName(), fluent.getOperator(), fluent.getValues());
+    buildable.setAdditionalProperties(fluent.getAdditionalProperties());
+    return buildable;
+  }
+  
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/PodFailurePolicyOnExitCodesRequirementFluent.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/PodFailurePolicyOnExitCodesRequirementFluent.java
@@ -1,0 +1,307 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.BaseFluent;
+import java.lang.Integer;
+import java.lang.Object;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.lang.SuppressWarnings;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * Generated
+ */
+@SuppressWarnings("unchecked")
+public class PodFailurePolicyOnExitCodesRequirementFluent<A extends io.fabric8.kubernetes.api.model.batch.v1.PodFailurePolicyOnExitCodesRequirementFluent<A>> extends BaseFluent<A>{
+
+  private Map<String,Object> additionalProperties;
+  private String containerName;
+  private String operator;
+  private List<Integer> values = new ArrayList<Integer>();
+
+  public PodFailurePolicyOnExitCodesRequirementFluent() {
+  }
+  
+  public PodFailurePolicyOnExitCodesRequirementFluent(PodFailurePolicyOnExitCodesRequirement instance) {
+    this.copyInstance(instance);
+  }
+
+  public A addAllToValues(Collection<Integer> items) {
+    if (this.values == null) {
+      this.values = new ArrayList();
+    }
+    for (Integer item : items) {
+      this.values.add(item);
+    }
+    return (A) this;
+  }
+  
+  public A addToAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null && map != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (map != null) {
+      this.additionalProperties.putAll(map);
+    }
+    return (A) this;
+  }
+  
+  public A addToAdditionalProperties(String key,Object value) {
+    if (this.additionalProperties == null && key != null && value != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (key != null && value != null) {
+      this.additionalProperties.put(key, value);
+    }
+    return (A) this;
+  }
+  
+  public A addToValues(Integer... items) {
+    if (this.values == null) {
+      this.values = new ArrayList();
+    }
+    for (Integer item : items) {
+      this.values.add(item);
+    }
+    return (A) this;
+  }
+  
+  public A addToValues(int index,Integer item) {
+    if (this.values == null) {
+      this.values = new ArrayList();
+    }
+    this.values.add(index, item);
+    return (A) this;
+  }
+  
+  protected void copyInstance(PodFailurePolicyOnExitCodesRequirement instance) {
+    instance = instance != null ? instance : new PodFailurePolicyOnExitCodesRequirement();
+    if (instance != null) {
+        this.withContainerName(instance.getContainerName());
+        this.withOperator(instance.getOperator());
+        this.withValues(instance.getValues());
+        this.withAdditionalProperties(instance.getAdditionalProperties());
+    }
+  }
+  
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || this.getClass() != o.getClass()) {
+      return false;
+    }
+    if (!(super.equals(o))) {
+      return false;
+    }
+    PodFailurePolicyOnExitCodesRequirementFluent that = (PodFailurePolicyOnExitCodesRequirementFluent) o;
+    if (!(Objects.equals(containerName, that.containerName))) {
+      return false;
+    }
+    if (!(Objects.equals(operator, that.operator))) {
+      return false;
+    }
+    if (!(Objects.equals(values, that.values))) {
+      return false;
+    }
+    if (!(Objects.equals(additionalProperties, that.additionalProperties))) {
+      return false;
+    }
+    return true;
+  }
+  
+  public Map<String,Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
+  
+  public String getContainerName() {
+    return this.containerName;
+  }
+  
+  public Integer getFirstValue() {
+    return this.values.get(0);
+  }
+  
+  public Integer getLastValue() {
+    return this.values.get(values.size() - 1);
+  }
+  
+  public Integer getMatchingValue(Predicate<Integer> predicate) {
+      for (Integer item : values) {
+        if (predicate.test(item)) {
+          return item;
+        }
+      }
+      return null;
+  }
+  
+  public String getOperator() {
+    return this.operator;
+  }
+  
+  public Integer getValue(int index) {
+    return this.values.get(index);
+  }
+  
+  public List<Integer> getValues() {
+    return this.values;
+  }
+  
+  public boolean hasAdditionalProperties() {
+    return this.additionalProperties != null;
+  }
+  
+  public boolean hasContainerName() {
+    return this.containerName != null;
+  }
+  
+  public boolean hasMatchingValue(Predicate<Integer> predicate) {
+      for (Integer item : values) {
+        if (predicate.test(item)) {
+          return true;
+        }
+      }
+      return false;
+  }
+  
+  public boolean hasOperator() {
+    return this.operator != null;
+  }
+  
+  public boolean hasValues() {
+    return this.values != null && !(this.values.isEmpty());
+  }
+  
+  public int hashCode() {
+    return Objects.hash(containerName, operator, values, additionalProperties);
+  }
+  
+  public A removeAllFromValues(Collection<Integer> items) {
+    if (this.values == null) {
+      return (A) this;
+    }
+    for (Integer item : items) {
+      this.values.remove(item);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(String key) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (key != null && this.additionalProperties != null) {
+      this.additionalProperties.remove(key);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (map != null) {
+      for (Object key : map.keySet()) {
+        if (this.additionalProperties != null) {
+          this.additionalProperties.remove(key);
+        }
+      }
+    }
+    return (A) this;
+  }
+  
+  public A removeFromValues(Integer... items) {
+    if (this.values == null) {
+      return (A) this;
+    }
+    for (Integer item : items) {
+      this.values.remove(item);
+    }
+    return (A) this;
+  }
+  
+  public A setToValues(int index,Integer item) {
+    if (this.values == null) {
+      this.values = new ArrayList();
+    }
+    this.values.set(index, item);
+    return (A) this;
+  }
+  
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+    if (!(containerName == null)) {
+        sb.append("containerName:");
+        sb.append(containerName);
+        sb.append(",");
+    }
+    if (!(operator == null)) {
+        sb.append("operator:");
+        sb.append(operator);
+        sb.append(",");
+    }
+    if (!(values == null) && !(values.isEmpty())) {
+        sb.append("values:");
+        sb.append(values);
+        sb.append(",");
+    }
+    if (!(additionalProperties == null) && !(additionalProperties.isEmpty())) {
+        sb.append("additionalProperties:");
+        sb.append(additionalProperties);
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+  
+  public <K,V>A withAdditionalProperties(Map<String,Object> additionalProperties) {
+    if (additionalProperties == null) {
+      this.additionalProperties = null;
+    } else {
+      this.additionalProperties = new LinkedHashMap(additionalProperties);
+    }
+    return (A) this;
+  }
+  
+  public A withContainerName(String containerName) {
+    this.containerName = containerName;
+    return (A) this;
+  }
+  
+  public A withOperator(String operator) {
+    this.operator = operator;
+    return (A) this;
+  }
+  
+  public A withValues(List<Integer> values) {
+    if (values != null) {
+        this.values = new ArrayList();
+        for (Integer item : values) {
+          this.addToValues(item);
+        }
+    } else {
+      this.values = null;
+    }
+    return (A) this;
+  }
+  
+  public A withValues(Integer... values) {
+    if (this.values != null) {
+        this.values.clear();
+        _visitables.remove("values");
+    }
+    if (values != null) {
+      for (Integer item : values) {
+        this.addToValues(item);
+      }
+    }
+    return (A) this;
+  }
+  
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/PodFailurePolicyOnPodConditionsPatternBuilder.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/PodFailurePolicyOnPodConditionsPatternBuilder.java
@@ -1,0 +1,33 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
+import java.lang.Object;
+public class PodFailurePolicyOnPodConditionsPatternBuilder extends PodFailurePolicyOnPodConditionsPatternFluent<PodFailurePolicyOnPodConditionsPatternBuilder> implements VisitableBuilder<PodFailurePolicyOnPodConditionsPattern,PodFailurePolicyOnPodConditionsPatternBuilder>{
+
+  PodFailurePolicyOnPodConditionsPatternFluent<?> fluent;
+
+  public PodFailurePolicyOnPodConditionsPatternBuilder() {
+    this(new PodFailurePolicyOnPodConditionsPattern());
+  }
+  
+  public PodFailurePolicyOnPodConditionsPatternBuilder(PodFailurePolicyOnPodConditionsPatternFluent<?> fluent) {
+    this(fluent, new PodFailurePolicyOnPodConditionsPattern());
+  }
+  
+  public PodFailurePolicyOnPodConditionsPatternBuilder(PodFailurePolicyOnPodConditionsPattern instance) {
+    this.fluent = this;
+    this.copyInstance(instance);
+  }
+  
+  public PodFailurePolicyOnPodConditionsPatternBuilder(PodFailurePolicyOnPodConditionsPatternFluent<?> fluent,PodFailurePolicyOnPodConditionsPattern instance) {
+    this.fluent = fluent;
+    fluent.copyInstance(instance);
+  }
+
+  public PodFailurePolicyOnPodConditionsPattern build() {
+    PodFailurePolicyOnPodConditionsPattern buildable = new PodFailurePolicyOnPodConditionsPattern(fluent.getStatus(), fluent.getType());
+    buildable.setAdditionalProperties(fluent.getAdditionalProperties());
+    return buildable;
+  }
+  
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/PodFailurePolicyOnPodConditionsPatternFluent.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/PodFailurePolicyOnPodConditionsPatternFluent.java
@@ -1,0 +1,173 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.BaseFluent;
+import java.lang.Object;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.lang.SuppressWarnings;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Generated
+ */
+@SuppressWarnings("unchecked")
+public class PodFailurePolicyOnPodConditionsPatternFluent<A extends io.fabric8.kubernetes.api.model.batch.v1.PodFailurePolicyOnPodConditionsPatternFluent<A>> extends BaseFluent<A>{
+
+  private Map<String,Object> additionalProperties;
+  private String status;
+  private String type;
+
+  public PodFailurePolicyOnPodConditionsPatternFluent() {
+  }
+  
+  public PodFailurePolicyOnPodConditionsPatternFluent(PodFailurePolicyOnPodConditionsPattern instance) {
+    this.copyInstance(instance);
+  }
+
+  public A addToAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null && map != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (map != null) {
+      this.additionalProperties.putAll(map);
+    }
+    return (A) this;
+  }
+  
+  public A addToAdditionalProperties(String key,Object value) {
+    if (this.additionalProperties == null && key != null && value != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (key != null && value != null) {
+      this.additionalProperties.put(key, value);
+    }
+    return (A) this;
+  }
+  
+  protected void copyInstance(PodFailurePolicyOnPodConditionsPattern instance) {
+    instance = instance != null ? instance : new PodFailurePolicyOnPodConditionsPattern();
+    if (instance != null) {
+        this.withStatus(instance.getStatus());
+        this.withType(instance.getType());
+        this.withAdditionalProperties(instance.getAdditionalProperties());
+    }
+  }
+  
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || this.getClass() != o.getClass()) {
+      return false;
+    }
+    if (!(super.equals(o))) {
+      return false;
+    }
+    PodFailurePolicyOnPodConditionsPatternFluent that = (PodFailurePolicyOnPodConditionsPatternFluent) o;
+    if (!(Objects.equals(status, that.status))) {
+      return false;
+    }
+    if (!(Objects.equals(type, that.type))) {
+      return false;
+    }
+    if (!(Objects.equals(additionalProperties, that.additionalProperties))) {
+      return false;
+    }
+    return true;
+  }
+  
+  public Map<String,Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
+  
+  public String getStatus() {
+    return this.status;
+  }
+  
+  public String getType() {
+    return this.type;
+  }
+  
+  public boolean hasAdditionalProperties() {
+    return this.additionalProperties != null;
+  }
+  
+  public boolean hasStatus() {
+    return this.status != null;
+  }
+  
+  public boolean hasType() {
+    return this.type != null;
+  }
+  
+  public int hashCode() {
+    return Objects.hash(status, type, additionalProperties);
+  }
+  
+  public A removeFromAdditionalProperties(String key) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (key != null && this.additionalProperties != null) {
+      this.additionalProperties.remove(key);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (map != null) {
+      for (Object key : map.keySet()) {
+        if (this.additionalProperties != null) {
+          this.additionalProperties.remove(key);
+        }
+      }
+    }
+    return (A) this;
+  }
+  
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+    if (!(status == null)) {
+        sb.append("status:");
+        sb.append(status);
+        sb.append(",");
+    }
+    if (!(type == null)) {
+        sb.append("type:");
+        sb.append(type);
+        sb.append(",");
+    }
+    if (!(additionalProperties == null) && !(additionalProperties.isEmpty())) {
+        sb.append("additionalProperties:");
+        sb.append(additionalProperties);
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+  
+  public <K,V>A withAdditionalProperties(Map<String,Object> additionalProperties) {
+    if (additionalProperties == null) {
+      this.additionalProperties = null;
+    } else {
+      this.additionalProperties = new LinkedHashMap(additionalProperties);
+    }
+    return (A) this;
+  }
+  
+  public A withStatus(String status) {
+    this.status = status;
+    return (A) this;
+  }
+  
+  public A withType(String type) {
+    this.type = type;
+    return (A) this;
+  }
+  
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/PodFailurePolicyRuleBuilder.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/PodFailurePolicyRuleBuilder.java
@@ -1,0 +1,33 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
+import java.lang.Object;
+public class PodFailurePolicyRuleBuilder extends PodFailurePolicyRuleFluent<PodFailurePolicyRuleBuilder> implements VisitableBuilder<PodFailurePolicyRule,PodFailurePolicyRuleBuilder>{
+
+  PodFailurePolicyRuleFluent<?> fluent;
+
+  public PodFailurePolicyRuleBuilder() {
+    this(new PodFailurePolicyRule());
+  }
+  
+  public PodFailurePolicyRuleBuilder(PodFailurePolicyRuleFluent<?> fluent) {
+    this(fluent, new PodFailurePolicyRule());
+  }
+  
+  public PodFailurePolicyRuleBuilder(PodFailurePolicyRule instance) {
+    this.fluent = this;
+    this.copyInstance(instance);
+  }
+  
+  public PodFailurePolicyRuleBuilder(PodFailurePolicyRuleFluent<?> fluent,PodFailurePolicyRule instance) {
+    this.fluent = fluent;
+    fluent.copyInstance(instance);
+  }
+
+  public PodFailurePolicyRule build() {
+    PodFailurePolicyRule buildable = new PodFailurePolicyRule(fluent.getAction(), fluent.buildOnExitCodes(), fluent.buildOnPodConditions());
+    buildable.setAdditionalProperties(fluent.getAdditionalProperties());
+    return buildable;
+  }
+  
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/PodFailurePolicyRuleFluent.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/PodFailurePolicyRuleFluent.java
@@ -1,0 +1,465 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.BaseFluent;
+import io.fabric8.kubernetes.api.builder.Nested;
+import java.lang.Object;
+import java.lang.RuntimeException;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.lang.SuppressWarnings;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+/**
+ * Generated
+ */
+@SuppressWarnings("unchecked")
+public class PodFailurePolicyRuleFluent<A extends io.fabric8.kubernetes.api.model.batch.v1.PodFailurePolicyRuleFluent<A>> extends BaseFluent<A>{
+
+  private String action;
+  private Map<String,Object> additionalProperties;
+  private PodFailurePolicyOnExitCodesRequirementBuilder onExitCodes;
+  private ArrayList<PodFailurePolicyOnPodConditionsPatternBuilder> onPodConditions = new ArrayList<PodFailurePolicyOnPodConditionsPatternBuilder>();
+
+  public PodFailurePolicyRuleFluent() {
+  }
+  
+  public PodFailurePolicyRuleFluent(PodFailurePolicyRule instance) {
+    this.copyInstance(instance);
+  }
+
+  public A addAllToOnPodConditions(Collection<PodFailurePolicyOnPodConditionsPattern> items) {
+    if (this.onPodConditions == null) {
+      this.onPodConditions = new ArrayList();
+    }
+    for (PodFailurePolicyOnPodConditionsPattern item : items) {
+        PodFailurePolicyOnPodConditionsPatternBuilder builder = new PodFailurePolicyOnPodConditionsPatternBuilder(item);
+        _visitables.get("onPodConditions").add(builder);
+        this.onPodConditions.add(builder);
+    }
+    return (A) this;
+  }
+  
+  public OnPodConditionsNested<A> addNewOnPodCondition() {
+    return new OnPodConditionsNested(-1, null);
+  }
+  
+  public A addNewOnPodCondition(String status,String type) {
+    return (A) this.addToOnPodConditions(new PodFailurePolicyOnPodConditionsPattern(status, type));
+  }
+  
+  public OnPodConditionsNested<A> addNewOnPodConditionLike(PodFailurePolicyOnPodConditionsPattern item) {
+    return new OnPodConditionsNested(-1, item);
+  }
+  
+  public A addToAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null && map != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (map != null) {
+      this.additionalProperties.putAll(map);
+    }
+    return (A) this;
+  }
+  
+  public A addToAdditionalProperties(String key,Object value) {
+    if (this.additionalProperties == null && key != null && value != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (key != null && value != null) {
+      this.additionalProperties.put(key, value);
+    }
+    return (A) this;
+  }
+  
+  public A addToOnPodConditions(PodFailurePolicyOnPodConditionsPattern... items) {
+    if (this.onPodConditions == null) {
+      this.onPodConditions = new ArrayList();
+    }
+    for (PodFailurePolicyOnPodConditionsPattern item : items) {
+        PodFailurePolicyOnPodConditionsPatternBuilder builder = new PodFailurePolicyOnPodConditionsPatternBuilder(item);
+        _visitables.get("onPodConditions").add(builder);
+        this.onPodConditions.add(builder);
+    }
+    return (A) this;
+  }
+  
+  public A addToOnPodConditions(int index,PodFailurePolicyOnPodConditionsPattern item) {
+    if (this.onPodConditions == null) {
+      this.onPodConditions = new ArrayList();
+    }
+    PodFailurePolicyOnPodConditionsPatternBuilder builder = new PodFailurePolicyOnPodConditionsPatternBuilder(item);
+    if (index < 0 || index >= onPodConditions.size()) {
+        _visitables.get("onPodConditions").add(builder);
+        onPodConditions.add(builder);
+    } else {
+        _visitables.get("onPodConditions").add(builder);
+        onPodConditions.add(index, builder);
+    }
+    return (A) this;
+  }
+  
+  public PodFailurePolicyOnPodConditionsPattern buildFirstOnPodCondition() {
+    return this.onPodConditions.get(0).build();
+  }
+  
+  public PodFailurePolicyOnPodConditionsPattern buildLastOnPodCondition() {
+    return this.onPodConditions.get(onPodConditions.size() - 1).build();
+  }
+  
+  public PodFailurePolicyOnPodConditionsPattern buildMatchingOnPodCondition(Predicate<PodFailurePolicyOnPodConditionsPatternBuilder> predicate) {
+      for (PodFailurePolicyOnPodConditionsPatternBuilder item : onPodConditions) {
+        if (predicate.test(item)) {
+          return item.build();
+        }
+      }
+      return null;
+  }
+  
+  public PodFailurePolicyOnExitCodesRequirement buildOnExitCodes() {
+    return this.onExitCodes != null ? this.onExitCodes.build() : null;
+  }
+  
+  public PodFailurePolicyOnPodConditionsPattern buildOnPodCondition(int index) {
+    return this.onPodConditions.get(index).build();
+  }
+  
+  public List<PodFailurePolicyOnPodConditionsPattern> buildOnPodConditions() {
+    return this.onPodConditions != null ? build(onPodConditions) : null;
+  }
+  
+  protected void copyInstance(PodFailurePolicyRule instance) {
+    instance = instance != null ? instance : new PodFailurePolicyRule();
+    if (instance != null) {
+        this.withAction(instance.getAction());
+        this.withOnExitCodes(instance.getOnExitCodes());
+        this.withOnPodConditions(instance.getOnPodConditions());
+        this.withAdditionalProperties(instance.getAdditionalProperties());
+    }
+  }
+  
+  public OnPodConditionsNested<A> editFirstOnPodCondition() {
+    if (onPodConditions.size() == 0) {
+      throw new RuntimeException(String.format("Can't edit first %s. The list is empty.", "onPodConditions"));
+    }
+    return this.setNewOnPodConditionLike(0, this.buildOnPodCondition(0));
+  }
+  
+  public OnPodConditionsNested<A> editLastOnPodCondition() {
+    int index = onPodConditions.size() - 1;
+    if (index < 0) {
+      throw new RuntimeException(String.format("Can't edit last %s. The list is empty.", "onPodConditions"));
+    }
+    return this.setNewOnPodConditionLike(index, this.buildOnPodCondition(index));
+  }
+  
+  public OnPodConditionsNested<A> editMatchingOnPodCondition(Predicate<PodFailurePolicyOnPodConditionsPatternBuilder> predicate) {
+    int index = -1;
+    for (int i = 0;i < onPodConditions.size();i++) {
+      if (predicate.test(onPodConditions.get(i))) {
+          index = i;
+          break;
+      }
+    }
+    if (index < 0) {
+      throw new RuntimeException(String.format("Can't edit matching %s. No match found.", "onPodConditions"));
+    }
+    return this.setNewOnPodConditionLike(index, this.buildOnPodCondition(index));
+  }
+  
+  public OnExitCodesNested<A> editOnExitCodes() {
+    return this.withNewOnExitCodesLike(Optional.ofNullable(this.buildOnExitCodes()).orElse(null));
+  }
+  
+  public OnPodConditionsNested<A> editOnPodCondition(int index) {
+    if (onPodConditions.size() <= index) {
+      throw new RuntimeException(String.format("Can't edit %s. Index exceeds size.", "onPodConditions"));
+    }
+    return this.setNewOnPodConditionLike(index, this.buildOnPodCondition(index));
+  }
+  
+  public OnExitCodesNested<A> editOrNewOnExitCodes() {
+    return this.withNewOnExitCodesLike(Optional.ofNullable(this.buildOnExitCodes()).orElse(new PodFailurePolicyOnExitCodesRequirementBuilder().build()));
+  }
+  
+  public OnExitCodesNested<A> editOrNewOnExitCodesLike(PodFailurePolicyOnExitCodesRequirement item) {
+    return this.withNewOnExitCodesLike(Optional.ofNullable(this.buildOnExitCodes()).orElse(item));
+  }
+  
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || this.getClass() != o.getClass()) {
+      return false;
+    }
+    if (!(super.equals(o))) {
+      return false;
+    }
+    PodFailurePolicyRuleFluent that = (PodFailurePolicyRuleFluent) o;
+    if (!(Objects.equals(action, that.action))) {
+      return false;
+    }
+    if (!(Objects.equals(onExitCodes, that.onExitCodes))) {
+      return false;
+    }
+    if (!(Objects.equals(onPodConditions, that.onPodConditions))) {
+      return false;
+    }
+    if (!(Objects.equals(additionalProperties, that.additionalProperties))) {
+      return false;
+    }
+    return true;
+  }
+  
+  public String getAction() {
+    return this.action;
+  }
+  
+  public Map<String,Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
+  
+  public boolean hasAction() {
+    return this.action != null;
+  }
+  
+  public boolean hasAdditionalProperties() {
+    return this.additionalProperties != null;
+  }
+  
+  public boolean hasMatchingOnPodCondition(Predicate<PodFailurePolicyOnPodConditionsPatternBuilder> predicate) {
+      for (PodFailurePolicyOnPodConditionsPatternBuilder item : onPodConditions) {
+        if (predicate.test(item)) {
+          return true;
+        }
+      }
+      return false;
+  }
+  
+  public boolean hasOnExitCodes() {
+    return this.onExitCodes != null;
+  }
+  
+  public boolean hasOnPodConditions() {
+    return this.onPodConditions != null && !(this.onPodConditions.isEmpty());
+  }
+  
+  public int hashCode() {
+    return Objects.hash(action, onExitCodes, onPodConditions, additionalProperties);
+  }
+  
+  public A removeAllFromOnPodConditions(Collection<PodFailurePolicyOnPodConditionsPattern> items) {
+    if (this.onPodConditions == null) {
+      return (A) this;
+    }
+    for (PodFailurePolicyOnPodConditionsPattern item : items) {
+        PodFailurePolicyOnPodConditionsPatternBuilder builder = new PodFailurePolicyOnPodConditionsPatternBuilder(item);
+        _visitables.get("onPodConditions").remove(builder);
+        this.onPodConditions.remove(builder);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(String key) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (key != null && this.additionalProperties != null) {
+      this.additionalProperties.remove(key);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (map != null) {
+      for (Object key : map.keySet()) {
+        if (this.additionalProperties != null) {
+          this.additionalProperties.remove(key);
+        }
+      }
+    }
+    return (A) this;
+  }
+  
+  public A removeFromOnPodConditions(PodFailurePolicyOnPodConditionsPattern... items) {
+    if (this.onPodConditions == null) {
+      return (A) this;
+    }
+    for (PodFailurePolicyOnPodConditionsPattern item : items) {
+        PodFailurePolicyOnPodConditionsPatternBuilder builder = new PodFailurePolicyOnPodConditionsPatternBuilder(item);
+        _visitables.get("onPodConditions").remove(builder);
+        this.onPodConditions.remove(builder);
+    }
+    return (A) this;
+  }
+  
+  public A removeMatchingFromOnPodConditions(Predicate<PodFailurePolicyOnPodConditionsPatternBuilder> predicate) {
+    if (onPodConditions == null) {
+      return (A) this;
+    }
+    Iterator<PodFailurePolicyOnPodConditionsPatternBuilder> each = onPodConditions.iterator();
+    List visitables = _visitables.get("onPodConditions");
+    while (each.hasNext()) {
+        PodFailurePolicyOnPodConditionsPatternBuilder builder = each.next();
+        if (predicate.test(builder)) {
+            visitables.remove(builder);
+            each.remove();
+        }
+    }
+    return (A) this;
+  }
+  
+  public OnPodConditionsNested<A> setNewOnPodConditionLike(int index,PodFailurePolicyOnPodConditionsPattern item) {
+    return new OnPodConditionsNested(index, item);
+  }
+  
+  public A setToOnPodConditions(int index,PodFailurePolicyOnPodConditionsPattern item) {
+    if (this.onPodConditions == null) {
+      this.onPodConditions = new ArrayList();
+    }
+    PodFailurePolicyOnPodConditionsPatternBuilder builder = new PodFailurePolicyOnPodConditionsPatternBuilder(item);
+    if (index < 0 || index >= onPodConditions.size()) {
+        _visitables.get("onPodConditions").add(builder);
+        onPodConditions.add(builder);
+    } else {
+        _visitables.get("onPodConditions").add(builder);
+        onPodConditions.set(index, builder);
+    }
+    return (A) this;
+  }
+  
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+    if (!(action == null)) {
+        sb.append("action:");
+        sb.append(action);
+        sb.append(",");
+    }
+    if (!(onExitCodes == null)) {
+        sb.append("onExitCodes:");
+        sb.append(onExitCodes);
+        sb.append(",");
+    }
+    if (!(onPodConditions == null) && !(onPodConditions.isEmpty())) {
+        sb.append("onPodConditions:");
+        sb.append(onPodConditions);
+        sb.append(",");
+    }
+    if (!(additionalProperties == null) && !(additionalProperties.isEmpty())) {
+        sb.append("additionalProperties:");
+        sb.append(additionalProperties);
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+  
+  public A withAction(String action) {
+    this.action = action;
+    return (A) this;
+  }
+  
+  public <K,V>A withAdditionalProperties(Map<String,Object> additionalProperties) {
+    if (additionalProperties == null) {
+      this.additionalProperties = null;
+    } else {
+      this.additionalProperties = new LinkedHashMap(additionalProperties);
+    }
+    return (A) this;
+  }
+  
+  public OnExitCodesNested<A> withNewOnExitCodes() {
+    return new OnExitCodesNested(null);
+  }
+  
+  public OnExitCodesNested<A> withNewOnExitCodesLike(PodFailurePolicyOnExitCodesRequirement item) {
+    return new OnExitCodesNested(item);
+  }
+  
+  public A withOnExitCodes(PodFailurePolicyOnExitCodesRequirement onExitCodes) {
+    this._visitables.remove("onExitCodes");
+    if (onExitCodes != null) {
+        this.onExitCodes = new PodFailurePolicyOnExitCodesRequirementBuilder(onExitCodes);
+        this._visitables.get("onExitCodes").add(this.onExitCodes);
+    } else {
+        this.onExitCodes = null;
+        this._visitables.get("onExitCodes").remove(this.onExitCodes);
+    }
+    return (A) this;
+  }
+  
+  public A withOnPodConditions(List<PodFailurePolicyOnPodConditionsPattern> onPodConditions) {
+    if (this.onPodConditions != null) {
+      this._visitables.get("onPodConditions").clear();
+    }
+    if (onPodConditions != null) {
+        this.onPodConditions = new ArrayList();
+        for (PodFailurePolicyOnPodConditionsPattern item : onPodConditions) {
+          this.addToOnPodConditions(item);
+        }
+    } else {
+      this.onPodConditions = null;
+    }
+    return (A) this;
+  }
+  
+  public A withOnPodConditions(PodFailurePolicyOnPodConditionsPattern... onPodConditions) {
+    if (this.onPodConditions != null) {
+        this.onPodConditions.clear();
+        _visitables.remove("onPodConditions");
+    }
+    if (onPodConditions != null) {
+      for (PodFailurePolicyOnPodConditionsPattern item : onPodConditions) {
+        this.addToOnPodConditions(item);
+      }
+    }
+    return (A) this;
+  }
+  public class OnExitCodesNested<N> extends PodFailurePolicyOnExitCodesRequirementFluent<OnExitCodesNested<N>> implements Nested<N>{
+  
+    PodFailurePolicyOnExitCodesRequirementBuilder builder;
+  
+    OnExitCodesNested(PodFailurePolicyOnExitCodesRequirement item) {
+      this.builder = new PodFailurePolicyOnExitCodesRequirementBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) PodFailurePolicyRuleFluent.this.withOnExitCodes(builder.build());
+    }
+    
+    public N endOnExitCodes() {
+      return and();
+    }
+    
+  }
+  public class OnPodConditionsNested<N> extends PodFailurePolicyOnPodConditionsPatternFluent<OnPodConditionsNested<N>> implements Nested<N>{
+  
+    PodFailurePolicyOnPodConditionsPatternBuilder builder;
+    int index;
+  
+    OnPodConditionsNested(int index,PodFailurePolicyOnPodConditionsPattern item) {
+      this.index = index;
+      this.builder = new PodFailurePolicyOnPodConditionsPatternBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) PodFailurePolicyRuleFluent.this.setToOnPodConditions(index, builder.build());
+    }
+    
+    public N endOnPodCondition() {
+      return and();
+    }
+    
+  }
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/SuccessPolicyBuilder.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/SuccessPolicyBuilder.java
@@ -1,0 +1,33 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
+import java.lang.Object;
+public class SuccessPolicyBuilder extends SuccessPolicyFluent<SuccessPolicyBuilder> implements VisitableBuilder<SuccessPolicy,SuccessPolicyBuilder>{
+
+  SuccessPolicyFluent<?> fluent;
+
+  public SuccessPolicyBuilder() {
+    this(new SuccessPolicy());
+  }
+  
+  public SuccessPolicyBuilder(SuccessPolicyFluent<?> fluent) {
+    this(fluent, new SuccessPolicy());
+  }
+  
+  public SuccessPolicyBuilder(SuccessPolicy instance) {
+    this.fluent = this;
+    this.copyInstance(instance);
+  }
+  
+  public SuccessPolicyBuilder(SuccessPolicyFluent<?> fluent,SuccessPolicy instance) {
+    this.fluent = fluent;
+    fluent.copyInstance(instance);
+  }
+
+  public SuccessPolicy build() {
+    SuccessPolicy buildable = new SuccessPolicy(fluent.buildRules());
+    buildable.setAdditionalProperties(fluent.getAdditionalProperties());
+    return buildable;
+  }
+  
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/SuccessPolicyFluent.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/SuccessPolicyFluent.java
@@ -1,0 +1,375 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.BaseFluent;
+import io.fabric8.kubernetes.api.builder.Nested;
+import java.lang.Integer;
+import java.lang.Object;
+import java.lang.RuntimeException;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.lang.SuppressWarnings;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * Generated
+ */
+@SuppressWarnings("unchecked")
+public class SuccessPolicyFluent<A extends io.fabric8.kubernetes.api.model.batch.v1.SuccessPolicyFluent<A>> extends BaseFluent<A>{
+
+  private Map<String,Object> additionalProperties;
+  private ArrayList<SuccessPolicyRuleBuilder> rules = new ArrayList<SuccessPolicyRuleBuilder>();
+
+  public SuccessPolicyFluent() {
+  }
+  
+  public SuccessPolicyFluent(SuccessPolicy instance) {
+    this.copyInstance(instance);
+  }
+
+  public A addAllToRules(Collection<SuccessPolicyRule> items) {
+    if (this.rules == null) {
+      this.rules = new ArrayList();
+    }
+    for (SuccessPolicyRule item : items) {
+        SuccessPolicyRuleBuilder builder = new SuccessPolicyRuleBuilder(item);
+        _visitables.get("rules").add(builder);
+        this.rules.add(builder);
+    }
+    return (A) this;
+  }
+  
+  public RulesNested<A> addNewRule() {
+    return new RulesNested(-1, null);
+  }
+  
+  public A addNewRule(Integer succeededCount,String succeededIndexes) {
+    return (A) this.addToRules(new SuccessPolicyRule(succeededCount, succeededIndexes));
+  }
+  
+  public RulesNested<A> addNewRuleLike(SuccessPolicyRule item) {
+    return new RulesNested(-1, item);
+  }
+  
+  public A addToAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null && map != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (map != null) {
+      this.additionalProperties.putAll(map);
+    }
+    return (A) this;
+  }
+  
+  public A addToAdditionalProperties(String key,Object value) {
+    if (this.additionalProperties == null && key != null && value != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (key != null && value != null) {
+      this.additionalProperties.put(key, value);
+    }
+    return (A) this;
+  }
+  
+  public A addToRules(SuccessPolicyRule... items) {
+    if (this.rules == null) {
+      this.rules = new ArrayList();
+    }
+    for (SuccessPolicyRule item : items) {
+        SuccessPolicyRuleBuilder builder = new SuccessPolicyRuleBuilder(item);
+        _visitables.get("rules").add(builder);
+        this.rules.add(builder);
+    }
+    return (A) this;
+  }
+  
+  public A addToRules(int index,SuccessPolicyRule item) {
+    if (this.rules == null) {
+      this.rules = new ArrayList();
+    }
+    SuccessPolicyRuleBuilder builder = new SuccessPolicyRuleBuilder(item);
+    if (index < 0 || index >= rules.size()) {
+        _visitables.get("rules").add(builder);
+        rules.add(builder);
+    } else {
+        _visitables.get("rules").add(builder);
+        rules.add(index, builder);
+    }
+    return (A) this;
+  }
+  
+  public SuccessPolicyRule buildFirstRule() {
+    return this.rules.get(0).build();
+  }
+  
+  public SuccessPolicyRule buildLastRule() {
+    return this.rules.get(rules.size() - 1).build();
+  }
+  
+  public SuccessPolicyRule buildMatchingRule(Predicate<SuccessPolicyRuleBuilder> predicate) {
+      for (SuccessPolicyRuleBuilder item : rules) {
+        if (predicate.test(item)) {
+          return item.build();
+        }
+      }
+      return null;
+  }
+  
+  public SuccessPolicyRule buildRule(int index) {
+    return this.rules.get(index).build();
+  }
+  
+  public List<SuccessPolicyRule> buildRules() {
+    return this.rules != null ? build(rules) : null;
+  }
+  
+  protected void copyInstance(SuccessPolicy instance) {
+    instance = instance != null ? instance : new SuccessPolicy();
+    if (instance != null) {
+        this.withRules(instance.getRules());
+        this.withAdditionalProperties(instance.getAdditionalProperties());
+    }
+  }
+  
+  public RulesNested<A> editFirstRule() {
+    if (rules.size() == 0) {
+      throw new RuntimeException(String.format("Can't edit first %s. The list is empty.", "rules"));
+    }
+    return this.setNewRuleLike(0, this.buildRule(0));
+  }
+  
+  public RulesNested<A> editLastRule() {
+    int index = rules.size() - 1;
+    if (index < 0) {
+      throw new RuntimeException(String.format("Can't edit last %s. The list is empty.", "rules"));
+    }
+    return this.setNewRuleLike(index, this.buildRule(index));
+  }
+  
+  public RulesNested<A> editMatchingRule(Predicate<SuccessPolicyRuleBuilder> predicate) {
+    int index = -1;
+    for (int i = 0;i < rules.size();i++) {
+      if (predicate.test(rules.get(i))) {
+          index = i;
+          break;
+      }
+    }
+    if (index < 0) {
+      throw new RuntimeException(String.format("Can't edit matching %s. No match found.", "rules"));
+    }
+    return this.setNewRuleLike(index, this.buildRule(index));
+  }
+  
+  public RulesNested<A> editRule(int index) {
+    if (rules.size() <= index) {
+      throw new RuntimeException(String.format("Can't edit %s. Index exceeds size.", "rules"));
+    }
+    return this.setNewRuleLike(index, this.buildRule(index));
+  }
+  
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || this.getClass() != o.getClass()) {
+      return false;
+    }
+    if (!(super.equals(o))) {
+      return false;
+    }
+    SuccessPolicyFluent that = (SuccessPolicyFluent) o;
+    if (!(Objects.equals(rules, that.rules))) {
+      return false;
+    }
+    if (!(Objects.equals(additionalProperties, that.additionalProperties))) {
+      return false;
+    }
+    return true;
+  }
+  
+  public Map<String,Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
+  
+  public boolean hasAdditionalProperties() {
+    return this.additionalProperties != null;
+  }
+  
+  public boolean hasMatchingRule(Predicate<SuccessPolicyRuleBuilder> predicate) {
+      for (SuccessPolicyRuleBuilder item : rules) {
+        if (predicate.test(item)) {
+          return true;
+        }
+      }
+      return false;
+  }
+  
+  public boolean hasRules() {
+    return this.rules != null && !(this.rules.isEmpty());
+  }
+  
+  public int hashCode() {
+    return Objects.hash(rules, additionalProperties);
+  }
+  
+  public A removeAllFromRules(Collection<SuccessPolicyRule> items) {
+    if (this.rules == null) {
+      return (A) this;
+    }
+    for (SuccessPolicyRule item : items) {
+        SuccessPolicyRuleBuilder builder = new SuccessPolicyRuleBuilder(item);
+        _visitables.get("rules").remove(builder);
+        this.rules.remove(builder);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(String key) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (key != null && this.additionalProperties != null) {
+      this.additionalProperties.remove(key);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (map != null) {
+      for (Object key : map.keySet()) {
+        if (this.additionalProperties != null) {
+          this.additionalProperties.remove(key);
+        }
+      }
+    }
+    return (A) this;
+  }
+  
+  public A removeFromRules(SuccessPolicyRule... items) {
+    if (this.rules == null) {
+      return (A) this;
+    }
+    for (SuccessPolicyRule item : items) {
+        SuccessPolicyRuleBuilder builder = new SuccessPolicyRuleBuilder(item);
+        _visitables.get("rules").remove(builder);
+        this.rules.remove(builder);
+    }
+    return (A) this;
+  }
+  
+  public A removeMatchingFromRules(Predicate<SuccessPolicyRuleBuilder> predicate) {
+    if (rules == null) {
+      return (A) this;
+    }
+    Iterator<SuccessPolicyRuleBuilder> each = rules.iterator();
+    List visitables = _visitables.get("rules");
+    while (each.hasNext()) {
+        SuccessPolicyRuleBuilder builder = each.next();
+        if (predicate.test(builder)) {
+            visitables.remove(builder);
+            each.remove();
+        }
+    }
+    return (A) this;
+  }
+  
+  public RulesNested<A> setNewRuleLike(int index,SuccessPolicyRule item) {
+    return new RulesNested(index, item);
+  }
+  
+  public A setToRules(int index,SuccessPolicyRule item) {
+    if (this.rules == null) {
+      this.rules = new ArrayList();
+    }
+    SuccessPolicyRuleBuilder builder = new SuccessPolicyRuleBuilder(item);
+    if (index < 0 || index >= rules.size()) {
+        _visitables.get("rules").add(builder);
+        rules.add(builder);
+    } else {
+        _visitables.get("rules").add(builder);
+        rules.set(index, builder);
+    }
+    return (A) this;
+  }
+  
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+    if (!(rules == null) && !(rules.isEmpty())) {
+        sb.append("rules:");
+        sb.append(rules);
+        sb.append(",");
+    }
+    if (!(additionalProperties == null) && !(additionalProperties.isEmpty())) {
+        sb.append("additionalProperties:");
+        sb.append(additionalProperties);
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+  
+  public <K,V>A withAdditionalProperties(Map<String,Object> additionalProperties) {
+    if (additionalProperties == null) {
+      this.additionalProperties = null;
+    } else {
+      this.additionalProperties = new LinkedHashMap(additionalProperties);
+    }
+    return (A) this;
+  }
+  
+  public A withRules(List<SuccessPolicyRule> rules) {
+    if (this.rules != null) {
+      this._visitables.get("rules").clear();
+    }
+    if (rules != null) {
+        this.rules = new ArrayList();
+        for (SuccessPolicyRule item : rules) {
+          this.addToRules(item);
+        }
+    } else {
+      this.rules = null;
+    }
+    return (A) this;
+  }
+  
+  public A withRules(SuccessPolicyRule... rules) {
+    if (this.rules != null) {
+        this.rules.clear();
+        _visitables.remove("rules");
+    }
+    if (rules != null) {
+      for (SuccessPolicyRule item : rules) {
+        this.addToRules(item);
+      }
+    }
+    return (A) this;
+  }
+  public class RulesNested<N> extends SuccessPolicyRuleFluent<RulesNested<N>> implements Nested<N>{
+  
+    SuccessPolicyRuleBuilder builder;
+    int index;
+  
+    RulesNested(int index,SuccessPolicyRule item) {
+      this.index = index;
+      this.builder = new SuccessPolicyRuleBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) SuccessPolicyFluent.this.setToRules(index, builder.build());
+    }
+    
+    public N endRule() {
+      return and();
+    }
+    
+  }
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/SuccessPolicyRuleBuilder.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/SuccessPolicyRuleBuilder.java
@@ -1,0 +1,33 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
+import java.lang.Object;
+public class SuccessPolicyRuleBuilder extends SuccessPolicyRuleFluent<SuccessPolicyRuleBuilder> implements VisitableBuilder<SuccessPolicyRule,SuccessPolicyRuleBuilder>{
+
+  SuccessPolicyRuleFluent<?> fluent;
+
+  public SuccessPolicyRuleBuilder() {
+    this(new SuccessPolicyRule());
+  }
+  
+  public SuccessPolicyRuleBuilder(SuccessPolicyRuleFluent<?> fluent) {
+    this(fluent, new SuccessPolicyRule());
+  }
+  
+  public SuccessPolicyRuleBuilder(SuccessPolicyRule instance) {
+    this.fluent = this;
+    this.copyInstance(instance);
+  }
+  
+  public SuccessPolicyRuleBuilder(SuccessPolicyRuleFluent<?> fluent,SuccessPolicyRule instance) {
+    this.fluent = fluent;
+    fluent.copyInstance(instance);
+  }
+
+  public SuccessPolicyRule build() {
+    SuccessPolicyRule buildable = new SuccessPolicyRule(fluent.getSucceededCount(), fluent.getSucceededIndexes());
+    buildable.setAdditionalProperties(fluent.getAdditionalProperties());
+    return buildable;
+  }
+  
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/SuccessPolicyRuleFluent.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/SuccessPolicyRuleFluent.java
@@ -1,0 +1,174 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.BaseFluent;
+import java.lang.Integer;
+import java.lang.Object;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.lang.SuppressWarnings;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Generated
+ */
+@SuppressWarnings("unchecked")
+public class SuccessPolicyRuleFluent<A extends io.fabric8.kubernetes.api.model.batch.v1.SuccessPolicyRuleFluent<A>> extends BaseFluent<A>{
+
+  private Map<String,Object> additionalProperties;
+  private Integer succeededCount;
+  private String succeededIndexes;
+
+  public SuccessPolicyRuleFluent() {
+  }
+  
+  public SuccessPolicyRuleFluent(SuccessPolicyRule instance) {
+    this.copyInstance(instance);
+  }
+
+  public A addToAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null && map != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (map != null) {
+      this.additionalProperties.putAll(map);
+    }
+    return (A) this;
+  }
+  
+  public A addToAdditionalProperties(String key,Object value) {
+    if (this.additionalProperties == null && key != null && value != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (key != null && value != null) {
+      this.additionalProperties.put(key, value);
+    }
+    return (A) this;
+  }
+  
+  protected void copyInstance(SuccessPolicyRule instance) {
+    instance = instance != null ? instance : new SuccessPolicyRule();
+    if (instance != null) {
+        this.withSucceededCount(instance.getSucceededCount());
+        this.withSucceededIndexes(instance.getSucceededIndexes());
+        this.withAdditionalProperties(instance.getAdditionalProperties());
+    }
+  }
+  
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || this.getClass() != o.getClass()) {
+      return false;
+    }
+    if (!(super.equals(o))) {
+      return false;
+    }
+    SuccessPolicyRuleFluent that = (SuccessPolicyRuleFluent) o;
+    if (!(Objects.equals(succeededCount, that.succeededCount))) {
+      return false;
+    }
+    if (!(Objects.equals(succeededIndexes, that.succeededIndexes))) {
+      return false;
+    }
+    if (!(Objects.equals(additionalProperties, that.additionalProperties))) {
+      return false;
+    }
+    return true;
+  }
+  
+  public Map<String,Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
+  
+  public Integer getSucceededCount() {
+    return this.succeededCount;
+  }
+  
+  public String getSucceededIndexes() {
+    return this.succeededIndexes;
+  }
+  
+  public boolean hasAdditionalProperties() {
+    return this.additionalProperties != null;
+  }
+  
+  public boolean hasSucceededCount() {
+    return this.succeededCount != null;
+  }
+  
+  public boolean hasSucceededIndexes() {
+    return this.succeededIndexes != null;
+  }
+  
+  public int hashCode() {
+    return Objects.hash(succeededCount, succeededIndexes, additionalProperties);
+  }
+  
+  public A removeFromAdditionalProperties(String key) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (key != null && this.additionalProperties != null) {
+      this.additionalProperties.remove(key);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (map != null) {
+      for (Object key : map.keySet()) {
+        if (this.additionalProperties != null) {
+          this.additionalProperties.remove(key);
+        }
+      }
+    }
+    return (A) this;
+  }
+  
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+    if (!(succeededCount == null)) {
+        sb.append("succeededCount:");
+        sb.append(succeededCount);
+        sb.append(",");
+    }
+    if (!(succeededIndexes == null)) {
+        sb.append("succeededIndexes:");
+        sb.append(succeededIndexes);
+        sb.append(",");
+    }
+    if (!(additionalProperties == null) && !(additionalProperties.isEmpty())) {
+        sb.append("additionalProperties:");
+        sb.append(additionalProperties);
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+  
+  public <K,V>A withAdditionalProperties(Map<String,Object> additionalProperties) {
+    if (additionalProperties == null) {
+      this.additionalProperties = null;
+    } else {
+      this.additionalProperties = new LinkedHashMap(additionalProperties);
+    }
+    return (A) this;
+  }
+  
+  public A withSucceededCount(Integer succeededCount) {
+    this.succeededCount = succeededCount;
+    return (A) this;
+  }
+  
+  public A withSucceededIndexes(String succeededIndexes) {
+    this.succeededIndexes = succeededIndexes;
+    return (A) this;
+  }
+  
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/UncountedTerminatedPodsBuilder.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/UncountedTerminatedPodsBuilder.java
@@ -1,0 +1,33 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
+import java.lang.Object;
+public class UncountedTerminatedPodsBuilder extends UncountedTerminatedPodsFluent<UncountedTerminatedPodsBuilder> implements VisitableBuilder<UncountedTerminatedPods,UncountedTerminatedPodsBuilder>{
+
+  UncountedTerminatedPodsFluent<?> fluent;
+
+  public UncountedTerminatedPodsBuilder() {
+    this(new UncountedTerminatedPods());
+  }
+  
+  public UncountedTerminatedPodsBuilder(UncountedTerminatedPodsFluent<?> fluent) {
+    this(fluent, new UncountedTerminatedPods());
+  }
+  
+  public UncountedTerminatedPodsBuilder(UncountedTerminatedPods instance) {
+    this.fluent = this;
+    this.copyInstance(instance);
+  }
+  
+  public UncountedTerminatedPodsBuilder(UncountedTerminatedPodsFluent<?> fluent,UncountedTerminatedPods instance) {
+    this.fluent = fluent;
+    fluent.copyInstance(instance);
+  }
+
+  public UncountedTerminatedPods build() {
+    UncountedTerminatedPods buildable = new UncountedTerminatedPods(fluent.getFailed(), fluent.getSucceeded());
+    buildable.setAdditionalProperties(fluent.getAdditionalProperties());
+    return buildable;
+  }
+  
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/UncountedTerminatedPodsFluent.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1/UncountedTerminatedPodsFluent.java
@@ -1,0 +1,389 @@
+package io.fabric8.kubernetes.api.model.batch.v1;
+
+import io.fabric8.kubernetes.api.builder.BaseFluent;
+import java.lang.Object;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.lang.SuppressWarnings;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * Generated
+ */
+@SuppressWarnings("unchecked")
+public class UncountedTerminatedPodsFluent<A extends io.fabric8.kubernetes.api.model.batch.v1.UncountedTerminatedPodsFluent<A>> extends BaseFluent<A>{
+
+  private Map<String,Object> additionalProperties;
+  private List<String> failed = new ArrayList<String>();
+  private List<String> succeeded = new ArrayList<String>();
+
+  public UncountedTerminatedPodsFluent() {
+  }
+  
+  public UncountedTerminatedPodsFluent(UncountedTerminatedPods instance) {
+    this.copyInstance(instance);
+  }
+
+  public A addAllToFailed(Collection<String> items) {
+    if (this.failed == null) {
+      this.failed = new ArrayList();
+    }
+    for (String item : items) {
+      this.failed.add(item);
+    }
+    return (A) this;
+  }
+  
+  public A addAllToSucceeded(Collection<String> items) {
+    if (this.succeeded == null) {
+      this.succeeded = new ArrayList();
+    }
+    for (String item : items) {
+      this.succeeded.add(item);
+    }
+    return (A) this;
+  }
+  
+  public A addToAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null && map != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (map != null) {
+      this.additionalProperties.putAll(map);
+    }
+    return (A) this;
+  }
+  
+  public A addToAdditionalProperties(String key,Object value) {
+    if (this.additionalProperties == null && key != null && value != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (key != null && value != null) {
+      this.additionalProperties.put(key, value);
+    }
+    return (A) this;
+  }
+  
+  public A addToFailed(String... items) {
+    if (this.failed == null) {
+      this.failed = new ArrayList();
+    }
+    for (String item : items) {
+      this.failed.add(item);
+    }
+    return (A) this;
+  }
+  
+  public A addToFailed(int index,String item) {
+    if (this.failed == null) {
+      this.failed = new ArrayList();
+    }
+    this.failed.add(index, item);
+    return (A) this;
+  }
+  
+  public A addToSucceeded(String... items) {
+    if (this.succeeded == null) {
+      this.succeeded = new ArrayList();
+    }
+    for (String item : items) {
+      this.succeeded.add(item);
+    }
+    return (A) this;
+  }
+  
+  public A addToSucceeded(int index,String item) {
+    if (this.succeeded == null) {
+      this.succeeded = new ArrayList();
+    }
+    this.succeeded.add(index, item);
+    return (A) this;
+  }
+  
+  protected void copyInstance(UncountedTerminatedPods instance) {
+    instance = instance != null ? instance : new UncountedTerminatedPods();
+    if (instance != null) {
+        this.withFailed(instance.getFailed());
+        this.withSucceeded(instance.getSucceeded());
+        this.withAdditionalProperties(instance.getAdditionalProperties());
+    }
+  }
+  
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || this.getClass() != o.getClass()) {
+      return false;
+    }
+    if (!(super.equals(o))) {
+      return false;
+    }
+    UncountedTerminatedPodsFluent that = (UncountedTerminatedPodsFluent) o;
+    if (!(Objects.equals(failed, that.failed))) {
+      return false;
+    }
+    if (!(Objects.equals(succeeded, that.succeeded))) {
+      return false;
+    }
+    if (!(Objects.equals(additionalProperties, that.additionalProperties))) {
+      return false;
+    }
+    return true;
+  }
+  
+  public Map<String,Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
+  
+  public List<String> getFailed() {
+    return this.failed;
+  }
+  
+  public String getFailed(int index) {
+    return this.failed.get(index);
+  }
+  
+  public String getFirstFailed() {
+    return this.failed.get(0);
+  }
+  
+  public String getFirstSucceeded() {
+    return this.succeeded.get(0);
+  }
+  
+  public String getLastFailed() {
+    return this.failed.get(failed.size() - 1);
+  }
+  
+  public String getLastSucceeded() {
+    return this.succeeded.get(succeeded.size() - 1);
+  }
+  
+  public String getMatchingFailed(Predicate<String> predicate) {
+      for (String item : failed) {
+        if (predicate.test(item)) {
+          return item;
+        }
+      }
+      return null;
+  }
+  
+  public String getMatchingSucceeded(Predicate<String> predicate) {
+      for (String item : succeeded) {
+        if (predicate.test(item)) {
+          return item;
+        }
+      }
+      return null;
+  }
+  
+  public List<String> getSucceeded() {
+    return this.succeeded;
+  }
+  
+  public String getSucceeded(int index) {
+    return this.succeeded.get(index);
+  }
+  
+  public boolean hasAdditionalProperties() {
+    return this.additionalProperties != null;
+  }
+  
+  public boolean hasFailed() {
+    return this.failed != null && !(this.failed.isEmpty());
+  }
+  
+  public boolean hasMatchingFailed(Predicate<String> predicate) {
+      for (String item : failed) {
+        if (predicate.test(item)) {
+          return true;
+        }
+      }
+      return false;
+  }
+  
+  public boolean hasMatchingSucceeded(Predicate<String> predicate) {
+      for (String item : succeeded) {
+        if (predicate.test(item)) {
+          return true;
+        }
+      }
+      return false;
+  }
+  
+  public boolean hasSucceeded() {
+    return this.succeeded != null && !(this.succeeded.isEmpty());
+  }
+  
+  public int hashCode() {
+    return Objects.hash(failed, succeeded, additionalProperties);
+  }
+  
+  public A removeAllFromFailed(Collection<String> items) {
+    if (this.failed == null) {
+      return (A) this;
+    }
+    for (String item : items) {
+      this.failed.remove(item);
+    }
+    return (A) this;
+  }
+  
+  public A removeAllFromSucceeded(Collection<String> items) {
+    if (this.succeeded == null) {
+      return (A) this;
+    }
+    for (String item : items) {
+      this.succeeded.remove(item);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(String key) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (key != null && this.additionalProperties != null) {
+      this.additionalProperties.remove(key);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (map != null) {
+      for (Object key : map.keySet()) {
+        if (this.additionalProperties != null) {
+          this.additionalProperties.remove(key);
+        }
+      }
+    }
+    return (A) this;
+  }
+  
+  public A removeFromFailed(String... items) {
+    if (this.failed == null) {
+      return (A) this;
+    }
+    for (String item : items) {
+      this.failed.remove(item);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromSucceeded(String... items) {
+    if (this.succeeded == null) {
+      return (A) this;
+    }
+    for (String item : items) {
+      this.succeeded.remove(item);
+    }
+    return (A) this;
+  }
+  
+  public A setToFailed(int index,String item) {
+    if (this.failed == null) {
+      this.failed = new ArrayList();
+    }
+    this.failed.set(index, item);
+    return (A) this;
+  }
+  
+  public A setToSucceeded(int index,String item) {
+    if (this.succeeded == null) {
+      this.succeeded = new ArrayList();
+    }
+    this.succeeded.set(index, item);
+    return (A) this;
+  }
+  
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+    if (!(failed == null) && !(failed.isEmpty())) {
+        sb.append("failed:");
+        sb.append(failed);
+        sb.append(",");
+    }
+    if (!(succeeded == null) && !(succeeded.isEmpty())) {
+        sb.append("succeeded:");
+        sb.append(succeeded);
+        sb.append(",");
+    }
+    if (!(additionalProperties == null) && !(additionalProperties.isEmpty())) {
+        sb.append("additionalProperties:");
+        sb.append(additionalProperties);
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+  
+  public <K,V>A withAdditionalProperties(Map<String,Object> additionalProperties) {
+    if (additionalProperties == null) {
+      this.additionalProperties = null;
+    } else {
+      this.additionalProperties = new LinkedHashMap(additionalProperties);
+    }
+    return (A) this;
+  }
+  
+  public A withFailed(List<String> failed) {
+    if (failed != null) {
+        this.failed = new ArrayList();
+        for (String item : failed) {
+          this.addToFailed(item);
+        }
+    } else {
+      this.failed = null;
+    }
+    return (A) this;
+  }
+  
+  public A withFailed(String... failed) {
+    if (this.failed != null) {
+        this.failed.clear();
+        _visitables.remove("failed");
+    }
+    if (failed != null) {
+      for (String item : failed) {
+        this.addToFailed(item);
+      }
+    }
+    return (A) this;
+  }
+  
+  public A withSucceeded(List<String> succeeded) {
+    if (succeeded != null) {
+        this.succeeded = new ArrayList();
+        for (String item : succeeded) {
+          this.addToSucceeded(item);
+        }
+    } else {
+      this.succeeded = null;
+    }
+    return (A) this;
+  }
+  
+  public A withSucceeded(String... succeeded) {
+    if (this.succeeded != null) {
+        this.succeeded.clear();
+        _visitables.remove("succeeded");
+    }
+    if (succeeded != null) {
+      for (String item : succeeded) {
+        this.addToSucceeded(item);
+      }
+    }
+    return (A) this;
+  }
+  
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1beta1/CronJobBuilder.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1beta1/CronJobBuilder.java
@@ -1,0 +1,33 @@
+package io.fabric8.kubernetes.api.model.batch.v1beta1;
+
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
+import java.lang.Object;
+public class CronJobBuilder extends CronJobFluent<CronJobBuilder> implements VisitableBuilder<CronJob,CronJobBuilder>{
+
+  CronJobFluent<?> fluent;
+
+  public CronJobBuilder() {
+    this(new CronJob());
+  }
+  
+  public CronJobBuilder(CronJobFluent<?> fluent) {
+    this(fluent, new CronJob());
+  }
+  
+  public CronJobBuilder(CronJob instance) {
+    this.fluent = this;
+    this.copyInstance(instance);
+  }
+  
+  public CronJobBuilder(CronJobFluent<?> fluent,CronJob instance) {
+    this.fluent = fluent;
+    fluent.copyInstance(instance);
+  }
+
+  public CronJob build() {
+    CronJob buildable = new CronJob(fluent.getApiVersion(), fluent.getKind(), fluent.buildMetadata(), fluent.buildSpec(), fluent.buildStatus());
+    buildable.setAdditionalProperties(fluent.getAdditionalProperties());
+    return buildable;
+  }
+  
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1beta1/CronJobFluent.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1beta1/CronJobFluent.java
@@ -1,0 +1,378 @@
+package io.fabric8.kubernetes.api.model.batch.v1beta1;
+
+import io.fabric8.kubernetes.api.builder.BaseFluent;
+import io.fabric8.kubernetes.api.builder.Nested;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMetaFluent;
+import java.lang.Object;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.lang.SuppressWarnings;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Generated
+ */
+@SuppressWarnings("unchecked")
+public class CronJobFluent<A extends io.fabric8.kubernetes.api.model.batch.v1beta1.CronJobFluent<A>> extends BaseFluent<A>{
+
+  private Map<String,Object> additionalProperties;
+  private String apiVersion;
+  private String kind;
+  private ObjectMetaBuilder metadata;
+  private CronJobSpecBuilder spec;
+  private CronJobStatusBuilder status;
+
+  public CronJobFluent() {
+  }
+  
+  public CronJobFluent(CronJob instance) {
+    this.copyInstance(instance);
+  }
+
+  public A addToAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null && map != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (map != null) {
+      this.additionalProperties.putAll(map);
+    }
+    return (A) this;
+  }
+  
+  public A addToAdditionalProperties(String key,Object value) {
+    if (this.additionalProperties == null && key != null && value != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (key != null && value != null) {
+      this.additionalProperties.put(key, value);
+    }
+    return (A) this;
+  }
+  
+  public ObjectMeta buildMetadata() {
+    return this.metadata != null ? this.metadata.build() : null;
+  }
+  
+  public CronJobSpec buildSpec() {
+    return this.spec != null ? this.spec.build() : null;
+  }
+  
+  public CronJobStatus buildStatus() {
+    return this.status != null ? this.status.build() : null;
+  }
+  
+  protected void copyInstance(CronJob instance) {
+    instance = instance != null ? instance : new CronJob();
+    if (instance != null) {
+        this.withApiVersion(instance.getApiVersion());
+        this.withKind(instance.getKind());
+        this.withMetadata(instance.getMetadata());
+        this.withSpec(instance.getSpec());
+        this.withStatus(instance.getStatus());
+        this.withAdditionalProperties(instance.getAdditionalProperties());
+    }
+  }
+  
+  public MetadataNested<A> editMetadata() {
+    return this.withNewMetadataLike(Optional.ofNullable(this.buildMetadata()).orElse(null));
+  }
+  
+  public MetadataNested<A> editOrNewMetadata() {
+    return this.withNewMetadataLike(Optional.ofNullable(this.buildMetadata()).orElse(new ObjectMetaBuilder().build()));
+  }
+  
+  public MetadataNested<A> editOrNewMetadataLike(ObjectMeta item) {
+    return this.withNewMetadataLike(Optional.ofNullable(this.buildMetadata()).orElse(item));
+  }
+  
+  public SpecNested<A> editOrNewSpec() {
+    return this.withNewSpecLike(Optional.ofNullable(this.buildSpec()).orElse(new CronJobSpecBuilder().build()));
+  }
+  
+  public SpecNested<A> editOrNewSpecLike(CronJobSpec item) {
+    return this.withNewSpecLike(Optional.ofNullable(this.buildSpec()).orElse(item));
+  }
+  
+  public StatusNested<A> editOrNewStatus() {
+    return this.withNewStatusLike(Optional.ofNullable(this.buildStatus()).orElse(new CronJobStatusBuilder().build()));
+  }
+  
+  public StatusNested<A> editOrNewStatusLike(CronJobStatus item) {
+    return this.withNewStatusLike(Optional.ofNullable(this.buildStatus()).orElse(item));
+  }
+  
+  public SpecNested<A> editSpec() {
+    return this.withNewSpecLike(Optional.ofNullable(this.buildSpec()).orElse(null));
+  }
+  
+  public StatusNested<A> editStatus() {
+    return this.withNewStatusLike(Optional.ofNullable(this.buildStatus()).orElse(null));
+  }
+  
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || this.getClass() != o.getClass()) {
+      return false;
+    }
+    if (!(super.equals(o))) {
+      return false;
+    }
+    CronJobFluent that = (CronJobFluent) o;
+    if (!(Objects.equals(apiVersion, that.apiVersion))) {
+      return false;
+    }
+    if (!(Objects.equals(kind, that.kind))) {
+      return false;
+    }
+    if (!(Objects.equals(metadata, that.metadata))) {
+      return false;
+    }
+    if (!(Objects.equals(spec, that.spec))) {
+      return false;
+    }
+    if (!(Objects.equals(status, that.status))) {
+      return false;
+    }
+    if (!(Objects.equals(additionalProperties, that.additionalProperties))) {
+      return false;
+    }
+    return true;
+  }
+  
+  public Map<String,Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
+  
+  public String getApiVersion() {
+    return this.apiVersion;
+  }
+  
+  public String getKind() {
+    return this.kind;
+  }
+  
+  public boolean hasAdditionalProperties() {
+    return this.additionalProperties != null;
+  }
+  
+  public boolean hasApiVersion() {
+    return this.apiVersion != null;
+  }
+  
+  public boolean hasKind() {
+    return this.kind != null;
+  }
+  
+  public boolean hasMetadata() {
+    return this.metadata != null;
+  }
+  
+  public boolean hasSpec() {
+    return this.spec != null;
+  }
+  
+  public boolean hasStatus() {
+    return this.status != null;
+  }
+  
+  public int hashCode() {
+    return Objects.hash(apiVersion, kind, metadata, spec, status, additionalProperties);
+  }
+  
+  public A removeFromAdditionalProperties(String key) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (key != null && this.additionalProperties != null) {
+      this.additionalProperties.remove(key);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (map != null) {
+      for (Object key : map.keySet()) {
+        if (this.additionalProperties != null) {
+          this.additionalProperties.remove(key);
+        }
+      }
+    }
+    return (A) this;
+  }
+  
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+    if (!(apiVersion == null)) {
+        sb.append("apiVersion:");
+        sb.append(apiVersion);
+        sb.append(",");
+    }
+    if (!(kind == null)) {
+        sb.append("kind:");
+        sb.append(kind);
+        sb.append(",");
+    }
+    if (!(metadata == null)) {
+        sb.append("metadata:");
+        sb.append(metadata);
+        sb.append(",");
+    }
+    if (!(spec == null)) {
+        sb.append("spec:");
+        sb.append(spec);
+        sb.append(",");
+    }
+    if (!(status == null)) {
+        sb.append("status:");
+        sb.append(status);
+        sb.append(",");
+    }
+    if (!(additionalProperties == null) && !(additionalProperties.isEmpty())) {
+        sb.append("additionalProperties:");
+        sb.append(additionalProperties);
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+  
+  public <K,V>A withAdditionalProperties(Map<String,Object> additionalProperties) {
+    if (additionalProperties == null) {
+      this.additionalProperties = null;
+    } else {
+      this.additionalProperties = new LinkedHashMap(additionalProperties);
+    }
+    return (A) this;
+  }
+  
+  public A withApiVersion(String apiVersion) {
+    this.apiVersion = apiVersion;
+    return (A) this;
+  }
+  
+  public A withKind(String kind) {
+    this.kind = kind;
+    return (A) this;
+  }
+  
+  public A withMetadata(ObjectMeta metadata) {
+    this._visitables.remove("metadata");
+    if (metadata != null) {
+        this.metadata = new ObjectMetaBuilder(metadata);
+        this._visitables.get("metadata").add(this.metadata);
+    } else {
+        this.metadata = null;
+        this._visitables.get("metadata").remove(this.metadata);
+    }
+    return (A) this;
+  }
+  
+  public MetadataNested<A> withNewMetadata() {
+    return new MetadataNested(null);
+  }
+  
+  public MetadataNested<A> withNewMetadataLike(ObjectMeta item) {
+    return new MetadataNested(item);
+  }
+  
+  public SpecNested<A> withNewSpec() {
+    return new SpecNested(null);
+  }
+  
+  public SpecNested<A> withNewSpecLike(CronJobSpec item) {
+    return new SpecNested(item);
+  }
+  
+  public StatusNested<A> withNewStatus() {
+    return new StatusNested(null);
+  }
+  
+  public StatusNested<A> withNewStatusLike(CronJobStatus item) {
+    return new StatusNested(item);
+  }
+  
+  public A withSpec(CronJobSpec spec) {
+    this._visitables.remove("spec");
+    if (spec != null) {
+        this.spec = new CronJobSpecBuilder(spec);
+        this._visitables.get("spec").add(this.spec);
+    } else {
+        this.spec = null;
+        this._visitables.get("spec").remove(this.spec);
+    }
+    return (A) this;
+  }
+  
+  public A withStatus(CronJobStatus status) {
+    this._visitables.remove("status");
+    if (status != null) {
+        this.status = new CronJobStatusBuilder(status);
+        this._visitables.get("status").add(this.status);
+    } else {
+        this.status = null;
+        this._visitables.get("status").remove(this.status);
+    }
+    return (A) this;
+  }
+  public class MetadataNested<N> extends ObjectMetaFluent<MetadataNested<N>> implements Nested<N>{
+  
+    ObjectMetaBuilder builder;
+  
+    MetadataNested(ObjectMeta item) {
+      this.builder = new ObjectMetaBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) CronJobFluent.this.withMetadata(builder.build());
+    }
+    
+    public N endMetadata() {
+      return and();
+    }
+    
+  }
+  public class SpecNested<N> extends CronJobSpecFluent<SpecNested<N>> implements Nested<N>{
+  
+    CronJobSpecBuilder builder;
+  
+    SpecNested(CronJobSpec item) {
+      this.builder = new CronJobSpecBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) CronJobFluent.this.withSpec(builder.build());
+    }
+    
+    public N endSpec() {
+      return and();
+    }
+    
+  }
+  public class StatusNested<N> extends CronJobStatusFluent<StatusNested<N>> implements Nested<N>{
+  
+    CronJobStatusBuilder builder;
+  
+    StatusNested(CronJobStatus item) {
+      this.builder = new CronJobStatusBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) CronJobFluent.this.withStatus(builder.build());
+    }
+    
+    public N endStatus() {
+      return and();
+    }
+    
+  }
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1beta1/CronJobListBuilder.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1beta1/CronJobListBuilder.java
@@ -1,0 +1,33 @@
+package io.fabric8.kubernetes.api.model.batch.v1beta1;
+
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
+import java.lang.Object;
+public class CronJobListBuilder extends CronJobListFluent<CronJobListBuilder> implements VisitableBuilder<CronJobList,CronJobListBuilder>{
+
+  CronJobListFluent<?> fluent;
+
+  public CronJobListBuilder() {
+    this(new CronJobList());
+  }
+  
+  public CronJobListBuilder(CronJobListFluent<?> fluent) {
+    this(fluent, new CronJobList());
+  }
+  
+  public CronJobListBuilder(CronJobList instance) {
+    this.fluent = this;
+    this.copyInstance(instance);
+  }
+  
+  public CronJobListBuilder(CronJobListFluent<?> fluent,CronJobList instance) {
+    this.fluent = fluent;
+    fluent.copyInstance(instance);
+  }
+
+  public CronJobList build() {
+    CronJobList buildable = new CronJobList(fluent.getApiVersion(), fluent.buildItems(), fluent.getKind(), fluent.getMetadata());
+    buildable.setAdditionalProperties(fluent.getAdditionalProperties());
+    return buildable;
+  }
+  
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1beta1/CronJobListFluent.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1beta1/CronJobListFluent.java
@@ -1,0 +1,440 @@
+package io.fabric8.kubernetes.api.model.batch.v1beta1;
+
+import io.fabric8.kubernetes.api.builder.BaseFluent;
+import io.fabric8.kubernetes.api.builder.Nested;
+import io.fabric8.kubernetes.api.model.ListMeta;
+import java.lang.Object;
+import java.lang.RuntimeException;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.lang.SuppressWarnings;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * Generated
+ */
+@SuppressWarnings("unchecked")
+public class CronJobListFluent<A extends io.fabric8.kubernetes.api.model.batch.v1beta1.CronJobListFluent<A>> extends BaseFluent<A>{
+
+  private Map<String,Object> additionalProperties;
+  private String apiVersion;
+  private ArrayList<CronJobBuilder> items = new ArrayList<CronJobBuilder>();
+  private String kind;
+  private ListMeta metadata;
+
+  public CronJobListFluent() {
+  }
+  
+  public CronJobListFluent(CronJobList instance) {
+    this.copyInstance(instance);
+  }
+
+  public A addAllToItems(Collection<CronJob> items) {
+    if (this.items == null) {
+      this.items = new ArrayList();
+    }
+    for (CronJob item : items) {
+        CronJobBuilder builder = new CronJobBuilder(item);
+        _visitables.get("items").add(builder);
+        this.items.add(builder);
+    }
+    return (A) this;
+  }
+  
+  public ItemsNested<A> addNewItem() {
+    return new ItemsNested(-1, null);
+  }
+  
+  public ItemsNested<A> addNewItemLike(CronJob item) {
+    return new ItemsNested(-1, item);
+  }
+  
+  public A addToAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null && map != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (map != null) {
+      this.additionalProperties.putAll(map);
+    }
+    return (A) this;
+  }
+  
+  public A addToAdditionalProperties(String key,Object value) {
+    if (this.additionalProperties == null && key != null && value != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (key != null && value != null) {
+      this.additionalProperties.put(key, value);
+    }
+    return (A) this;
+  }
+  
+  public A addToItems(CronJob... items) {
+    if (this.items == null) {
+      this.items = new ArrayList();
+    }
+    for (CronJob item : items) {
+        CronJobBuilder builder = new CronJobBuilder(item);
+        _visitables.get("items").add(builder);
+        this.items.add(builder);
+    }
+    return (A) this;
+  }
+  
+  public A addToItems(int index,CronJob item) {
+    if (this.items == null) {
+      this.items = new ArrayList();
+    }
+    CronJobBuilder builder = new CronJobBuilder(item);
+    if (index < 0 || index >= items.size()) {
+        _visitables.get("items").add(builder);
+        items.add(builder);
+    } else {
+        _visitables.get("items").add(builder);
+        items.add(index, builder);
+    }
+    return (A) this;
+  }
+  
+  public CronJob buildFirstItem() {
+    return this.items.get(0).build();
+  }
+  
+  public CronJob buildItem(int index) {
+    return this.items.get(index).build();
+  }
+  
+  public List<CronJob> buildItems() {
+    return this.items != null ? build(items) : null;
+  }
+  
+  public CronJob buildLastItem() {
+    return this.items.get(items.size() - 1).build();
+  }
+  
+  public CronJob buildMatchingItem(Predicate<CronJobBuilder> predicate) {
+      for (CronJobBuilder item : items) {
+        if (predicate.test(item)) {
+          return item.build();
+        }
+      }
+      return null;
+  }
+  
+  protected void copyInstance(CronJobList instance) {
+    instance = instance != null ? instance : new CronJobList();
+    if (instance != null) {
+        this.withApiVersion(instance.getApiVersion());
+        this.withItems(instance.getItems());
+        this.withKind(instance.getKind());
+        this.withMetadata(instance.getMetadata());
+        this.withAdditionalProperties(instance.getAdditionalProperties());
+    }
+  }
+  
+  public ItemsNested<A> editFirstItem() {
+    if (items.size() == 0) {
+      throw new RuntimeException(String.format("Can't edit first %s. The list is empty.", "items"));
+    }
+    return this.setNewItemLike(0, this.buildItem(0));
+  }
+  
+  public ItemsNested<A> editItem(int index) {
+    if (items.size() <= index) {
+      throw new RuntimeException(String.format("Can't edit %s. Index exceeds size.", "items"));
+    }
+    return this.setNewItemLike(index, this.buildItem(index));
+  }
+  
+  public ItemsNested<A> editLastItem() {
+    int index = items.size() - 1;
+    if (index < 0) {
+      throw new RuntimeException(String.format("Can't edit last %s. The list is empty.", "items"));
+    }
+    return this.setNewItemLike(index, this.buildItem(index));
+  }
+  
+  public ItemsNested<A> editMatchingItem(Predicate<CronJobBuilder> predicate) {
+    int index = -1;
+    for (int i = 0;i < items.size();i++) {
+      if (predicate.test(items.get(i))) {
+          index = i;
+          break;
+      }
+    }
+    if (index < 0) {
+      throw new RuntimeException(String.format("Can't edit matching %s. No match found.", "items"));
+    }
+    return this.setNewItemLike(index, this.buildItem(index));
+  }
+  
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || this.getClass() != o.getClass()) {
+      return false;
+    }
+    if (!(super.equals(o))) {
+      return false;
+    }
+    CronJobListFluent that = (CronJobListFluent) o;
+    if (!(Objects.equals(apiVersion, that.apiVersion))) {
+      return false;
+    }
+    if (!(Objects.equals(items, that.items))) {
+      return false;
+    }
+    if (!(Objects.equals(kind, that.kind))) {
+      return false;
+    }
+    if (!(Objects.equals(metadata, that.metadata))) {
+      return false;
+    }
+    if (!(Objects.equals(additionalProperties, that.additionalProperties))) {
+      return false;
+    }
+    return true;
+  }
+  
+  public Map<String,Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
+  
+  public String getApiVersion() {
+    return this.apiVersion;
+  }
+  
+  public String getKind() {
+    return this.kind;
+  }
+  
+  public ListMeta getMetadata() {
+    return this.metadata;
+  }
+  
+  public boolean hasAdditionalProperties() {
+    return this.additionalProperties != null;
+  }
+  
+  public boolean hasApiVersion() {
+    return this.apiVersion != null;
+  }
+  
+  public boolean hasItems() {
+    return this.items != null && !(this.items.isEmpty());
+  }
+  
+  public boolean hasKind() {
+    return this.kind != null;
+  }
+  
+  public boolean hasMatchingItem(Predicate<CronJobBuilder> predicate) {
+      for (CronJobBuilder item : items) {
+        if (predicate.test(item)) {
+          return true;
+        }
+      }
+      return false;
+  }
+  
+  public boolean hasMetadata() {
+    return this.metadata != null;
+  }
+  
+  public int hashCode() {
+    return Objects.hash(apiVersion, items, kind, metadata, additionalProperties);
+  }
+  
+  public A removeAllFromItems(Collection<CronJob> items) {
+    if (this.items == null) {
+      return (A) this;
+    }
+    for (CronJob item : items) {
+        CronJobBuilder builder = new CronJobBuilder(item);
+        _visitables.get("items").remove(builder);
+        this.items.remove(builder);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(String key) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (key != null && this.additionalProperties != null) {
+      this.additionalProperties.remove(key);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (map != null) {
+      for (Object key : map.keySet()) {
+        if (this.additionalProperties != null) {
+          this.additionalProperties.remove(key);
+        }
+      }
+    }
+    return (A) this;
+  }
+  
+  public A removeFromItems(CronJob... items) {
+    if (this.items == null) {
+      return (A) this;
+    }
+    for (CronJob item : items) {
+        CronJobBuilder builder = new CronJobBuilder(item);
+        _visitables.get("items").remove(builder);
+        this.items.remove(builder);
+    }
+    return (A) this;
+  }
+  
+  public A removeMatchingFromItems(Predicate<CronJobBuilder> predicate) {
+    if (items == null) {
+      return (A) this;
+    }
+    Iterator<CronJobBuilder> each = items.iterator();
+    List visitables = _visitables.get("items");
+    while (each.hasNext()) {
+        CronJobBuilder builder = each.next();
+        if (predicate.test(builder)) {
+            visitables.remove(builder);
+            each.remove();
+        }
+    }
+    return (A) this;
+  }
+  
+  public ItemsNested<A> setNewItemLike(int index,CronJob item) {
+    return new ItemsNested(index, item);
+  }
+  
+  public A setToItems(int index,CronJob item) {
+    if (this.items == null) {
+      this.items = new ArrayList();
+    }
+    CronJobBuilder builder = new CronJobBuilder(item);
+    if (index < 0 || index >= items.size()) {
+        _visitables.get("items").add(builder);
+        items.add(builder);
+    } else {
+        _visitables.get("items").add(builder);
+        items.set(index, builder);
+    }
+    return (A) this;
+  }
+  
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+    if (!(apiVersion == null)) {
+        sb.append("apiVersion:");
+        sb.append(apiVersion);
+        sb.append(",");
+    }
+    if (!(items == null) && !(items.isEmpty())) {
+        sb.append("items:");
+        sb.append(items);
+        sb.append(",");
+    }
+    if (!(kind == null)) {
+        sb.append("kind:");
+        sb.append(kind);
+        sb.append(",");
+    }
+    if (!(metadata == null)) {
+        sb.append("metadata:");
+        sb.append(metadata);
+        sb.append(",");
+    }
+    if (!(additionalProperties == null) && !(additionalProperties.isEmpty())) {
+        sb.append("additionalProperties:");
+        sb.append(additionalProperties);
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+  
+  public <K,V>A withAdditionalProperties(Map<String,Object> additionalProperties) {
+    if (additionalProperties == null) {
+      this.additionalProperties = null;
+    } else {
+      this.additionalProperties = new LinkedHashMap(additionalProperties);
+    }
+    return (A) this;
+  }
+  
+  public A withApiVersion(String apiVersion) {
+    this.apiVersion = apiVersion;
+    return (A) this;
+  }
+  
+  public A withItems(List<CronJob> items) {
+    if (this.items != null) {
+      this._visitables.get("items").clear();
+    }
+    if (items != null) {
+        this.items = new ArrayList();
+        for (CronJob item : items) {
+          this.addToItems(item);
+        }
+    } else {
+      this.items = null;
+    }
+    return (A) this;
+  }
+  
+  public A withItems(CronJob... items) {
+    if (this.items != null) {
+        this.items.clear();
+        _visitables.remove("items");
+    }
+    if (items != null) {
+      for (CronJob item : items) {
+        this.addToItems(item);
+      }
+    }
+    return (A) this;
+  }
+  
+  public A withKind(String kind) {
+    this.kind = kind;
+    return (A) this;
+  }
+  
+  public A withMetadata(ListMeta metadata) {
+    this.metadata = metadata;
+    return (A) this;
+  }
+  public class ItemsNested<N> extends CronJobFluent<ItemsNested<N>> implements Nested<N>{
+  
+    CronJobBuilder builder;
+    int index;
+  
+    ItemsNested(int index,CronJob item) {
+      this.index = index;
+      this.builder = new CronJobBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) CronJobListFluent.this.setToItems(index, builder.build());
+    }
+    
+    public N endItem() {
+      return and();
+    }
+    
+  }
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1beta1/CronJobSpecBuilder.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1beta1/CronJobSpecBuilder.java
@@ -1,0 +1,33 @@
+package io.fabric8.kubernetes.api.model.batch.v1beta1;
+
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
+import java.lang.Object;
+public class CronJobSpecBuilder extends CronJobSpecFluent<CronJobSpecBuilder> implements VisitableBuilder<CronJobSpec,CronJobSpecBuilder>{
+
+  CronJobSpecFluent<?> fluent;
+
+  public CronJobSpecBuilder() {
+    this(new CronJobSpec());
+  }
+  
+  public CronJobSpecBuilder(CronJobSpecFluent<?> fluent) {
+    this(fluent, new CronJobSpec());
+  }
+  
+  public CronJobSpecBuilder(CronJobSpec instance) {
+    this.fluent = this;
+    this.copyInstance(instance);
+  }
+  
+  public CronJobSpecBuilder(CronJobSpecFluent<?> fluent,CronJobSpec instance) {
+    this.fluent = fluent;
+    fluent.copyInstance(instance);
+  }
+
+  public CronJobSpec build() {
+    CronJobSpec buildable = new CronJobSpec(fluent.getConcurrencyPolicy(), fluent.getFailedJobsHistoryLimit(), fluent.buildJobTemplate(), fluent.getSchedule(), fluent.getStartingDeadlineSeconds(), fluent.getSuccessfulJobsHistoryLimit(), fluent.getSuspend());
+    buildable.setAdditionalProperties(fluent.getAdditionalProperties());
+    return buildable;
+  }
+  
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1beta1/CronJobSpecFluent.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1beta1/CronJobSpecFluent.java
@@ -1,0 +1,340 @@
+package io.fabric8.kubernetes.api.model.batch.v1beta1;
+
+import io.fabric8.kubernetes.api.builder.BaseFluent;
+import io.fabric8.kubernetes.api.builder.Nested;
+import java.lang.Boolean;
+import java.lang.Integer;
+import java.lang.Long;
+import java.lang.Object;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.lang.SuppressWarnings;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Generated
+ */
+@SuppressWarnings("unchecked")
+public class CronJobSpecFluent<A extends io.fabric8.kubernetes.api.model.batch.v1beta1.CronJobSpecFluent<A>> extends BaseFluent<A>{
+
+  private Map<String,Object> additionalProperties;
+  private String concurrencyPolicy;
+  private Integer failedJobsHistoryLimit;
+  private JobTemplateSpecBuilder jobTemplate;
+  private String schedule;
+  private Long startingDeadlineSeconds;
+  private Integer successfulJobsHistoryLimit;
+  private Boolean suspend;
+
+  public CronJobSpecFluent() {
+  }
+  
+  public CronJobSpecFluent(CronJobSpec instance) {
+    this.copyInstance(instance);
+  }
+
+  public A addToAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null && map != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (map != null) {
+      this.additionalProperties.putAll(map);
+    }
+    return (A) this;
+  }
+  
+  public A addToAdditionalProperties(String key,Object value) {
+    if (this.additionalProperties == null && key != null && value != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (key != null && value != null) {
+      this.additionalProperties.put(key, value);
+    }
+    return (A) this;
+  }
+  
+  public JobTemplateSpec buildJobTemplate() {
+    return this.jobTemplate != null ? this.jobTemplate.build() : null;
+  }
+  
+  protected void copyInstance(CronJobSpec instance) {
+    instance = instance != null ? instance : new CronJobSpec();
+    if (instance != null) {
+        this.withConcurrencyPolicy(instance.getConcurrencyPolicy());
+        this.withFailedJobsHistoryLimit(instance.getFailedJobsHistoryLimit());
+        this.withJobTemplate(instance.getJobTemplate());
+        this.withSchedule(instance.getSchedule());
+        this.withStartingDeadlineSeconds(instance.getStartingDeadlineSeconds());
+        this.withSuccessfulJobsHistoryLimit(instance.getSuccessfulJobsHistoryLimit());
+        this.withSuspend(instance.getSuspend());
+        this.withAdditionalProperties(instance.getAdditionalProperties());
+    }
+  }
+  
+  public JobTemplateNested<A> editJobTemplate() {
+    return this.withNewJobTemplateLike(Optional.ofNullable(this.buildJobTemplate()).orElse(null));
+  }
+  
+  public JobTemplateNested<A> editOrNewJobTemplate() {
+    return this.withNewJobTemplateLike(Optional.ofNullable(this.buildJobTemplate()).orElse(new JobTemplateSpecBuilder().build()));
+  }
+  
+  public JobTemplateNested<A> editOrNewJobTemplateLike(JobTemplateSpec item) {
+    return this.withNewJobTemplateLike(Optional.ofNullable(this.buildJobTemplate()).orElse(item));
+  }
+  
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || this.getClass() != o.getClass()) {
+      return false;
+    }
+    if (!(super.equals(o))) {
+      return false;
+    }
+    CronJobSpecFluent that = (CronJobSpecFluent) o;
+    if (!(Objects.equals(concurrencyPolicy, that.concurrencyPolicy))) {
+      return false;
+    }
+    if (!(Objects.equals(failedJobsHistoryLimit, that.failedJobsHistoryLimit))) {
+      return false;
+    }
+    if (!(Objects.equals(jobTemplate, that.jobTemplate))) {
+      return false;
+    }
+    if (!(Objects.equals(schedule, that.schedule))) {
+      return false;
+    }
+    if (!(Objects.equals(startingDeadlineSeconds, that.startingDeadlineSeconds))) {
+      return false;
+    }
+    if (!(Objects.equals(successfulJobsHistoryLimit, that.successfulJobsHistoryLimit))) {
+      return false;
+    }
+    if (!(Objects.equals(suspend, that.suspend))) {
+      return false;
+    }
+    if (!(Objects.equals(additionalProperties, that.additionalProperties))) {
+      return false;
+    }
+    return true;
+  }
+  
+  public Map<String,Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
+  
+  public String getConcurrencyPolicy() {
+    return this.concurrencyPolicy;
+  }
+  
+  public Integer getFailedJobsHistoryLimit() {
+    return this.failedJobsHistoryLimit;
+  }
+  
+  public String getSchedule() {
+    return this.schedule;
+  }
+  
+  public Long getStartingDeadlineSeconds() {
+    return this.startingDeadlineSeconds;
+  }
+  
+  public Integer getSuccessfulJobsHistoryLimit() {
+    return this.successfulJobsHistoryLimit;
+  }
+  
+  public Boolean getSuspend() {
+    return this.suspend;
+  }
+  
+  public boolean hasAdditionalProperties() {
+    return this.additionalProperties != null;
+  }
+  
+  public boolean hasConcurrencyPolicy() {
+    return this.concurrencyPolicy != null;
+  }
+  
+  public boolean hasFailedJobsHistoryLimit() {
+    return this.failedJobsHistoryLimit != null;
+  }
+  
+  public boolean hasJobTemplate() {
+    return this.jobTemplate != null;
+  }
+  
+  public boolean hasSchedule() {
+    return this.schedule != null;
+  }
+  
+  public boolean hasStartingDeadlineSeconds() {
+    return this.startingDeadlineSeconds != null;
+  }
+  
+  public boolean hasSuccessfulJobsHistoryLimit() {
+    return this.successfulJobsHistoryLimit != null;
+  }
+  
+  public boolean hasSuspend() {
+    return this.suspend != null;
+  }
+  
+  public int hashCode() {
+    return Objects.hash(concurrencyPolicy, failedJobsHistoryLimit, jobTemplate, schedule, startingDeadlineSeconds, successfulJobsHistoryLimit, suspend, additionalProperties);
+  }
+  
+  public A removeFromAdditionalProperties(String key) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (key != null && this.additionalProperties != null) {
+      this.additionalProperties.remove(key);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (map != null) {
+      for (Object key : map.keySet()) {
+        if (this.additionalProperties != null) {
+          this.additionalProperties.remove(key);
+        }
+      }
+    }
+    return (A) this;
+  }
+  
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+    if (!(concurrencyPolicy == null)) {
+        sb.append("concurrencyPolicy:");
+        sb.append(concurrencyPolicy);
+        sb.append(",");
+    }
+    if (!(failedJobsHistoryLimit == null)) {
+        sb.append("failedJobsHistoryLimit:");
+        sb.append(failedJobsHistoryLimit);
+        sb.append(",");
+    }
+    if (!(jobTemplate == null)) {
+        sb.append("jobTemplate:");
+        sb.append(jobTemplate);
+        sb.append(",");
+    }
+    if (!(schedule == null)) {
+        sb.append("schedule:");
+        sb.append(schedule);
+        sb.append(",");
+    }
+    if (!(startingDeadlineSeconds == null)) {
+        sb.append("startingDeadlineSeconds:");
+        sb.append(startingDeadlineSeconds);
+        sb.append(",");
+    }
+    if (!(successfulJobsHistoryLimit == null)) {
+        sb.append("successfulJobsHistoryLimit:");
+        sb.append(successfulJobsHistoryLimit);
+        sb.append(",");
+    }
+    if (!(suspend == null)) {
+        sb.append("suspend:");
+        sb.append(suspend);
+        sb.append(",");
+    }
+    if (!(additionalProperties == null) && !(additionalProperties.isEmpty())) {
+        sb.append("additionalProperties:");
+        sb.append(additionalProperties);
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+  
+  public <K,V>A withAdditionalProperties(Map<String,Object> additionalProperties) {
+    if (additionalProperties == null) {
+      this.additionalProperties = null;
+    } else {
+      this.additionalProperties = new LinkedHashMap(additionalProperties);
+    }
+    return (A) this;
+  }
+  
+  public A withConcurrencyPolicy(String concurrencyPolicy) {
+    this.concurrencyPolicy = concurrencyPolicy;
+    return (A) this;
+  }
+  
+  public A withFailedJobsHistoryLimit(Integer failedJobsHistoryLimit) {
+    this.failedJobsHistoryLimit = failedJobsHistoryLimit;
+    return (A) this;
+  }
+  
+  public A withJobTemplate(JobTemplateSpec jobTemplate) {
+    this._visitables.remove("jobTemplate");
+    if (jobTemplate != null) {
+        this.jobTemplate = new JobTemplateSpecBuilder(jobTemplate);
+        this._visitables.get("jobTemplate").add(this.jobTemplate);
+    } else {
+        this.jobTemplate = null;
+        this._visitables.get("jobTemplate").remove(this.jobTemplate);
+    }
+    return (A) this;
+  }
+  
+  public JobTemplateNested<A> withNewJobTemplate() {
+    return new JobTemplateNested(null);
+  }
+  
+  public JobTemplateNested<A> withNewJobTemplateLike(JobTemplateSpec item) {
+    return new JobTemplateNested(item);
+  }
+  
+  public A withSchedule(String schedule) {
+    this.schedule = schedule;
+    return (A) this;
+  }
+  
+  public A withStartingDeadlineSeconds(Long startingDeadlineSeconds) {
+    this.startingDeadlineSeconds = startingDeadlineSeconds;
+    return (A) this;
+  }
+  
+  public A withSuccessfulJobsHistoryLimit(Integer successfulJobsHistoryLimit) {
+    this.successfulJobsHistoryLimit = successfulJobsHistoryLimit;
+    return (A) this;
+  }
+  
+  public A withSuspend() {
+    return withSuspend(true);
+  }
+  
+  public A withSuspend(Boolean suspend) {
+    this.suspend = suspend;
+    return (A) this;
+  }
+  public class JobTemplateNested<N> extends JobTemplateSpecFluent<JobTemplateNested<N>> implements Nested<N>{
+  
+    JobTemplateSpecBuilder builder;
+  
+    JobTemplateNested(JobTemplateSpec item) {
+      this.builder = new JobTemplateSpecBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) CronJobSpecFluent.this.withJobTemplate(builder.build());
+    }
+    
+    public N endJobTemplate() {
+      return and();
+    }
+    
+  }
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1beta1/CronJobStatusBuilder.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1beta1/CronJobStatusBuilder.java
@@ -1,0 +1,33 @@
+package io.fabric8.kubernetes.api.model.batch.v1beta1;
+
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
+import java.lang.Object;
+public class CronJobStatusBuilder extends CronJobStatusFluent<CronJobStatusBuilder> implements VisitableBuilder<CronJobStatus,CronJobStatusBuilder>{
+
+  CronJobStatusFluent<?> fluent;
+
+  public CronJobStatusBuilder() {
+    this(new CronJobStatus());
+  }
+  
+  public CronJobStatusBuilder(CronJobStatusFluent<?> fluent) {
+    this(fluent, new CronJobStatus());
+  }
+  
+  public CronJobStatusBuilder(CronJobStatus instance) {
+    this.fluent = this;
+    this.copyInstance(instance);
+  }
+  
+  public CronJobStatusBuilder(CronJobStatusFluent<?> fluent,CronJobStatus instance) {
+    this.fluent = fluent;
+    fluent.copyInstance(instance);
+  }
+
+  public CronJobStatus build() {
+    CronJobStatus buildable = new CronJobStatus(fluent.buildActive(), fluent.getLastScheduleTime(), fluent.getLastSuccessfulTime());
+    buildable.setAdditionalProperties(fluent.getAdditionalProperties());
+    return buildable;
+  }
+  
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1beta1/CronJobStatusFluent.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1beta1/CronJobStatusFluent.java
@@ -1,0 +1,419 @@
+package io.fabric8.kubernetes.api.model.batch.v1beta1;
+
+import io.fabric8.kubernetes.api.builder.BaseFluent;
+import io.fabric8.kubernetes.api.builder.Nested;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectReferenceBuilder;
+import io.fabric8.kubernetes.api.model.ObjectReferenceFluent;
+import java.lang.Object;
+import java.lang.RuntimeException;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.lang.SuppressWarnings;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * Generated
+ */
+@SuppressWarnings("unchecked")
+public class CronJobStatusFluent<A extends io.fabric8.kubernetes.api.model.batch.v1beta1.CronJobStatusFluent<A>> extends BaseFluent<A>{
+
+  private ArrayList<ObjectReferenceBuilder> active = new ArrayList<ObjectReferenceBuilder>();
+  private Map<String,Object> additionalProperties;
+  private String lastScheduleTime;
+  private String lastSuccessfulTime;
+
+  public CronJobStatusFluent() {
+  }
+  
+  public CronJobStatusFluent(CronJobStatus instance) {
+    this.copyInstance(instance);
+  }
+
+  public A addAllToActive(Collection<ObjectReference> items) {
+    if (this.active == null) {
+      this.active = new ArrayList();
+    }
+    for (ObjectReference item : items) {
+        ObjectReferenceBuilder builder = new ObjectReferenceBuilder(item);
+        _visitables.get("active").add(builder);
+        this.active.add(builder);
+    }
+    return (A) this;
+  }
+  
+  public ActiveNested<A> addNewActive() {
+    return new ActiveNested(-1, null);
+  }
+  
+  public ActiveNested<A> addNewActiveLike(ObjectReference item) {
+    return new ActiveNested(-1, item);
+  }
+  
+  public A addToActive(ObjectReference... items) {
+    if (this.active == null) {
+      this.active = new ArrayList();
+    }
+    for (ObjectReference item : items) {
+        ObjectReferenceBuilder builder = new ObjectReferenceBuilder(item);
+        _visitables.get("active").add(builder);
+        this.active.add(builder);
+    }
+    return (A) this;
+  }
+  
+  public A addToActive(int index,ObjectReference item) {
+    if (this.active == null) {
+      this.active = new ArrayList();
+    }
+    ObjectReferenceBuilder builder = new ObjectReferenceBuilder(item);
+    if (index < 0 || index >= active.size()) {
+        _visitables.get("active").add(builder);
+        active.add(builder);
+    } else {
+        _visitables.get("active").add(builder);
+        active.add(index, builder);
+    }
+    return (A) this;
+  }
+  
+  public A addToAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null && map != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (map != null) {
+      this.additionalProperties.putAll(map);
+    }
+    return (A) this;
+  }
+  
+  public A addToAdditionalProperties(String key,Object value) {
+    if (this.additionalProperties == null && key != null && value != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (key != null && value != null) {
+      this.additionalProperties.put(key, value);
+    }
+    return (A) this;
+  }
+  
+  public List<ObjectReference> buildActive() {
+    return this.active != null ? build(active) : null;
+  }
+  
+  public ObjectReference buildActive(int index) {
+    return this.active.get(index).build();
+  }
+  
+  public ObjectReference buildFirstActive() {
+    return this.active.get(0).build();
+  }
+  
+  public ObjectReference buildLastActive() {
+    return this.active.get(active.size() - 1).build();
+  }
+  
+  public ObjectReference buildMatchingActive(Predicate<ObjectReferenceBuilder> predicate) {
+      for (ObjectReferenceBuilder item : active) {
+        if (predicate.test(item)) {
+          return item.build();
+        }
+      }
+      return null;
+  }
+  
+  protected void copyInstance(CronJobStatus instance) {
+    instance = instance != null ? instance : new CronJobStatus();
+    if (instance != null) {
+        this.withActive(instance.getActive());
+        this.withLastScheduleTime(instance.getLastScheduleTime());
+        this.withLastSuccessfulTime(instance.getLastSuccessfulTime());
+        this.withAdditionalProperties(instance.getAdditionalProperties());
+    }
+  }
+  
+  public ActiveNested<A> editActive(int index) {
+    if (active.size() <= index) {
+      throw new RuntimeException(String.format("Can't edit %s. Index exceeds size.", "active"));
+    }
+    return this.setNewActiveLike(index, this.buildActive(index));
+  }
+  
+  public ActiveNested<A> editFirstActive() {
+    if (active.size() == 0) {
+      throw new RuntimeException(String.format("Can't edit first %s. The list is empty.", "active"));
+    }
+    return this.setNewActiveLike(0, this.buildActive(0));
+  }
+  
+  public ActiveNested<A> editLastActive() {
+    int index = active.size() - 1;
+    if (index < 0) {
+      throw new RuntimeException(String.format("Can't edit last %s. The list is empty.", "active"));
+    }
+    return this.setNewActiveLike(index, this.buildActive(index));
+  }
+  
+  public ActiveNested<A> editMatchingActive(Predicate<ObjectReferenceBuilder> predicate) {
+    int index = -1;
+    for (int i = 0;i < active.size();i++) {
+      if (predicate.test(active.get(i))) {
+          index = i;
+          break;
+      }
+    }
+    if (index < 0) {
+      throw new RuntimeException(String.format("Can't edit matching %s. No match found.", "active"));
+    }
+    return this.setNewActiveLike(index, this.buildActive(index));
+  }
+  
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || this.getClass() != o.getClass()) {
+      return false;
+    }
+    if (!(super.equals(o))) {
+      return false;
+    }
+    CronJobStatusFluent that = (CronJobStatusFluent) o;
+    if (!(Objects.equals(active, that.active))) {
+      return false;
+    }
+    if (!(Objects.equals(lastScheduleTime, that.lastScheduleTime))) {
+      return false;
+    }
+    if (!(Objects.equals(lastSuccessfulTime, that.lastSuccessfulTime))) {
+      return false;
+    }
+    if (!(Objects.equals(additionalProperties, that.additionalProperties))) {
+      return false;
+    }
+    return true;
+  }
+  
+  public Map<String,Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
+  
+  public String getLastScheduleTime() {
+    return this.lastScheduleTime;
+  }
+  
+  public String getLastSuccessfulTime() {
+    return this.lastSuccessfulTime;
+  }
+  
+  public boolean hasActive() {
+    return this.active != null && !(this.active.isEmpty());
+  }
+  
+  public boolean hasAdditionalProperties() {
+    return this.additionalProperties != null;
+  }
+  
+  public boolean hasLastScheduleTime() {
+    return this.lastScheduleTime != null;
+  }
+  
+  public boolean hasLastSuccessfulTime() {
+    return this.lastSuccessfulTime != null;
+  }
+  
+  public boolean hasMatchingActive(Predicate<ObjectReferenceBuilder> predicate) {
+      for (ObjectReferenceBuilder item : active) {
+        if (predicate.test(item)) {
+          return true;
+        }
+      }
+      return false;
+  }
+  
+  public int hashCode() {
+    return Objects.hash(active, lastScheduleTime, lastSuccessfulTime, additionalProperties);
+  }
+  
+  public A removeAllFromActive(Collection<ObjectReference> items) {
+    if (this.active == null) {
+      return (A) this;
+    }
+    for (ObjectReference item : items) {
+        ObjectReferenceBuilder builder = new ObjectReferenceBuilder(item);
+        _visitables.get("active").remove(builder);
+        this.active.remove(builder);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromActive(ObjectReference... items) {
+    if (this.active == null) {
+      return (A) this;
+    }
+    for (ObjectReference item : items) {
+        ObjectReferenceBuilder builder = new ObjectReferenceBuilder(item);
+        _visitables.get("active").remove(builder);
+        this.active.remove(builder);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(String key) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (key != null && this.additionalProperties != null) {
+      this.additionalProperties.remove(key);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (map != null) {
+      for (Object key : map.keySet()) {
+        if (this.additionalProperties != null) {
+          this.additionalProperties.remove(key);
+        }
+      }
+    }
+    return (A) this;
+  }
+  
+  public A removeMatchingFromActive(Predicate<ObjectReferenceBuilder> predicate) {
+    if (active == null) {
+      return (A) this;
+    }
+    Iterator<ObjectReferenceBuilder> each = active.iterator();
+    List visitables = _visitables.get("active");
+    while (each.hasNext()) {
+        ObjectReferenceBuilder builder = each.next();
+        if (predicate.test(builder)) {
+            visitables.remove(builder);
+            each.remove();
+        }
+    }
+    return (A) this;
+  }
+  
+  public ActiveNested<A> setNewActiveLike(int index,ObjectReference item) {
+    return new ActiveNested(index, item);
+  }
+  
+  public A setToActive(int index,ObjectReference item) {
+    if (this.active == null) {
+      this.active = new ArrayList();
+    }
+    ObjectReferenceBuilder builder = new ObjectReferenceBuilder(item);
+    if (index < 0 || index >= active.size()) {
+        _visitables.get("active").add(builder);
+        active.add(builder);
+    } else {
+        _visitables.get("active").add(builder);
+        active.set(index, builder);
+    }
+    return (A) this;
+  }
+  
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+    if (!(active == null) && !(active.isEmpty())) {
+        sb.append("active:");
+        sb.append(active);
+        sb.append(",");
+    }
+    if (!(lastScheduleTime == null)) {
+        sb.append("lastScheduleTime:");
+        sb.append(lastScheduleTime);
+        sb.append(",");
+    }
+    if (!(lastSuccessfulTime == null)) {
+        sb.append("lastSuccessfulTime:");
+        sb.append(lastSuccessfulTime);
+        sb.append(",");
+    }
+    if (!(additionalProperties == null) && !(additionalProperties.isEmpty())) {
+        sb.append("additionalProperties:");
+        sb.append(additionalProperties);
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+  
+  public A withActive(List<ObjectReference> active) {
+    if (this.active != null) {
+      this._visitables.get("active").clear();
+    }
+    if (active != null) {
+        this.active = new ArrayList();
+        for (ObjectReference item : active) {
+          this.addToActive(item);
+        }
+    } else {
+      this.active = null;
+    }
+    return (A) this;
+  }
+  
+  public A withActive(ObjectReference... active) {
+    if (this.active != null) {
+        this.active.clear();
+        _visitables.remove("active");
+    }
+    if (active != null) {
+      for (ObjectReference item : active) {
+        this.addToActive(item);
+      }
+    }
+    return (A) this;
+  }
+  
+  public <K,V>A withAdditionalProperties(Map<String,Object> additionalProperties) {
+    if (additionalProperties == null) {
+      this.additionalProperties = null;
+    } else {
+      this.additionalProperties = new LinkedHashMap(additionalProperties);
+    }
+    return (A) this;
+  }
+  
+  public A withLastScheduleTime(String lastScheduleTime) {
+    this.lastScheduleTime = lastScheduleTime;
+    return (A) this;
+  }
+  
+  public A withLastSuccessfulTime(String lastSuccessfulTime) {
+    this.lastSuccessfulTime = lastSuccessfulTime;
+    return (A) this;
+  }
+  public class ActiveNested<N> extends ObjectReferenceFluent<ActiveNested<N>> implements Nested<N>{
+  
+    ObjectReferenceBuilder builder;
+    int index;
+  
+    ActiveNested(int index,ObjectReference item) {
+      this.index = index;
+      this.builder = new ObjectReferenceBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) CronJobStatusFluent.this.setToActive(index, builder.build());
+    }
+    
+    public N endActive() {
+      return and();
+    }
+    
+  }
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1beta1/JobTemplateSpecBuilder.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1beta1/JobTemplateSpecBuilder.java
@@ -1,0 +1,33 @@
+package io.fabric8.kubernetes.api.model.batch.v1beta1;
+
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
+import java.lang.Object;
+public class JobTemplateSpecBuilder extends JobTemplateSpecFluent<JobTemplateSpecBuilder> implements VisitableBuilder<JobTemplateSpec,JobTemplateSpecBuilder>{
+
+  JobTemplateSpecFluent<?> fluent;
+
+  public JobTemplateSpecBuilder() {
+    this(new JobTemplateSpec());
+  }
+  
+  public JobTemplateSpecBuilder(JobTemplateSpecFluent<?> fluent) {
+    this(fluent, new JobTemplateSpec());
+  }
+  
+  public JobTemplateSpecBuilder(JobTemplateSpec instance) {
+    this.fluent = this;
+    this.copyInstance(instance);
+  }
+  
+  public JobTemplateSpecBuilder(JobTemplateSpecFluent<?> fluent,JobTemplateSpec instance) {
+    this.fluent = fluent;
+    fluent.copyInstance(instance);
+  }
+
+  public JobTemplateSpec build() {
+    JobTemplateSpec buildable = new JobTemplateSpec(fluent.buildMetadata(), fluent.buildSpec());
+    buildable.setAdditionalProperties(fluent.getAdditionalProperties());
+    return buildable;
+  }
+  
+}

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1beta1/JobTemplateSpecFluent.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated-builders/java/io/fabric8/kubernetes/api/model/batch/v1beta1/JobTemplateSpecFluent.java
@@ -1,0 +1,268 @@
+package io.fabric8.kubernetes.api.model.batch.v1beta1;
+
+import io.fabric8.kubernetes.api.builder.BaseFluent;
+import io.fabric8.kubernetes.api.builder.Nested;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMetaFluent;
+import io.fabric8.kubernetes.api.model.batch.v1.JobSpec;
+import io.fabric8.kubernetes.api.model.batch.v1.JobSpecBuilder;
+import io.fabric8.kubernetes.api.model.batch.v1.JobSpecFluent;
+import java.lang.Object;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.lang.SuppressWarnings;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Generated
+ */
+@SuppressWarnings("unchecked")
+public class JobTemplateSpecFluent<A extends io.fabric8.kubernetes.api.model.batch.v1beta1.JobTemplateSpecFluent<A>> extends BaseFluent<A>{
+
+  private Map<String,Object> additionalProperties;
+  private ObjectMetaBuilder metadata;
+  private JobSpecBuilder spec;
+
+  public JobTemplateSpecFluent() {
+  }
+  
+  public JobTemplateSpecFluent(JobTemplateSpec instance) {
+    this.copyInstance(instance);
+  }
+
+  public A addToAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null && map != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (map != null) {
+      this.additionalProperties.putAll(map);
+    }
+    return (A) this;
+  }
+  
+  public A addToAdditionalProperties(String key,Object value) {
+    if (this.additionalProperties == null && key != null && value != null) {
+      this.additionalProperties = new LinkedHashMap();
+    }
+    if (key != null && value != null) {
+      this.additionalProperties.put(key, value);
+    }
+    return (A) this;
+  }
+  
+  public ObjectMeta buildMetadata() {
+    return this.metadata != null ? this.metadata.build() : null;
+  }
+  
+  public JobSpec buildSpec() {
+    return this.spec != null ? this.spec.build() : null;
+  }
+  
+  protected void copyInstance(JobTemplateSpec instance) {
+    instance = instance != null ? instance : new JobTemplateSpec();
+    if (instance != null) {
+        this.withMetadata(instance.getMetadata());
+        this.withSpec(instance.getSpec());
+        this.withAdditionalProperties(instance.getAdditionalProperties());
+    }
+  }
+  
+  public MetadataNested<A> editMetadata() {
+    return this.withNewMetadataLike(Optional.ofNullable(this.buildMetadata()).orElse(null));
+  }
+  
+  public MetadataNested<A> editOrNewMetadata() {
+    return this.withNewMetadataLike(Optional.ofNullable(this.buildMetadata()).orElse(new ObjectMetaBuilder().build()));
+  }
+  
+  public MetadataNested<A> editOrNewMetadataLike(ObjectMeta item) {
+    return this.withNewMetadataLike(Optional.ofNullable(this.buildMetadata()).orElse(item));
+  }
+  
+  public SpecNested<A> editOrNewSpec() {
+    return this.withNewSpecLike(Optional.ofNullable(this.buildSpec()).orElse(new JobSpecBuilder().build()));
+  }
+  
+  public SpecNested<A> editOrNewSpecLike(JobSpec item) {
+    return this.withNewSpecLike(Optional.ofNullable(this.buildSpec()).orElse(item));
+  }
+  
+  public SpecNested<A> editSpec() {
+    return this.withNewSpecLike(Optional.ofNullable(this.buildSpec()).orElse(null));
+  }
+  
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || this.getClass() != o.getClass()) {
+      return false;
+    }
+    if (!(super.equals(o))) {
+      return false;
+    }
+    JobTemplateSpecFluent that = (JobTemplateSpecFluent) o;
+    if (!(Objects.equals(metadata, that.metadata))) {
+      return false;
+    }
+    if (!(Objects.equals(spec, that.spec))) {
+      return false;
+    }
+    if (!(Objects.equals(additionalProperties, that.additionalProperties))) {
+      return false;
+    }
+    return true;
+  }
+  
+  public Map<String,Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
+  
+  public boolean hasAdditionalProperties() {
+    return this.additionalProperties != null;
+  }
+  
+  public boolean hasMetadata() {
+    return this.metadata != null;
+  }
+  
+  public boolean hasSpec() {
+    return this.spec != null;
+  }
+  
+  public int hashCode() {
+    return Objects.hash(metadata, spec, additionalProperties);
+  }
+  
+  public A removeFromAdditionalProperties(String key) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (key != null && this.additionalProperties != null) {
+      this.additionalProperties.remove(key);
+    }
+    return (A) this;
+  }
+  
+  public A removeFromAdditionalProperties(Map<String,Object> map) {
+    if (this.additionalProperties == null) {
+      return (A) this;
+    }
+    if (map != null) {
+      for (Object key : map.keySet()) {
+        if (this.additionalProperties != null) {
+          this.additionalProperties.remove(key);
+        }
+      }
+    }
+    return (A) this;
+  }
+  
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+    if (!(metadata == null)) {
+        sb.append("metadata:");
+        sb.append(metadata);
+        sb.append(",");
+    }
+    if (!(spec == null)) {
+        sb.append("spec:");
+        sb.append(spec);
+        sb.append(",");
+    }
+    if (!(additionalProperties == null) && !(additionalProperties.isEmpty())) {
+        sb.append("additionalProperties:");
+        sb.append(additionalProperties);
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+  
+  public <K,V>A withAdditionalProperties(Map<String,Object> additionalProperties) {
+    if (additionalProperties == null) {
+      this.additionalProperties = null;
+    } else {
+      this.additionalProperties = new LinkedHashMap(additionalProperties);
+    }
+    return (A) this;
+  }
+  
+  public A withMetadata(ObjectMeta metadata) {
+    this._visitables.remove("metadata");
+    if (metadata != null) {
+        this.metadata = new ObjectMetaBuilder(metadata);
+        this._visitables.get("metadata").add(this.metadata);
+    } else {
+        this.metadata = null;
+        this._visitables.get("metadata").remove(this.metadata);
+    }
+    return (A) this;
+  }
+  
+  public MetadataNested<A> withNewMetadata() {
+    return new MetadataNested(null);
+  }
+  
+  public MetadataNested<A> withNewMetadataLike(ObjectMeta item) {
+    return new MetadataNested(item);
+  }
+  
+  public SpecNested<A> withNewSpec() {
+    return new SpecNested(null);
+  }
+  
+  public SpecNested<A> withNewSpecLike(JobSpec item) {
+    return new SpecNested(item);
+  }
+  
+  public A withSpec(JobSpec spec) {
+    this._visitables.remove("spec");
+    if (spec != null) {
+        this.spec = new JobSpecBuilder(spec);
+        this._visitables.get("spec").add(this.spec);
+    } else {
+        this.spec = null;
+        this._visitables.get("spec").remove(this.spec);
+    }
+    return (A) this;
+  }
+  public class MetadataNested<N> extends ObjectMetaFluent<MetadataNested<N>> implements Nested<N>{
+  
+    ObjectMetaBuilder builder;
+  
+    MetadataNested(ObjectMeta item) {
+      this.builder = new ObjectMetaBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) JobTemplateSpecFluent.this.withMetadata(builder.build());
+    }
+    
+    public N endMetadata() {
+      return and();
+    }
+    
+  }
+  public class SpecNested<N> extends JobSpecFluent<SpecNested<N>> implements Nested<N>{
+  
+    JobSpecBuilder builder;
+  
+    SpecNested(JobSpec item) {
+      this.builder = new JobSpecBuilder(this, item);
+    }
+  
+    public N and() {
+      return (N) JobTemplateSpecFluent.this.withSpec(builder.build());
+    }
+    
+    public N endSpec() {
+      return and();
+    }
+    
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,7 @@
     <javadoc.sourcepath>
       ${project.basedir}/src/main/java;
       ${project.basedir}/src/generated/java;
+      ${project.basedir}/src/generated-builders/java;
       ${project.build.sourceDirectory};
       ${project.build.directory}/generated-sources/annotations;
     </javadoc.sourcepath>
@@ -1268,6 +1269,7 @@
                 <exclude>license.txt</exclude>
                 <exclude>**/test-kubeconfig</exclude>
                 <exclude>**/src/generated/java/**/*</exclude>
+                <exclude>**/src/generated-builders/java/**/*</exclude>
                 <exclude>**/io/fabric8/kubernetes/client/lib/**/*.java</exclude>
                 <exclude>kubernetes-model/vendor/**/*</exclude>
                 <exclude>kubernetes-model/generate</exclude>
@@ -1623,7 +1625,7 @@
         <sonar.links.ci>https://github.com/fabric8io/kubernetes-client/actions</sonar.links.ci>
         <sonar.links.scm>https://github.com/fabric8io/kubernetes-client</sonar.links.scm>
         <sonar.links.issue>https://github.com/fabric8io/kubernetes-client/issues</sonar.links.issue>
-        <sonar.exclusions>**/src/generated/java/**/*</sonar.exclusions>
+        <sonar.exclusions>**/src/generated/java/**/*,**/src/generated-builders/java/**/*</sonar.exclusions>
         <sonar.coverage.exclusions>**/kubernetes-examples/**/*,**/extensions/**/examples/**/*</sonar.coverage.exclusions>
         <karaf.itest.skip>true</karaf.itest.skip>
       </properties>


### PR DESCRIPTION
## Summary

Reference proof-of-concept for #5622, scoped to a single module (`kubernetes-model-batch`): snapshot sundrio's annotation-processor output (`*Builder.java` / `*Fluent.java`) into committed source and skip sundrio APT in the default build, so the Builders/Fluents compile as plain javac source. This removes the per-build APT round-trip that dominates model-module build time.

This is an independent take from #7979 and deliberately avoids the antrun copy-with-filter that PR uses. The key finding: with the reactor building dependencies first, sundrio's APT already emits **only the module's own Builders** (no shallow "shadow" copies of referenced types like `PodTemplateSpecFluent`), so no filtering and no copy step are needed.

## Mechanism

A dedicated, committed source root `src/generated-builders/java` holds the Builders/Fluents, kept separate from the POJOs in `src/generated/java`:

- **Default build** (no `-Pgenerate`): `maven-compiler-plugin` names only the Lombok processors, so sundrio APT does not run and the committed Builders compile as plain source. Lombok still runs, keeping `equals`/`hashCode`/`toString`.
- **`-Pgenerate`** (via `make generate-model`): the compiler's `generatedSourcesDirectory` points at `src/generated-builders/java`, and it names the Lombok + sundrio processors so they load from the **compile classpath** — sundrio then resolves referenced Builders from dependency jars rather than emitting shallow shadow copies.

`build-helper` adds `src/generated-builders/java` as a source root. Supporting config (license excludes, `sonar.exclusions`, `javadoc.sourcepath`, `.gitattributes`, and the `generate-model.yml` drift guard) is extended to the new directory.

## Why a separate directory (vs. writing into `src/generated/java`)

`maven-compiler-plugin` deletes its `generatedSourcesDirectory` before annotation processing. Pointing it at `src/generated/java` deletes the POJOs that are sundrio's input. A separate directory makes that wipe land on exactly the Builders — which is what you want on a regen — while the POJOs are untouched. The same wipe makes regeneration idempotent and removes orphaned Builders when a POJO is deleted (verified with a removal test).

## Evidence (local, `kubernetes-model-batch`)

- `-Pgenerate` regenerates 44 Builders/Fluents, **byte-identical** to the previous APT output, **zero** shadow files.
- Default build runs **zero** sundrio generation, produces a jar with a **byte-identical class list**, and the module test passes.
- `license:check` and `spotless:check` pass.

## Corrections vs. the issue's original plan

- The issue's `<proc>none</proc>` would disable Lombok too, silently dropping `equals`/`hashCode`/`toString`. The default build runs Lombok-only instead.
- No copy/antrun and no Makefile stale-file cleanup are needed: the compiler's `generatedSourcesDirectory` wipe plus the openapi generator's own `deleteDirectory` of `src/generated/java` handle staleness.

## Scope and follow-ups (tracked on #5622)

This is a single-module POC. Lifting the wiring into the model parent pom for all model modules (atomically with committing their Builders), the modules with hand-written `@Buildable` sources, a parent-level `generate` profile, and the option to make the default-build processor selection less brittle (`annotationProcessorPaths` = lombok only) are follow-ups described on the issue.

## Commits

1. **config** — build wiring + license/sonar/javadoc/`.gitattributes`/CI-guard.
2. **generated** — the 44 committed Builder/Fluent files.
