### PR TITLE
refactor(kubernetes-model-generator): drop committed-Builders gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,19 +43,15 @@ openapi-generate-java-classes:
 	# Test dependency needed for model de/serialization validation
 	mvn $(MAVEN_ARGS) clean install -pl . -pl zjsonpatch
 	cd kubernetes-model-generator && mvn $(MAVEN_ARGS) -Pgenerate clean install
-	cd extensions && mvn $(MAVEN_ARGS) \
-		-pl . \
-		-pl certmanager/model \
-		-pl chaosmesh/model \
-		-pl istio/model \
-		-pl knative/model \
-		-pl open-cluster-management/model \
-		-pl open-virtual-network/model \
-		-pl tekton/model \
-		-pl verticalpodautoscaler/model \
-		-pl volcano/model \
-		-pl volumesnapshot/model \
-		-Pgenerate clean install
+	# Every extensions/**/model module, discovered rather than enumerated: this list also decides what
+	# the generate-model.yml drift check can see, so a hand-written one fails open — an extension model
+	# module missing from it is never regenerated and its committed Builders go stale silently.
+	# Discovery has to be guarded or it fails open the same way: an empty result would collapse to
+	# `-pl .`, which builds only the aggregator and reports success having regenerated nothing.
+	cd extensions && \
+		MODELS="$$(find . -path '*/target' -prune -o -path '*/model/pom.xml' -print | sed 's|/pom.xml$$||;s|^\./||' | sort | tr '\n' ',' | sed 's/,$$//')" && \
+		{ [ -n "$$MODELS" ] || { echo 'ERROR: no extensions/**/model modules discovered; refusing to regenerate nothing' >&2; exit 1; }; } && \
+		mvn $(MAVEN_ARGS) -pl ".,$$MODELS" -Pgenerate clean install
 
 .PHONY: generate-model
 generate-model: openapi-generate-schema openapi-generate-java-classes

--- a/kubernetes-model-generator/kubernetes-model-batch/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-batch/pom.xml
@@ -44,8 +44,8 @@
   </dependencies>
 
   <!-- The build config that snapshots/compiles the committed sundrio Builders is generic and lives
-       in the parent pom (kubernetes-model-generator): the 'committed-generated-builders' profile
-       (auto-activated because src/generated-builders/java exists here) plus the 'generate' profile. -->
+       in the parent pom (kubernetes-model-generator): its unconditional <build> for the default build,
+       plus the 'generate' profile for regeneration. -->
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/kubernetes-model-core/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-core/pom.xml
@@ -126,8 +126,8 @@
   </dependencies>
 
   <!-- The build config that snapshots/compiles the committed sundrio Builders is generic and lives
-       in the parent pom (kubernetes-model-generator): the 'committed-generated-builders' profile
-       (auto-activated because src/generated-builders/java exists here) plus the 'generate' profile. -->
+       in the parent pom (kubernetes-model-generator): its unconditional <build> for the default build,
+       plus the 'generate' profile for regeneration. -->
   <profiles>
     <profile>
       <id>generate</id>

