### PR TITLE
chore(deps): tidy go.sum and expand gateway-api changelog (8033)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,10 @@
 * Fix #8033: bump gateway-api from 1.5.1 to 1.6.1
 
 #### New Features
-* Fix #8033: gateway-api model gains `v1.TCPRoute` and `v1.UDPRoute` (both graduated from `v1alpha2` upstream in gateway-api v1.6.0; the `v1alpha2` types remain available)
+* Fix #8033: gateway-api model gains `v1.TCPRoute` and `v1.UDPRoute` (both graduated from `v1alpha2` upstream in gateway-api v1.6.0). The `v1alpha2` types remain available, but upstream has deprecated them and will remove them in a future release, so new code should use the `v1` types
 
 #### _**Note**_: Breaking changes
-* Fix #8033: gateway-api model `v1.SessionPersistence` no longer exposes `idleTimeout` (removed upstream in gateway-api v1.6.0)
+* Fix #8033: gateway-api model `v1.SessionPersistence` no longer exposes `idleTimeout` (removed upstream in gateway-api v1.6.0). Besides the field, this removes `getIdleTimeout()`/`setIdleTimeout()`, collapses the canonical constructor from five arguments to four, and drops `SessionPersistenceFluent.withIdleTimeout()`/`getIdleTimeout()`/`hasIdleTimeout()`, so the builder form (`withNewSessionPersistence().withIdleTimeout(...)`) no longer compiles. There is no runtime data loss: the class keeps its `@JsonAnyGetter`/`@JsonAnySetter`, and both the fluent and the builder carry `additionalProperties` through, so JSON or YAML still containing `idleTimeout` continues to deserialize and re-serialize intact
 * Fix #8028: (kube-api-test) `Fabric8ClientInjectionHandler` moved to `io.fabric8.kubeapitest.junit.inject`. It is resolved through `ServiceLoader`, so only code naming the class directly is affected
 * Fix #8028: (openshift-model) The bundle no longer exports or contains `io.fabric8.openshift.api.model.config.*`. Maven consumers are unaffected (`openshift-model-config` is a compile dependency), but OSGi deployments importing those packages must install the `openshift-model-config` bundle, which the `openshift-client` Karaf feature already does
 

--- a/kubernetes-model-generator/openapi/generator/go.sum
+++ b/kubernetes-model-generator/openapi/generator/go.sum
@@ -6538,8 +6538,6 @@ k8s.io/kube-openapi v0.0.0-20220124234850-424119656bbf/go.mod h1:sX9MT8g7NVZM5lV
 k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00/go.mod h1:AsvuZPBlUDVuCdzJ87iajxtXuR9oktsTctW/R9wwouA=
 k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340/go.mod h1:yD4MZYeKMBwQKVht279WycxKyM84kkAx2DPrTXaeb98=
 k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912/go.mod h1:kdmbQkyfwUagLfXIad1y2TdrjPFWp2Q89B3qkRwf/pQ=
-k8s.io/kube-openapi v0.0.0-20260414162039-ec9c827d403f h1:4Qiq0YAoQATdgmHALJWz9rJ4fj20pB3xebpB4CFNhYM=
-k8s.io/kube-openapi v0.0.0-20260414162039-ec9c827d403f/go.mod h1:uGBT7iTA6c6MvqUvSXIaYZo9ukscABYi2btjhvgKGZ0=
 k8s.io/kube-openapi v0.0.0-20260501160325-927ab1f70cd6 h1:ngxu1nL4SbFuXwu1EY7cSKcVqSjTQPVbYQT6WNjTXaU=
 k8s.io/kube-openapi v0.0.0-20260501160325-927ab1f70cd6/go.mod h1:uGBT7iTA6c6MvqUvSXIaYZo9ukscABYi2btjhvgKGZ0=
 k8s.io/metrics v0.36.1 h1:MQPb+G4RhrKEpt8NETPssbW8QgGUc4Jbqu1jx+kPqGk=
@@ -6672,8 +6670,6 @@ sigs.k8s.io/cluster-api-provider-azure v1.22.1 h1:BAzjKZR6Fzwu4oq0AwAeILT/FoyEzS
 sigs.k8s.io/cluster-api-provider-azure v1.22.1/go.mod h1:T+9N2Gt7plZ+29VSN6Ncw75lx9ANH19uN4OxzVRQKZk=
 sigs.k8s.io/controller-runtime v0.19.7 h1:DLABZfMr20A+AwCZOHhcbcu+TqBXnJZaVBri9K3EO48=
 sigs.k8s.io/controller-runtime v0.19.7/go.mod h1:iRmWllt8IlaLjvTTDLhRBXIEtkCK6hwVBJJsYS9Ajf4=
-sigs.k8s.io/gateway-api v1.5.1 h1:RqVRIlkhLhUO8wOHKTLnTJA6o/1un4po4/6M1nRzdd0=
-sigs.k8s.io/gateway-api v1.5.1/go.mod h1:GvCETiaMAlLym5CovLxGjS0NysqFk3+Yuq3/rh6QL2o=
 sigs.k8s.io/gateway-api v1.6.1 h1:mock6phZbI6rvZerwrVNk7hVNymQgHo+6sJ81Ia7ftY=
 sigs.k8s.io/gateway-api v1.6.1/go.mod h1:FVfx3t389ybeXOqvDghLbdvJdSCfI/PReqCUI3lu3mY=
 sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6/go.mod h1:p4QtZmO4uMYipTQNzagwnNoseA6OxSUutVw05NhYDRs=


### PR DESCRIPTION
Follow-up to #8033.

### go.sum

The gateway-api v1.6.1 bump left the superseded hashes for
`sigs.k8s.io/gateway-api v1.5.1` and
`k8s.io/kube-openapi v0.0.0-20260414162039-ec9c827d403f` in `go.sum`
alongside the new ones. That is what `go get` produces; `go mod tidy`
prunes them, and the previous bumps of both dependencies did so.

Nothing was broken by it: the build, `go mod verify` and the `setup-go`
cache key are all unaffected, and no CI job inspects `go.sum`. This is
hygiene, so the next contributor to run `go mod tidy` does not pick up an
unrelated four-line deletion.

Worth recording for next time: `go mod tidy` cannot run on a clean
checkout of this module. `cmd/openapi.go` declares
`//go:generate go run ../tools/generator/openapi.go`, and the
`cmd/generated_*_openapi` packages it produces are not committed, so tidy
fails to resolve the `cmd` package. The sequence is `go generate ./...`
then `go mod tidy`, which is what the `openapi-generate-schema` target
already does.

`go.mod` is unchanged, and the generator still builds with
`-mod=readonly`, which would fail on any missing `go.sum` entry.

### CHANGELOG

Two clarifications to the existing #8033 entries:

- gateway-api v1.6.0 did not merely keep `v1alpha2.TCPRoute`/`UDPRoute`
  around, it deprecated them and will remove them in a future release.
  The generated code carries no `@Deprecated` marker and the v1alpha2
  descriptions are identical to the new v1 ones, so the changelog is the
  only place a user would learn this.
- The `SessionPersistence.idleTimeout` removal also drops
  `getIdleTimeout()`/`setIdleTimeout()`, collapses the canonical
  constructor from five arguments to four, and removes
  `SessionPersistenceFluent.withIdleTimeout()`/`getIdleTimeout()`/
  `hasIdleTimeout()`. The builder form is the one most likely to appear
  in user code. The entry now also records that there is no runtime data
  loss, since `additionalProperties` carries the field through.