### PR TITLE
ci: update chaos test to use helm chart

### DIFF
--- a/.github/workflows/e2e-chaos-tests.yml
+++ b/.github/workflows/e2e-chaos-tests.yml
@@ -27,10 +27,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CHAOS_MESH_VERSION: 2.6.0
-  # When bumping CHAOS_MESH_VERSION, update this checksum to match the new install.sh:
-  #   curl -sSL "https://mirrors.chaos-mesh.org/v<VERSION>/install.sh" | sha256sum
-  CHAOS_MESH_INSTALL_SHA256: 49374b8edb60d1a1f4a68fcb22c0eb9f99338a4e55fa32e51a88c0b9a0ef1adb
+  CHAOS_MESH_VERSION: 2.8.3
   CHAOS_TESTS_MODULE: chaos-tests
   MAVEN_ARGS: -B -C -V -ntp -Dhttp.keepAlive=false -e
 
@@ -70,9 +67,9 @@ jobs:
           version: ${{ matrix.kubernetes }}
       - name: Install Chaos Mesh
         run: |
-          curl -sSL "https://mirrors.chaos-mesh.org/v${CHAOS_MESH_VERSION}/install.sh" -o install.sh
-          echo "${CHAOS_MESH_INSTALL_SHA256}  install.sh" | sha256sum -c -
-          bash install.sh
+          helm repo add chaos-mesh https://charts.chaos-mesh.org
+          kubectl create ns chaos-mesh
+          helm install chaos-mesh chaos-mesh/chaos-mesh -n=chaos-mesh --version ${CHAOS_MESH_VERSION}
           kubectl wait --for=condition=Ready pods --all-namespaces --all --timeout=600s
       - name: Run Chaos Tests
         env:


### PR DESCRIPTION
Fixes #7878 

Update chaos test CI to use chaos mesh helm charts