--- a/kubernetes-model-generator/pom.xml
+++ b/kubernetes-model-generator/pom.xml
@@ -96,11 +96,10 @@
     <openapi.storageversionmigrator-revision>5c8923c5ff96ceb4435f66b986b5aec2dd0cbc22</openapi.storageversionmigrator-revision>
     <openapi.whereabouts-revision>5bb9e1542cf987458db181bedee7c051a1538dc1</openapi.whereabouts-revision>
     <!-- Where sundrio APT writes the generated Builders/Fluents under -Pgenerate (see the 'generate'
-         profile below). Defaults to maven-compiler-plugin's own default generatedSourcesDirectory
-         (the throwaway compiler output dir), which is correct for modules that have NOT yet
-         snapshotted their Builders into src/generated-builders/java. The 'committed-generated-builders'
-         profile overrides it to the committed source root for modules that have. -->
-    <sundrio.generatedBuildersDirectory>${project.build.directory}/generated-sources/annotations</sundrio.generatedBuildersDirectory>
+         profile below): straight into the committed source root, so regenerating updates the files
+         that are under version control. Every model module now has its Builders committed (#5622),
+         so this is unconditional; it used to be an override in a file-gated profile. -->
+    <sundrio.generatedBuildersDirectory>${basedir}/src/generated-builders/java</sundrio.generatedBuildersDirectory>
     <osgi.require-capability>
       osgi.extender;
       filter:="(osgi.extender=osgi.serviceloader.registrar)"
@@ -335,110 +334,103 @@
           </excludes>
         </configuration>
       </plugin>
+      <!-- ============================================================================================
+           #5622 — committed sundrio Builders (default-build half)
+           ============================================================================================
+           sundrio's APT output (*Builder.java / *Fluent.java) is snapshotted into a committed source
+           root, src/generated-builders/java, so the default build compiles it as plain source instead
+           of re-running annotation processing every time (~4-5s/module faster). The POJOs it is
+           generated from live alongside it in src/generated/java.
+
+           This was a file-gated `committed-generated-builders` profile while the conversion was in
+           progress, so that a module without committed Builders would not silently lose its public
+           Builder/Fluent API. All 49 *model* modules under this parent are converted, so the gate is
+           gone and the configuration is unconditional.
+
+           SCOPE, because this parent is inherited more widely than the model modules: extensions/pom.xml
+           parents off it too, so everything here also applies to openapi/maven-plugin, openapi/validator
+           and the extensions/*/client, */tests and */examples modules (all except
+           open-virtual-network's client and tests, which parent off the root pom directly). None of them
+           declares @Buildable, so today they only lose an annotation-processing round that was already
+           emitting nothing, and gain a source root that does not exist, which javac ignores.
+
+           The consequence to know about: adding @Buildable to one of those modules will NOT produce a
+           Builder any more, because sundrio is off the processor path there. That surfaces as a compile
+           error the moment the Builder is referenced, and the fix is to put the type in a */model module
+           (where Builders are committed) or to give that module its own empty
+           <annotationProcessorPaths combine.self="override"/>. Re-gating this on file existence to keep
+           sundrio available there would reintroduce exactly the per-module activation this replaced.
+
+           Under -Pgenerate those modules also get an empty src/generated-builders/java, because
+           maven-compiler-plugin creates its generatedSourcesDirectory; it is untracked and git does not
+           record empty directories.
+
+           Two mechanics worth stating so they are not broken by accident:
+           - declaring build-helper here also activates the executions this pom manages for it
+             (add-source src/generated/java, add-resource src/generated/resources, attach-artifact with
+             skipAttach), in every descendant rather than only the converted modules. They are no-ops
+             where those directories are absent, which is everywhere outside the model modules.
+           - a child pom that declares its own <annotationProcessorPaths> would win over this one by
+             inheritance and silently restore a lombok-only path under -Pgenerate. No module under this
+             parent declares maven-compiler-plugin today; keep it that way. -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-generated-builders-source</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${basedir}/src/generated-builders/java</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!-- Run Lombok only (it keeps equals/hashCode/toString on the POJOs) and leave sundrio APT
+               off, so the committed Builders compile as plain source. Restricting the processor path
+               to the lombok artifact is enough on its own: javac auto-discovers Lombok through its
+               META-INF/services, and sundrio (builder-annotations) is simply not on the path, so it
+               never runs. This deliberately avoids naming Lombok's internal processor classes, which
+               are coupled to ${lombok.version}. The 'generate' profile below re-enables sundrio. -->
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>${lombok.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 
   <profiles>
-    <!-- ============================================================================================
-         #5622 — committed sundrio Builders, per-module opt-in gate
-         ============================================================================================
-         Snapshotting sundrio's APT output (*Builder.java / *Fluent.java) into a committed source root
-         (src/generated-builders/java) lets the default build compile those Builders as plain source
-         instead of re-running sundrio APT on every build (~4-5s/module faster). See the module POJOs
-         in src/generated/java for the analogous jsonschema case.
-
-         This profile carries the DEFAULT-build half of that mechanism and MUST only apply to modules
-         whose Builders are already committed — otherwise sundrio APT would be turned off for a module
-         that has no committed Builders, and it would SILENTLY ship with no Builder/Fluent public API.
-         It is therefore gated on the existence of src/generated-builders/java, so it activates only
-         for already-converted modules (kubernetes-model-batch, kubernetes-model-core, ...) and leaves
-         every not-yet-converted module on the classpath-auto-discovered sundrio APT it uses today.
-
-         vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-         TODO(#5622): THIS FILE-EXISTENCE GATE IS TRANSITIONAL. Once EVERY model module under this
-         parent has its Builders committed to src/generated-builders/java, DELETE the <activation>
-         below and move this profile's <build> (and the property override) into the parent's
-         unconditional <build>, so the config is truly generic with no per-module gate. Until then,
-         converting a new module needs NO pom change here: commit its src/generated-builders/java and
-         this profile starts applying to it automatically. Tracked as the next step in issue #5622.
-         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-         ============================================================================================ -->
-    <profile>
-      <id>committed-generated-builders</id>
-      <activation>
-        <file>
-          <!-- Must be ${basedir}; ${project.basedir} is NOT interpolated during profile activation. -->
-          <exists>${basedir}/src/generated-builders/java</exists>
-        </file>
-      </activation>
-      <properties>
-        <!-- Regenerate Builders into the committed source root (overrides the throwaway default). -->
-        <sundrio.generatedBuildersDirectory>${basedir}/src/generated-builders/java</sundrio.generatedBuildersDirectory>
-      </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>build-helper-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>add-generated-builders-source</id>
-                <phase>generate-sources</phase>
-                <goals>
-                  <goal>add-source</goal>
-                </goals>
-                <configuration>
-                  <sources>
-                    <source>${basedir}/src/generated-builders/java</source>
-                  </sources>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <!-- Default build: run Lombok only (keeps equals/hashCode/toString on the POJOs) and
-                   leave sundrio APT off, so the committed Builders in src/generated-builders/java are
-                   compiled as plain source instead of being regenerated. Restricting
-                   annotationProcessorPaths to the lombok artifact is enough on its own: javac
-                   auto-discovers Lombok via its META-INF/services, and sundrio (builder-annotations)
-                   is simply not on the processor path so it never runs. This deliberately avoids
-                   naming Lombok's internal processor classes, which are coupled to ${lombok.version}.
-                   The 'generate' profile below re-enables sundrio for regeneration. -->
-              <annotationProcessorPaths>
-                <path>
-                  <groupId>org.projectlombok</groupId>
-                  <artifactId>lombok</artifactId>
-                  <version>${lombok.version}</version>
-                </path>
-              </annotationProcessorPaths>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
     <!-- #5622 — regeneration half of the mechanism (activated by `mvn -Pgenerate`, e.g. via
-         `make generate-model`). Universal on purpose: it is a no-op-preserving change for
-         not-yet-converted modules (sundrio.generatedBuildersDirectory defaults to the throwaway
-         compiler output dir, and an empty annotationProcessorPaths falls back to classpath
-         auto-discovery, so those modules regenerate into target/ exactly as they do today).
-         For converted modules the 'committed-generated-builders' profile above redirects the output
-         into the committed src/generated-builders/java source root.
+         `make generate-model`); the default-build half is unconditional, in <build> above.
+
          The empty <annotationProcessorPaths> override is what re-enables sundrio: with no processor
          path, javac discovers BOTH Lombok and sundrio from the compile classpath, so sundrio resolves
-         its referenced Builders from the dependency jars (no shadow copies).
+         its referenced Builders from the dependency jars (no shadow copies). It must stay an override
+         of the lombok-only path in <build>; profiles are injected into this pom's own model before
+         inheritance is assembled, so descendants inherit an already-empty value and cannot reorder or
+         lose it. If it ever stopped winning, sundrio would SILENTLY stop regenerating and
+         `make generate-model` would just recompile the stale committed Builders — the
+         generate-model.yml drift guard is the safety net that would catch that.
 
-         >>> ORDER MATTERS: this 'generate' profile MUST stay declared AFTER
-         'committed-generated-builders'. Maven merges same-pom active profiles in declaration order
-         with the later one dominant, and combine.self="override" is read from the dominant node. If
-         the two are ever reordered, the empty override becomes recessive, the lombok-only processor
-         path from 'committed-generated-builders' survives under -Pgenerate, and sundrio SILENTLY
-         stops regenerating for converted modules (make generate-model would just recompile the stale
-         committed Builders). The generate-model.yml drift guard is the safety net that would catch it,
-         but keep the ordering. <<< -->
+         Note this makes implicit classpath discovery the ONLY route by which sundrio ever runs. javac
+         warns about it from JDK 21 and it is expected to be disabled by default eventually, at which
+         point regeneration silently produces nothing rather than merely slowing down; the drift guard
+         would again be what catches it. -->
+
     <profile>
       <id>generate</id>
       <build>


### PR DESCRIPTION
Completes #5622's follow-up #1. With `kubernetes-model-common` converted in #8006, all 49
model modules under `kubernetes-model-generator` have their sundrio Builders committed, so
the transitional per-module gate has nothing left to gate.

- the `committed-generated-builders` profile and its `<file><exists>` activation are gone;
  its `<build>` (build-helper `add-source` + the lombok-only `annotationProcessorPaths`)
  moves into the parent's unconditional `<build>`
- `sundrio.generatedBuildersDirectory` now points at `${basedir}/src/generated-builders/java`
  directly instead of being overridden per module
- the `generate` profile is unchanged, and its `combine.self="override"` no longer depends on
  profile declaration order, since it now overrides the base `<build>` rather than a sibling
  profile. The ordering warning that guarded that is removed.
- `Makefile`: the 10 `extensions/*/model` modules are discovered instead of enumerated

Net -12 lines.

### Scope, which is wider than "model modules"

`extensions/pom.xml` parents off this pom, so the unconditional config also reaches
`openapi/maven-plugin`, `openapi/validator` and the `extensions/*/client`, `*/tests`,
`*/examples` modules - all except `open-virtual-network`'s `client` and `tests`, which parent
off the root pom directly and are untouched.

None of those modules declares `@Buildable`, so there is no behavioural change today. The
consequence to know about is forward-looking: adding `@Buildable` to one of them will no
longer produce a Builder. I verified this rather than assuming it - a probe `@Buildable` class
in `extensions/volcano/client` generates a Builder/Fluent before this change and none after.
It is not a silent trap in practice, because the Builder's absence is a compile error the
moment anything references it; the pom documents it and points at the fix (put the type in a
`*/model` module, or give that module its own empty `<annotationProcessorPaths>`).

### Verification

Whole-reactor before/after, same base commit:

- all **194 jars**: class CRC-32 lists **identical** (99,212 entries); all **194 OSGi
  manifests** identical
- full build with tests: **3313 tests, 0 failures, 0 errors**. `kube-api-test` fails
  identically on an unmodified tree (it starts a real kube-apiserver) and inherits from the
  root pom, not this parent
- the only sundrio APT left anywhere is in `kubernetes-client-api` and `openshift-client-api`,
  which are root-pom descendants and out of scope here
- `make openapi-generate-java-classes`: 3x BUILD SUCCESS with **zero drift** across every
  `src/generated/java` and `src/generated-builders/java`
- the Makefile's discovered list is byte-identical to the enumerated one it replaces, and the
  empty-result guard was tested by running the discovery where nothing matches
- full jar entry lists (resources included, not just classes) compared for both `openapi/*`
  modules, since `maven-core` puts a second annotation processor (sisu) on that classpath:
  identical, so nothing was silently dropped
- `license:check` and `spotless:check` pass

### Known cosmetic side effect

Under `-Pgenerate`, modules with nothing to generate get an empty `src/generated-builders/java`,
because maven-compiler-plugin creates its `generatedSourcesDirectory`. It is untracked and git
does not record empty directories. Gating it away would reintroduce the per-module activation
this PR removes, so it is documented in the pom instead.

### Follow-up not included here

`make generate-javadoc-links` has no CI guard, and a stale `doc/javadoc-links/*/element-list`
fails silently (offline `<offlineLink>` package lists, `javadoc.doclint=none`, and `make javadoc`
never fails on an unresolvable link). It needs a full build to check without false positives, so
it does not fit `generate-model.yml`. Tracked as a follow-up on #5622 rather than as its own issue.
