### PR TITLE
fix(mockwebserver): upgrade to WebSocket synchronously to avoid "Request has already been read"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 7.9-SNAPSHOT
 
 #### Bugs
+* Fix #7983: (mockwebserver) WebSocket upgrades are now performed synchronously from the Vert.x request handler instead of from the asynchronous `HttpServerRequest#body()` callback. Deferring the upgrade let the request end event be processed first, so `HttpServerRequest#toWebSocket()` intermittently threw `IllegalStateException: Request has already been read` and the upgrade was lost (surfacing as flaky `exec`/`attach` mock-server tests). Upgrade requests carry no body, so they are detected via the `Upgrade` header and upgraded before the request is read; the asynchronous path is unchanged for regular HTTP requests
 * Fix #7955: (java-generator) Malicious CRD schema values can no longer inject executable code into the generated Java sources. Schema-controlled values (enum values, CRD group/version/names, property names, descriptions and defaults) are emitted as fully escaped Java string literals, so a value carrying a Unicode-escaped quote cannot break out of its literal once `javac` decodes it. As a defense in depth, each generated class is also re-parsed and structurally validated before it is written (with Java Unicode escape preprocessing enabled to match `javac`), aborting generation on any residual structural mismatch
 
 #### Improvements

--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/vertx/HttpServerRequestHandler.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/vertx/HttpServerRequestHandler.java
@@ -48,6 +48,25 @@ public abstract class HttpServerRequestHandler implements Handler<HttpServerRequ
         event.response().setStatusCode(500).setStatusMessage(err.getMessage()).send();
       }
     };
+    // A WebSocket upgrade must be performed synchronously from within the request handler, before
+    // the request is read. Reading the (empty) body first and upgrading from the asynchronous body
+    // callback makes Vert.x's HttpServerRequest#toWebSocket() intermittently throw
+    // "Request has already been read" once the request end event has been processed on the event
+    // loop. WebSocket upgrade requests never carry a body, so there is nothing to read here.
+    if (isWebSocketUpgrade(event)) {
+      final RecordedRequest request = toRecordedRequest(event, null);
+      final MockResponse mockResponse = onHttpRequest(request);
+      if (mockResponse.getWebSocketListener() != null) {
+        event.toWebSocket()
+            .onFailure(exceptionHandler)
+            .onSuccess(new ServerWebSocketHandler(request, mockResponse));
+        return;
+      }
+      // Not a WebSocket response after all; reply as a standard HTTP response.
+      event.resume();
+      sendResponse(event, mockResponse);
+      return;
+    }
     event.resume();
     final Future<io.vertx.core.buffer.Buffer> body;
     if (hasBody(event)) {
@@ -57,12 +76,7 @@ public abstract class HttpServerRequestHandler implements Handler<HttpServerRequ
     }
     body.onFailure(exceptionHandler);
     body.onSuccess(bodyBuffer -> {
-      final RecordedRequest request = new RecordedRequest(
-          event.version().alpnName().toUpperCase(Locale.ROOT),
-          HttpMethod.fromVertx(event.method()),
-          event.uri(),
-          Headers.builder().addAll(event.headers()).build(),
-          new io.fabric8.mockwebserver.http.Buffer(bodyBuffer == null ? null : bodyBuffer.getBytes()));
+      final RecordedRequest request = toRecordedRequest(event, bodyBuffer);
       final MockResponse mockResponse = onHttpRequest(request);
       // WebSocket
       if (mockResponse.getWebSocketListener() != null) {
@@ -72,24 +86,42 @@ public abstract class HttpServerRequestHandler implements Handler<HttpServerRequ
         return;
       }
       // Standard Http Response
-      final HttpServerResponse vertxResponse = event.response();
-      vertxResponse.setStatusCode(mockResponse.code());
-      mockResponse.getHeaders().toMultimap().forEach((key, values) -> vertxResponse.headers().add(key, values));
-      if (mockResponse.getBody() != null && mockResponse.getBody().size() > 0) {
-        if (!vertxResponse.headers().contains(TRANSFER_ENCODING)) {
-          vertxResponse.headers().add(CONTENT_LENGTH, String.valueOf(mockResponse.getBody().size()));
-        }
-        final io.vertx.core.buffer.Buffer toSend = io.vertx.core.buffer.Buffer.buffer(mockResponse.getBody().getBytes());
-        if (mockResponse.getBodyDelay() != null) {
-          vertx.setTimer(mockResponse.getBodyDelay().toMillis(), timerId -> vertxResponse.send(toSend));
-        } else {
-          vertxResponse.send(toSend);
-        }
-      } else {
-        vertxResponse.end();
-      }
+      sendResponse(event, mockResponse);
     });
 
