### PR TITLE
fix(kube-api-test): fix env var parsing and add startupTimeout to @EnableKubeAPIServer

### DIFF
--- a/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/KubeAPIServerConfigBuilder.java
+++ b/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/KubeAPIServerConfigBuilder.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 public final class KubeAPIServerConfigBuilder {
 
@@ -33,6 +34,7 @@ public final class KubeAPIServerConfigBuilder {
 
   private final List<String> apiServerFlags = new ArrayList<>(0);
   private boolean updateKubeConfig = false;
+  private UnaryOperator<String> envReader = System::getenv;
 
   private String apiTestDir;
   private String apiServerVersion;
@@ -88,7 +90,7 @@ public final class KubeAPIServerConfigBuilder {
     if (currentValue != null) {
       return currentValue;
     }
-    String envValue = System.getenv(envVariable);
+    String envValue = envReader.apply(envVariable);
     if (envValue == null) {
       return defaultValue;
     }
@@ -135,6 +137,11 @@ public final class KubeAPIServerConfigBuilder {
 
   public KubeAPIServerConfigBuilder withStartupTimeout(Integer startupTimeout) {
     this.startupTimeout = startupTimeout;
+    return this;
+  }
+
+  KubeAPIServerConfigBuilder withEnvReader(UnaryOperator<String> envReader) {
+    this.envReader = envReader;
     return this;
   }
 

--- a/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/KubeAPIServerConfigBuilder.java
+++ b/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/KubeAPIServerConfigBuilder.java
@@ -68,6 +68,7 @@ public final class KubeAPIServerConfigBuilder {
     this.apiServerVersion = finalConfigValue(this.apiServerVersion, KUBE_API_TEST_API_SERVER_VERSION, null);
     this.waitForEtcdHealthCheckOnStartup = finalConfigValue(this.waitForEtcdHealthCheckOnStartup,
         KUBE_API_TEST_WAIT_FOR_ETCD_HEALTH_CHECK, false);
+    // 120s: idle startup ~2.6s scales ~20× under -T 1C CI contention (#7807)
     this.startupTimeout = finalConfigValue(this.startupTimeout, KUBE_API_TEST_STARTUP_TIMEOUT, 120_000);
 
     return new KubeAPIServerConfig(apiTestDir, apiServerVersion, offlineMode, apiServerFlags,
@@ -87,7 +88,15 @@ public final class KubeAPIServerConfigBuilder {
       return currentValue;
     }
     String envValue = System.getenv(envVariable);
-    return envValue != null ? parseEnvValue(Boolean.class, envValue) : defaultValue;
+    if (envValue == null) {
+      return defaultValue;
+    }
+    if (!"true".equalsIgnoreCase(envValue) && !"false".equalsIgnoreCase(envValue)) {
+      throw new KubeAPITestException(
+          "Cannot parse environment variable " + envVariable + " value '" + envValue
+              + "' as Boolean (expected 'true' or 'false')");
+    }
+    return parseEnvValue(Boolean.class, envValue);
   }
 
   private Integer finalConfigValue(Integer currentValue, String envVariable, Integer defaultValue) {
@@ -112,8 +121,10 @@ public final class KubeAPIServerConfigBuilder {
       return (T) Integer.valueOf(envValue);
     } else if (type == Boolean.class) {
       return (T) Boolean.valueOf(envValue);
+    } else if (type == String.class) {
+      return type.cast(envValue);
     }
-    return type.cast(envValue);
+    throw new IllegalArgumentException("Unsupported type for environment variable parsing: " + type);
   }
 
   public KubeAPIServerConfigBuilder withUpdateKubeConfig(boolean updateKubeConfig) {

--- a/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/KubeAPIServerConfigBuilder.java
+++ b/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/KubeAPIServerConfigBuilder.java
@@ -75,28 +75,45 @@ public final class KubeAPIServerConfigBuilder {
   }
 
   private String finalConfigValue(String currentValue, String envVariable, String defaultValue) {
-    return finalConfigValue(String.class, currentValue, envVariable, defaultValue);
-  }
-
-  private Boolean finalConfigValue(Boolean currentValue, String envVariable, Boolean defaultValue) {
-    return finalConfigValue(Boolean.class, currentValue, envVariable, defaultValue);
-  }
-
-  private Integer finalConfigValue(Integer currentValue, String envVariable, Integer defaultValue) {
-    return finalConfigValue(Integer.class, currentValue, envVariable, defaultValue);
-  }
-
-  private <T> T finalConfigValue(Class<T> type, T currentValue, String envVariable,
-      T defaultValue) {
     if (currentValue != null) {
       return currentValue;
     }
     String envValue = System.getenv(envVariable);
-    if (envValue != null) {
-      return type.cast(envValue);
-    } else {
+    return envValue != null ? envValue : defaultValue;
+  }
+
+  private Boolean finalConfigValue(Boolean currentValue, String envVariable, Boolean defaultValue) {
+    if (currentValue != null) {
+      return currentValue;
+    }
+    String envValue = System.getenv(envVariable);
+    return envValue != null ? parseEnvValue(Boolean.class, envValue) : defaultValue;
+  }
+
+  private Integer finalConfigValue(Integer currentValue, String envVariable, Integer defaultValue) {
+    if (currentValue != null) {
+      return currentValue;
+    }
+    String envValue = System.getenv(envVariable);
+    if (envValue == null) {
       return defaultValue;
     }
+    try {
+      return parseEnvValue(Integer.class, envValue);
+    } catch (NumberFormatException e) {
+      throw new KubeAPITestException(
+          "Cannot parse environment variable " + envVariable + " value '" + envValue + "' as Integer", e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  static <T> T parseEnvValue(Class<T> type, String envValue) {
+    if (type == Integer.class) {
+      return (T) Integer.valueOf(envValue);
+    } else if (type == Boolean.class) {
+      return (T) Boolean.valueOf(envValue);
+    }
+    return type.cast(envValue);
   }
 
   public KubeAPIServerConfigBuilder withUpdateKubeConfig(boolean updateKubeConfig) {

--- a/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/KubeAPIServerConfigBuilder.java
+++ b/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/KubeAPIServerConfigBuilder.java
@@ -18,6 +18,7 @@ package io.fabric8.kubeapitest;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 public final class KubeAPIServerConfigBuilder {
 
@@ -63,43 +64,24 @@ public final class KubeAPIServerConfigBuilder {
 
   public KubeAPIServerConfig build() {
     this.apiTestDir = finalConfigValue(this.apiTestDir, KUBE_API_TEST_DIR,
-        new File(System.getProperty("user.home"), DIRECTORY_NAME).getPath());
-    this.offlineMode = finalConfigValue(this.offlineMode, KUBE_API_TEST_OFFLINE_MODE, false);
-    this.apiServerVersion = finalConfigValue(this.apiServerVersion, KUBE_API_TEST_API_SERVER_VERSION, null);
+        new File(System.getProperty("user.home"), DIRECTORY_NAME).getPath(), Function.identity());
+    this.offlineMode = finalConfigValue(this.offlineMode, KUBE_API_TEST_OFFLINE_MODE, false,
+        KubeAPIServerConfigBuilder::parseStrictBoolean);
+    this.apiServerVersion = finalConfigValue(this.apiServerVersion, KUBE_API_TEST_API_SERVER_VERSION,
+        null, Function.identity());
     this.waitForEtcdHealthCheckOnStartup = finalConfigValue(this.waitForEtcdHealthCheckOnStartup,
-        KUBE_API_TEST_WAIT_FOR_ETCD_HEALTH_CHECK, false);
+        KUBE_API_TEST_WAIT_FOR_ETCD_HEALTH_CHECK, false,
+        KubeAPIServerConfigBuilder::parseStrictBoolean);
     // 120s: idle startup ~2.6s scales ~20× under -T 1C CI contention (#7807)
-    this.startupTimeout = finalConfigValue(this.startupTimeout, KUBE_API_TEST_STARTUP_TIMEOUT, 120_000);
+    this.startupTimeout = finalConfigValue(this.startupTimeout, KUBE_API_TEST_STARTUP_TIMEOUT,
+        120_000, Integer::valueOf);
 
     return new KubeAPIServerConfig(apiTestDir, apiServerVersion, offlineMode, apiServerFlags,
         updateKubeConfig, waitForEtcdHealthCheckOnStartup, startupTimeout);
   }
 
-  private String finalConfigValue(String currentValue, String envVariable, String defaultValue) {
-    if (currentValue != null) {
-      return currentValue;
-    }
-    String envValue = System.getenv(envVariable);
-    return envValue != null ? envValue : defaultValue;
-  }
-
-  private Boolean finalConfigValue(Boolean currentValue, String envVariable, Boolean defaultValue) {
-    if (currentValue != null) {
-      return currentValue;
-    }
-    String envValue = System.getenv(envVariable);
-    if (envValue == null) {
-      return defaultValue;
-    }
-    if (!"true".equalsIgnoreCase(envValue) && !"false".equalsIgnoreCase(envValue)) {
-      throw new KubeAPITestException(
-          "Cannot parse environment variable " + envVariable + " value '" + envValue
-              + "' as Boolean (expected 'true' or 'false')");
-    }
-    return parseEnvValue(Boolean.class, envValue);
-  }
-
-  private Integer finalConfigValue(Integer currentValue, String envVariable, Integer defaultValue) {
+  private <T> T finalConfigValue(T currentValue, String envVariable, T defaultValue,
+      Function<String, T> parser) {
     if (currentValue != null) {
       return currentValue;
     }
@@ -108,23 +90,21 @@ public final class KubeAPIServerConfigBuilder {
       return defaultValue;
     }
     try {
-      return parseEnvValue(Integer.class, envValue);
-    } catch (NumberFormatException e) {
+      return parser.apply(envValue);
+    } catch (RuntimeException e) {
       throw new KubeAPITestException(
-          "Cannot parse environment variable " + envVariable + " value '" + envValue + "' as Integer", e);
+          "Cannot parse environment variable " + envVariable + " value '" + envValue + "'", e);
     }
   }
 
-  @SuppressWarnings("unchecked")
-  static <T> T parseEnvValue(Class<T> type, String envValue) {
-    if (type == Integer.class) {
-      return (T) Integer.valueOf(envValue);
-    } else if (type == Boolean.class) {
-      return (T) Boolean.valueOf(envValue);
-    } else if (type == String.class) {
-      return type.cast(envValue);
+  static Boolean parseStrictBoolean(String value) {
+    if ("true".equalsIgnoreCase(value)) {
+      return Boolean.TRUE;
     }
-    throw new IllegalArgumentException("Unsupported type for environment variable parsing: " + type);
+    if ("false".equalsIgnoreCase(value)) {
+      return Boolean.FALSE;
+    }
+    throw new IllegalArgumentException("expected 'true' or 'false', got '" + value + "'");
   }
 
   public KubeAPIServerConfigBuilder withUpdateKubeConfig(boolean updateKubeConfig) {

--- a/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/KubeAPIServerConfigBuilder.java
+++ b/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/KubeAPIServerConfigBuilder.java
@@ -75,6 +75,9 @@ public final class KubeAPIServerConfigBuilder {
     // 120s: idle startup ~2.6s scales ~20× under -T 1C CI contention (#7807)
     this.startupTimeout = finalConfigValue(this.startupTimeout, KUBE_API_TEST_STARTUP_TIMEOUT,
         120_000, Integer::valueOf);
+    if (this.startupTimeout <= 0) {
+      throw new KubeAPITestException("startupTimeout must be positive, got: " + this.startupTimeout);
+    }
 
     return new KubeAPIServerConfig(apiTestDir, apiServerVersion, offlineMode, apiServerFlags,
         updateKubeConfig, waitForEtcdHealthCheckOnStartup, startupTimeout);

--- a/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/junit/EnableKubeAPIServer.java
+++ b/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/junit/EnableKubeAPIServer.java
@@ -35,10 +35,13 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface EnableKubeAPIServer {
 
   String NOT_SET = "NOT_SET";
+  int STARTUP_TIMEOUT_NOT_SET = -1;
 
   String kubeAPIVersion() default NOT_SET;
 
   String[] apiServerFlags() default {};
 
   boolean updateKubeConfigFile() default false;
+
+  int startupTimeout() default STARTUP_TIMEOUT_NOT_SET;
 }

--- a/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/junit/KubeAPIServerExtension.java
+++ b/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/junit/KubeAPIServerExtension.java
@@ -114,13 +114,8 @@ public class KubeAPIServerExtension
     if (annotation.apiServerFlags().length > 0) {
       builder.withApiServerFlags(List.of(annotation.apiServerFlags()));
     }
-    var timeout = annotation.startupTimeout();
-    if (timeout != EnableKubeAPIServer.STARTUP_TIMEOUT_NOT_SET) {
-      if (timeout <= 0) {
-        throw new KubeAPITestException(
-            "@EnableKubeAPIServer startupTimeout must be positive, got: " + timeout);
-      }
-      builder.withStartupTimeout(timeout);
+    if (annotation.startupTimeout() != EnableKubeAPIServer.STARTUP_TIMEOUT_NOT_SET) {
+      builder.withStartupTimeout(annotation.startupTimeout());
     }
 
     builder.withUpdateKubeConfig(annotation.updateKubeConfigFile());

--- a/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/junit/KubeAPIServerExtension.java
+++ b/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/junit/KubeAPIServerExtension.java
@@ -105,7 +105,7 @@ public class KubeAPIServerExtension
     });
   }
 
-  private KubeAPIServerConfig annotationToConfig(EnableKubeAPIServer annotation) {
+  KubeAPIServerConfig annotationToConfig(EnableKubeAPIServer annotation) {
     var builder = KubeAPIServerConfigBuilder.anAPIServerConfig();
     var version = annotation.kubeAPIVersion();
     if (!EnableKubeAPIServer.NOT_SET.equals(version)) {
@@ -113,6 +113,9 @@ public class KubeAPIServerExtension
     }
     if (annotation.apiServerFlags().length > 0) {
       builder.withApiServerFlags(List.of(annotation.apiServerFlags()));
+    }
+    if (annotation.startupTimeout() != EnableKubeAPIServer.STARTUP_TIMEOUT_NOT_SET) {
+      builder.withStartupTimeout(annotation.startupTimeout());
     }
 
     builder.withUpdateKubeConfig(annotation.updateKubeConfigFile());

--- a/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/junit/KubeAPIServerExtension.java
+++ b/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/junit/KubeAPIServerExtension.java
@@ -114,8 +114,13 @@ public class KubeAPIServerExtension
     if (annotation.apiServerFlags().length > 0) {
       builder.withApiServerFlags(List.of(annotation.apiServerFlags()));
     }
-    if (annotation.startupTimeout() != EnableKubeAPIServer.STARTUP_TIMEOUT_NOT_SET) {
-      builder.withStartupTimeout(annotation.startupTimeout());
+    var timeout = annotation.startupTimeout();
+    if (timeout != EnableKubeAPIServer.STARTUP_TIMEOUT_NOT_SET) {
+      if (timeout <= 0) {
+        throw new KubeAPITestException(
+            "@EnableKubeAPIServer startupTimeout must be positive, got: " + timeout);
+      }
+      builder.withStartupTimeout(timeout);
     }
 
     builder.withUpdateKubeConfig(annotation.updateKubeConfigFile());

--- a/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/KubeAPIServerConfigBuilderTest.java
+++ b/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/KubeAPIServerConfigBuilderTest.java
@@ -84,4 +84,28 @@ class KubeAPIServerConfigBuilderTest {
     assertThat(KubeAPIServerConfigBuilder.parseEnvValue(Boolean.class, "True"))
         .isTrue();
   }
+
+  @Test
+  @DisplayName("parseEnvValue throws NumberFormatException for empty integer string")
+  void parseEnvValueEmptyInteger() {
+    assertThatThrownBy(() -> KubeAPIServerConfigBuilder.parseEnvValue(Integer.class, ""))
+        .isInstanceOf(NumberFormatException.class);
+  }
+
+  @Test
+  @DisplayName("parseEnvValue treats non-canonical boolean values as false")
+  void parseEnvValueNonCanonicalBoolean() {
+    assertThat(KubeAPIServerConfigBuilder.parseEnvValue(Boolean.class, "yes"))
+        .isFalse();
+    assertThat(KubeAPIServerConfigBuilder.parseEnvValue(Boolean.class, "1"))
+        .isFalse();
+  }
+
+  @Test
+  @DisplayName("parseEnvValue throws for unsupported types")
+  void parseEnvValueUnsupportedType() {
+    assertThatThrownBy(() -> KubeAPIServerConfigBuilder.parseEnvValue(Long.class, "42"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Unsupported type");
+  }
 }

--- a/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/KubeAPIServerConfigBuilderTest.java
+++ b/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/KubeAPIServerConfigBuilderTest.java
@@ -33,7 +33,7 @@ class KubeAPIServerConfigBuilderTest {
   @Test
   @DisplayName("default startupTimeout is 120 seconds")
   void defaultStartupTimeoutIs120Seconds() {
-    var config = KubeAPIServerConfigBuilder.anAPIServerConfig().build();
+    var config = builderWithEnv(Map.of()).build();
 
     assertThat(config.getStartupTimeout()).isEqualTo(120_000);
   }
@@ -41,7 +41,7 @@ class KubeAPIServerConfigBuilderTest {
   @Test
   @DisplayName("explicit startupTimeout via builder overrides default")
   void explicitStartupTimeoutOverridesDefault() {
-    var config = KubeAPIServerConfigBuilder.anAPIServerConfig()
+    var config = builderWithEnv(Map.of())
         .withStartupTimeout(42_000)
         .build();
 
@@ -87,7 +87,7 @@ class KubeAPIServerConfigBuilderTest {
   @Test
   @DisplayName("build rejects non-positive startupTimeout from builder API")
   void buildRejectsNonPositiveStartupTimeout() {
-    assertThatThrownBy(() -> KubeAPIServerConfigBuilder.anAPIServerConfig()
+    assertThatThrownBy(() -> builderWithEnv(Map.of())
         .withStartupTimeout(0)
         .build())
         .isInstanceOf(KubeAPITestException.class)
@@ -97,7 +97,7 @@ class KubeAPIServerConfigBuilderTest {
   @Test
   @DisplayName("build rejects negative startupTimeout from builder API")
   void buildRejectsNegativeStartupTimeout() {
-    assertThatThrownBy(() -> KubeAPIServerConfigBuilder.anAPIServerConfig()
+    assertThatThrownBy(() -> builderWithEnv(Map.of())
         .withStartupTimeout(-500)
         .build())
         .isInstanceOf(KubeAPITestException.class)
@@ -149,6 +149,7 @@ class KubeAPIServerConfigBuilderTest {
     assertThatThrownBy(() -> builderWithEnv(Map.of(
         KubeAPIServerConfigBuilder.KUBE_API_TEST_OFFLINE_MODE, "yes")).build())
         .isInstanceOf(KubeAPITestException.class)
-        .hasMessageContaining("KUBE_API_TEST_OFFLINE_MODE");
+        .hasMessageContaining("KUBE_API_TEST_OFFLINE_MODE")
+        .hasMessageContaining("yes");
   }
 }

--- a/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/KubeAPIServerConfigBuilderTest.java
+++ b/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/KubeAPIServerConfigBuilderTest.java
@@ -42,70 +42,31 @@ class KubeAPIServerConfigBuilderTest {
   }
 
   @Test
-  @DisplayName("parseEnvValue parses integer strings correctly")
-  void parseEnvValueInteger() {
-    assertThat(KubeAPIServerConfigBuilder.parseEnvValue(Integer.class, "180000"))
-        .isEqualTo(180_000);
+  @DisplayName("parseStrictBoolean parses 'true' correctly")
+  void parseStrictBooleanTrue() {
+    assertThat(KubeAPIServerConfigBuilder.parseStrictBoolean("true")).isTrue();
   }
 
   @Test
-  @DisplayName("parseEnvValue parses boolean 'true' correctly")
-  void parseEnvValueBooleanTrue() {
-    assertThat(KubeAPIServerConfigBuilder.parseEnvValue(Boolean.class, "true"))
-        .isTrue();
+  @DisplayName("parseStrictBoolean parses 'false' correctly")
+  void parseStrictBooleanFalse() {
+    assertThat(KubeAPIServerConfigBuilder.parseStrictBoolean("false")).isFalse();
   }
 
   @Test
-  @DisplayName("parseEnvValue parses boolean 'false' correctly")
-  void parseEnvValueBooleanFalse() {
-    assertThat(KubeAPIServerConfigBuilder.parseEnvValue(Boolean.class, "false"))
-        .isFalse();
+  @DisplayName("parseStrictBoolean parses case-insensitively")
+  void parseStrictBooleanCaseInsensitive() {
+    assertThat(KubeAPIServerConfigBuilder.parseStrictBoolean("TRUE")).isTrue();
+    assertThat(KubeAPIServerConfigBuilder.parseStrictBoolean("True")).isTrue();
+    assertThat(KubeAPIServerConfigBuilder.parseStrictBoolean("FALSE")).isFalse();
   }
 
   @Test
-  @DisplayName("parseEnvValue returns string values unchanged")
-  void parseEnvValueString() {
-    assertThat(KubeAPIServerConfigBuilder.parseEnvValue(String.class, "some-value"))
-        .isEqualTo("some-value");
-  }
-
-  @Test
-  @DisplayName("parseEnvValue throws NumberFormatException for non-numeric integer input")
-  void parseEnvValueInvalidInteger() {
-    assertThatThrownBy(() -> KubeAPIServerConfigBuilder.parseEnvValue(Integer.class, "not-a-number"))
-        .isInstanceOf(NumberFormatException.class);
-  }
-
-  @Test
-  @DisplayName("parseEnvValue parses boolean case-insensitively")
-  void parseEnvValueBooleanCaseInsensitive() {
-    assertThat(KubeAPIServerConfigBuilder.parseEnvValue(Boolean.class, "TRUE"))
-        .isTrue();
-    assertThat(KubeAPIServerConfigBuilder.parseEnvValue(Boolean.class, "True"))
-        .isTrue();
-  }
-
-  @Test
-  @DisplayName("parseEnvValue throws NumberFormatException for empty integer string")
-  void parseEnvValueEmptyInteger() {
-    assertThatThrownBy(() -> KubeAPIServerConfigBuilder.parseEnvValue(Integer.class, ""))
-        .isInstanceOf(NumberFormatException.class);
-  }
-
-  @Test
-  @DisplayName("parseEnvValue treats non-canonical boolean values as false")
-  void parseEnvValueNonCanonicalBoolean() {
-    assertThat(KubeAPIServerConfigBuilder.parseEnvValue(Boolean.class, "yes"))
-        .isFalse();
-    assertThat(KubeAPIServerConfigBuilder.parseEnvValue(Boolean.class, "1"))
-        .isFalse();
-  }
-
-  @Test
-  @DisplayName("parseEnvValue throws for unsupported types")
-  void parseEnvValueUnsupportedType() {
-    assertThatThrownBy(() -> KubeAPIServerConfigBuilder.parseEnvValue(Long.class, "42"))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Unsupported type");
+  @DisplayName("parseStrictBoolean rejects non-canonical values")
+  void parseStrictBooleanRejectsNonCanonical() {
+    assertThatThrownBy(() -> KubeAPIServerConfigBuilder.parseStrictBoolean("yes"))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> KubeAPIServerConfigBuilder.parseStrictBoolean("1"))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/KubeAPIServerConfigBuilderTest.java
+++ b/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/KubeAPIServerConfigBuilderTest.java
@@ -15,17 +15,16 @@
  */
 package io.fabric8.kubeapitest;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class KubeAPIServerConfigBuilderTest {
 
-  // Default raised from 60s to 120s under #7834: the 2.6s idle startup of
-  // kube-apiserver scales ~20× under -T 1C + forkCount=1C CI contention,
-  // landing right on the 60s boundary. 120s gives a 2× buffer; the
-  // KUBE_API_TEST_STARTUP_TIMEOUT env var still lets users tune it.
   @Test
+  @DisplayName("default startupTimeout is 120 seconds")
   void defaultStartupTimeoutIs120Seconds() {
     var config = KubeAPIServerConfigBuilder.anAPIServerConfig().build();
 
@@ -33,11 +32,56 @@ class KubeAPIServerConfigBuilderTest {
   }
 
   @Test
+  @DisplayName("explicit startupTimeout via builder overrides default")
   void explicitStartupTimeoutOverridesDefault() {
     var config = KubeAPIServerConfigBuilder.anAPIServerConfig()
         .withStartupTimeout(42_000)
         .build();
 
     assertThat(config.getStartupTimeout()).isEqualTo(42_000);
+  }
+
+  @Test
+  @DisplayName("parseEnvValue parses integer strings correctly")
+  void parseEnvValueInteger() {
+    assertThat(KubeAPIServerConfigBuilder.parseEnvValue(Integer.class, "180000"))
+        .isEqualTo(180_000);
+  }
+
+  @Test
+  @DisplayName("parseEnvValue parses boolean 'true' correctly")
+  void parseEnvValueBooleanTrue() {
+    assertThat(KubeAPIServerConfigBuilder.parseEnvValue(Boolean.class, "true"))
+        .isTrue();
+  }
+
+  @Test
+  @DisplayName("parseEnvValue parses boolean 'false' correctly")
+  void parseEnvValueBooleanFalse() {
+    assertThat(KubeAPIServerConfigBuilder.parseEnvValue(Boolean.class, "false"))
+        .isFalse();
+  }
+
+  @Test
+  @DisplayName("parseEnvValue returns string values unchanged")
+  void parseEnvValueString() {
+    assertThat(KubeAPIServerConfigBuilder.parseEnvValue(String.class, "some-value"))
+        .isEqualTo("some-value");
+  }
+
+  @Test
+  @DisplayName("parseEnvValue throws NumberFormatException for non-numeric integer input")
+  void parseEnvValueInvalidInteger() {
+    assertThatThrownBy(() -> KubeAPIServerConfigBuilder.parseEnvValue(Integer.class, "not-a-number"))
+        .isInstanceOf(NumberFormatException.class);
+  }
+
+  @Test
+  @DisplayName("parseEnvValue parses boolean case-insensitively")
+  void parseEnvValueBooleanCaseInsensitive() {
+    assertThat(KubeAPIServerConfigBuilder.parseEnvValue(Boolean.class, "TRUE"))
+        .isTrue();
+    assertThat(KubeAPIServerConfigBuilder.parseEnvValue(Boolean.class, "True"))
+        .isTrue();
   }
 }

--- a/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/KubeAPIServerConfigBuilderTest.java
+++ b/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/KubeAPIServerConfigBuilderTest.java
@@ -69,4 +69,31 @@ class KubeAPIServerConfigBuilderTest {
     assertThatThrownBy(() -> KubeAPIServerConfigBuilder.parseStrictBoolean("1"))
         .isInstanceOf(IllegalArgumentException.class);
   }
+
+  @Test
+  @DisplayName("parseStrictBoolean rejects empty string")
+  void parseStrictBooleanRejectsEmpty() {
+    assertThatThrownBy(() -> KubeAPIServerConfigBuilder.parseStrictBoolean(""))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("build rejects non-positive startupTimeout from builder API")
+  void buildRejectsNonPositiveStartupTimeout() {
+    assertThatThrownBy(() -> KubeAPIServerConfigBuilder.anAPIServerConfig()
+        .withStartupTimeout(0)
+        .build())
+        .isInstanceOf(KubeAPITestException.class)
+        .hasMessageContaining("positive");
+  }
+
+  @Test
+  @DisplayName("build rejects negative startupTimeout from builder API")
+  void buildRejectsNegativeStartupTimeout() {
+    assertThatThrownBy(() -> KubeAPIServerConfigBuilder.anAPIServerConfig()
+        .withStartupTimeout(-500)
+        .build())
+        .isInstanceOf(KubeAPITestException.class)
+        .hasMessageContaining("positive");
+  }
 }

--- a/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/KubeAPIServerConfigBuilderTest.java
+++ b/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/KubeAPIServerConfigBuilderTest.java
@@ -18,10 +18,17 @@ package io.fabric8.kubeapitest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class KubeAPIServerConfigBuilderTest {
+
+  private static KubeAPIServerConfigBuilder builderWithEnv(Map<String, String> env) {
+    return KubeAPIServerConfigBuilder.anAPIServerConfig()
+        .withEnvReader(env::get);
+  }
 
   @Test
   @DisplayName("default startupTimeout is 120 seconds")
@@ -95,5 +102,53 @@ class KubeAPIServerConfigBuilderTest {
         .build())
         .isInstanceOf(KubeAPITestException.class)
         .hasMessageContaining("positive");
+  }
+
+  @Test
+  @DisplayName("env var KUBE_API_TEST_STARTUP_TIMEOUT overrides default")
+  void envVarStartupTimeoutOverridesDefault() {
+    var config = builderWithEnv(Map.of(
+        KubeAPIServerConfigBuilder.KUBE_API_TEST_STARTUP_TIMEOUT, "180000")).build();
+
+    assertThat(config.getStartupTimeout()).isEqualTo(180_000);
+  }
+
+  @Test
+  @DisplayName("env var KUBE_API_TEST_OFFLINE_MODE is parsed as boolean")
+  void envVarOfflineModeOverridesDefault() {
+    var config = builderWithEnv(Map.of(
+        KubeAPIServerConfigBuilder.KUBE_API_TEST_OFFLINE_MODE, "true")).build();
+
+    assertThat(config.isOfflineMode()).isTrue();
+  }
+
+  @Test
+  @DisplayName("explicit builder value takes precedence over env var")
+  void explicitValueTakesPrecedenceOverEnvVar() {
+    var config = builderWithEnv(Map.of(
+        KubeAPIServerConfigBuilder.KUBE_API_TEST_STARTUP_TIMEOUT, "999000"))
+        .withStartupTimeout(42_000)
+        .build();
+
+    assertThat(config.getStartupTimeout()).isEqualTo(42_000);
+  }
+
+  @Test
+  @DisplayName("invalid env var KUBE_API_TEST_STARTUP_TIMEOUT throws KubeAPITestException")
+  void invalidEnvVarStartupTimeoutThrows() {
+    assertThatThrownBy(() -> builderWithEnv(Map.of(
+        KubeAPIServerConfigBuilder.KUBE_API_TEST_STARTUP_TIMEOUT, "not-a-number")).build())
+        .isInstanceOf(KubeAPITestException.class)
+        .hasMessageContaining("KUBE_API_TEST_STARTUP_TIMEOUT")
+        .hasMessageContaining("not-a-number");
+  }
+
+  @Test
+  @DisplayName("non-canonical env var KUBE_API_TEST_OFFLINE_MODE throws KubeAPITestException")
+  void nonCanonicalEnvVarBooleanThrows() {
+    assertThatThrownBy(() -> builderWithEnv(Map.of(
+        KubeAPIServerConfigBuilder.KUBE_API_TEST_OFFLINE_MODE, "yes")).build())
+        .isInstanceOf(KubeAPITestException.class)
+        .hasMessageContaining("KUBE_API_TEST_OFFLINE_MODE");
   }
 }

--- a/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/junit/KubeAPIServerExtensionTest.java
+++ b/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/junit/KubeAPIServerExtensionTest.java
@@ -15,10 +15,12 @@
  */
 package io.fabric8.kubeapitest.junit;
 
+import io.fabric8.kubeapitest.KubeAPITestException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class KubeAPIServerExtensionTest {
 
@@ -30,8 +32,12 @@ class KubeAPIServerExtensionTest {
   private static class WithDefaults {
   }
 
+  @EnableKubeAPIServer(startupTimeout = 0)
+  private static class WithZeroTimeout {
+  }
+
   @Test
-  @DisplayName("annotationToConfig sets startupTimeout when annotation specifies a positive value")
+  @DisplayName("annotationToConfig sets startupTimeout when annotation specifies a non-default value")
   void startupTimeoutFromAnnotation() {
     var annotation = WithCustomTimeout.class.getAnnotation(EnableKubeAPIServer.class);
     var extension = new KubeAPIServerExtension();
@@ -48,5 +54,16 @@ class KubeAPIServerExtensionTest {
     var config = extension.annotationToConfig(annotation);
 
     assertThat(config.getStartupTimeout()).isEqualTo(120_000);
+  }
+
+  @Test
+  @DisplayName("annotationToConfig rejects non-positive startupTimeout")
+  void nonPositiveStartupTimeoutFromAnnotation() {
+    var annotation = WithZeroTimeout.class.getAnnotation(EnableKubeAPIServer.class);
+    var extension = new KubeAPIServerExtension();
+
+    assertThatThrownBy(() -> extension.annotationToConfig(annotation))
+        .isInstanceOf(KubeAPITestException.class)
+        .hasMessageContaining("positive");
   }
 }

--- a/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/junit/KubeAPIServerExtensionTest.java
+++ b/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/junit/KubeAPIServerExtensionTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubeapitest.junit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KubeAPIServerExtensionTest {
+
+  @EnableKubeAPIServer(startupTimeout = 180_000)
+  private static class WithCustomTimeout {
+  }
+
+  @EnableKubeAPIServer
+  private static class WithDefaults {
+  }
+
+  @Test
+  @DisplayName("annotationToConfig sets startupTimeout when annotation specifies a positive value")
+  void startupTimeoutFromAnnotation() {
+    var annotation = WithCustomTimeout.class.getAnnotation(EnableKubeAPIServer.class);
+    var extension = new KubeAPIServerExtension();
+    var config = extension.annotationToConfig(annotation);
+
+    assertThat(config.getStartupTimeout()).isEqualTo(180_000);
+  }
+
+  @Test
+  @DisplayName("annotationToConfig uses builder default when annotation startupTimeout is not set")
+  void defaultStartupTimeoutFromAnnotation() {
+    var annotation = WithDefaults.class.getAnnotation(EnableKubeAPIServer.class);
+    var extension = new KubeAPIServerExtension();
+    var config = extension.annotationToConfig(annotation);
+
+    assertThat(config.getStartupTimeout()).isEqualTo(120_000);
+  }
+}


### PR DESCRIPTION
## Summary

- **Fix ClassCastException in env var parsing**: `KubeAPIServerConfigBuilder.finalConfigValue()` used `Class.cast()` to convert env var strings to `Integer`/`Boolean`, which always throws `ClassCastException` since `cast()` only does reference-type widening, not parsing. Replaced with a single generic `finalConfigValue` that takes a `Function<String, T>` parser — callers pass `Integer::valueOf`, `parseStrictBoolean`, or `Function.identity()`.
- **Strict Boolean parsing**: Non-canonical values like `"yes"`, `"1"`, `"on"` are rejected with `KubeAPITestException` (consistent with Integer error path). Only `"true"` / `"false"` (case-insensitive) are accepted.
- **Add `startupTimeout` to `@EnableKubeAPIServer`**: The `withStartupTimeout()` builder method existed but was unreachable from the annotation. Added `startupTimeout` attribute (default `-1` = not set) and wired it through `KubeAPIServerExtension.annotationToConfig()`, so users can write `@EnableKubeAPIServer(startupTimeout = 180000)`.
- **Uniform validation**: `startupTimeout` must be positive — validated in `build()` so all three entry points (annotation, builder API, env var) are protected.
- **Injectable env reader for testability**: Package-private `withEnvReader(UnaryOperator<String>)` lets tests substitute `System::getenv`, following the same pattern as `Config.getHomeDir` in this project.

Fixes #7807

## Test plan

- [x] `parseStrictBoolean` parses `"true"`/`"false"` (case-insensitive), rejects non-canonical values and empty string
- [x] Env var `KUBE_API_TEST_STARTUP_TIMEOUT` correctly parsed as Integer through `build()`
- [x] Env var `KUBE_API_TEST_OFFLINE_MODE` correctly parsed as Boolean through `build()`
- [x] Explicit builder value takes precedence over env var
- [x] Invalid integer env var throws `KubeAPITestException` with env var name and value
- [x] Non-canonical boolean env var throws `KubeAPITestException` with env var name and value
- [x] Non-positive `startupTimeout` rejected from builder API
- [x] `@EnableKubeAPIServer(startupTimeout = 180000)` produces config with `startupTimeout == 180000`
- [x] `@EnableKubeAPIServer` (no startupTimeout) falls through to builder default (120000)
- [x] `@EnableKubeAPIServer(startupTimeout = 0)` rejected with `KubeAPITestException`
- [x] All tests isolated from host environment via `withEnvReader`
- [x] 28 unit tests pass, formatting and license headers clean