+  }
+
+  private RecordedRequest toRecordedRequest(HttpServerRequest event, io.vertx.core.buffer.Buffer bodyBuffer) {
+    return new RecordedRequest(
+        event.version().alpnName().toUpperCase(Locale.ROOT),
+        HttpMethod.fromVertx(event.method()),
+        event.uri(),
+        Headers.builder().addAll(event.headers()).build(),
+        new io.fabric8.mockwebserver.http.Buffer(bodyBuffer == null ? null : bodyBuffer.getBytes()));
+  }
+
+  private void sendResponse(HttpServerRequest event, MockResponse mockResponse) {
+    final HttpServerResponse vertxResponse = event.response();
+    vertxResponse.setStatusCode(mockResponse.code());
+    mockResponse.getHeaders().toMultimap().forEach((key, values) -> vertxResponse.headers().add(key, values));
+    if (mockResponse.getBody() != null && mockResponse.getBody().size() > 0) {
+      if (!vertxResponse.headers().contains(TRANSFER_ENCODING)) {
+        vertxResponse.headers().add(CONTENT_LENGTH, String.valueOf(mockResponse.getBody().size()));
+      }
+      final io.vertx.core.buffer.Buffer toSend = io.vertx.core.buffer.Buffer.buffer(mockResponse.getBody().getBytes());
+      if (mockResponse.getBodyDelay() != null) {
+        vertx.setTimer(mockResponse.getBodyDelay().toMillis(), timerId -> vertxResponse.send(toSend));
+      } else {
+        vertxResponse.send(toSend);
+      }
+    } else {
+      vertxResponse.end();
+    }
+  }
+
+  private static boolean isWebSocketUpgrade(HttpServerRequest event) {
+    final String upgrade = event.getHeader("Upgrade");
+    return upgrade != null && upgrade.toLowerCase(Locale.ROOT).contains("websocket");
   }
 
   private static boolean hasBody(HttpServerRequest event) {

--- a/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/MockWebServerWebSocketTest.groovy
+++ b/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/MockWebServerWebSocketTest.groovy
@@ -22,6 +22,7 @@ import io.fabric8.mockwebserver.http.WebSocketListener
 import io.vertx.core.Vertx
 import io.vertx.core.buffer.Buffer
 import io.vertx.core.http.WebSocketClient
+import io.vertx.core.http.WebSocketConnectOptions
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
@@ -202,6 +203,38 @@ class MockWebServerWebSocketTest extends Specification {
 		then: "The close message should be the expected one"
 		receivedCode == 1000
 		receivedReason == "Normal closure"
+	}
+
+	def "Upgrades to WebSocket even when the request carries content headers"() {
+		given: "A WebSocketUpgrade expectation"
+		String receivedMessage = null
+		server.enqueue(new MockResponse().withWebSocketUpgrade(new WebSocketListener() {
+					@Override
+					void onMessage(WebSocket webSocket, String text) {
+						receivedMessage = text
+					}
+				}))
+		and: "A WebSocket request carrying a Content-Type header (previously routed through the async body reader)"
+		def options = new WebSocketConnectOptions()
+				.setHost(server.getHostName())
+				.setPort(server.port)
+				.setURI("/websocket")
+				.addHeader("Content-Type", "application/octet-stream")
+		def wsReq = wsClient.connect(options)
+		and: "An instance of PollingConditions"
+		def condition = new PollingConditions(timeout: 10)
+
+		when: "The request is sent and a text message is written"
+		wsReq.onSuccess { ws ->
+			ws.writeTextMessage("A text message from the client")
+		}
+
+		then: "The upgrade succeeds and the message is received"
+		condition.eventually {
+			assert wsReq.isComplete()
+			assert wsReq.succeeded()
+			assert receivedMessage == "A text message from the client"
+		}
 	}
 
 	def "Sends WebSocket onClose messages to client"() {


### PR DESCRIPTION
## Description

The Vert.x-based mock web server (`io.fabric8.mockwebserver.vertx.HttpServerRequestHandler`) performs the WebSocket upgrade from **inside the asynchronous `HttpServerRequest#body()` callback**:

```java
event.resume();
final Future<Buffer> body = hasBody(event) ? event.body() : Future.succeededFuture(null);
body.onSuccess(bodyBuffer -> {
    ...
    if (mockResponse.getWebSocketListener() != null) {
        event.toWebSocket()...   // upgrade attempted after an async hop
    }
});
```

By the time that callback runs, the request's end event has usually been processed on the event loop, so `HttpServerRequest#toWebSocket()` intermittently throws:

```
java.lang.IllegalStateException: Request has already been read
    at io.vertx.core.http.impl.Http1xServerRequest.checkEnded(Http1xServerRequest.java:743)
    ...
    at io.fabric8.mockwebserver.vertx.HttpServerRequestHandler.lambda$handle$…
```

The upgrade is then lost. This is the well-known Vert.x constraint that `toWebSocket()` must be called synchronously in the request handler, before the request is read (see [vert-x3/vertx-web#1774](https://github.com/vert-x3/vertx-web/issues/1774)). It surfaces downstream as flaky failures in tests that exercise pod `exec`/`attach` over the mock server.

### Fix

WebSocket upgrade requests never carry a body, so detect them up front (via the `Upgrade` header) and perform the upgrade **synchronously** from `handle()`, before the request is read. The existing asynchronous body-reading path is retained unchanged for regular HTTP requests. Shared response-writing and request-recording logic is extracted into small helper methods to avoid duplication.

### Verification

A regression test (`MockWebServerWebSocketTest`) upgrades a request that carries a `Content-Type` header — which previously routed through the async body reader. It **fails on `main`** with the exact `IllegalStateException: Request has already been read` and **passes with this change**. The full `junit/mockwebserver` module suite (215 tests) is green.

### Downstream reference

Reported and tracked internally at Gradle: `https://github.com/gradle/dv/issues/68461` (private tracker — link included for provenance; not publicly accessible).

## Type of change

 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase; test, version modification, documentation, etc.)

## Checklist

 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the javadocs and other documentation accordingly — n/a (internal handler behavior)
 - [ ] No new bugs, code smells, etc. in SonarCloud report
 - [ ] I tested my code in Kubernetes — n/a (mock web server only; no cluster interaction)
 - [ ] I tested my code in OpenShift — n/a (mock web server only; no cluster interaction)
