### PR TITLE
feat(kubernetes-client-api,kubernetes-client): add typed DSL accessor…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Fix #8033: bump gateway-api from 1.5.1 to 1.6.1
 
 #### New Features
+* Fix #8041: (kubernetes-client-api, kubernetes-client) `V1CertificatesAPIGroupDSL` gains a typed `podCertificateRequests()` accessor and `V1DynamicresourceAllocationAPIGroupDSL` gains a typed `deviceTaintRules()` accessor, matching the typed-DSL treatment already given to other v1.37 resources (e.g. `ClusterTrustBundle`). Both resources were previously reachable only through the generic `client.resources(...)` API
 * Fix #7752: Support for Kubernetes v1.37.0 (Garhwal)
 * Fix #8033: gateway-api model gains `v1.TCPRoute` and `v1.UDPRoute` (both graduated from `v1alpha2` upstream in gateway-api v1.6.0). The `v1alpha2` types remain available, but upstream has deprecated them and will remove them in a future release, so new code should use the `v1` types
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/V1CertificatesAPIGroupDSL.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/V1CertificatesAPIGroupDSL.java
@@ -19,10 +19,14 @@ import io.fabric8.kubernetes.api.model.certificates.v1.CertificateSigningRequest
 import io.fabric8.kubernetes.api.model.certificates.v1.CertificateSigningRequestList;
 import io.fabric8.kubernetes.api.model.certificates.v1.ClusterTrustBundle;
 import io.fabric8.kubernetes.api.model.certificates.v1.ClusterTrustBundleList;
+import io.fabric8.kubernetes.api.model.certificates.v1.PodCertificateRequest;
+import io.fabric8.kubernetes.api.model.certificates.v1.PodCertificateRequestList;
 import io.fabric8.kubernetes.client.Client;
 
 public interface V1CertificatesAPIGroupDSL extends Client {
   NonNamespaceOperation<CertificateSigningRequest, CertificateSigningRequestList, CertificateSigningRequestResource<CertificateSigningRequest>> certificateSigningRequests();
 
   NonNamespaceOperation<ClusterTrustBundle, ClusterTrustBundleList, Resource<ClusterTrustBundle>> clusterTrustBundles();
+
+  MixedOperation<PodCertificateRequest, PodCertificateRequestList, Resource<PodCertificateRequest>> podCertificateRequests();
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/V1DynamicresourceAllocationAPIGroupDSL.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/V1DynamicresourceAllocationAPIGroupDSL.java
@@ -46,4 +46,11 @@ public interface V1DynamicresourceAllocationAPIGroupDSL extends Client {
    * @return {@link NonNamespaceOperation} for ResourceSlice
    */
   NonNamespaceOperation<ResourceSlice, ResourceSliceList, Resource<ResourceSlice>> resourcesSlices();
+
+  /**
+   * API entrypoint for resource.k8s.io/v1 DeviceTaintRule (cluster-scoped)
+   *
+   * @return {@link NonNamespaceOperation} for DeviceTaintRule
+   */
+  NonNamespaceOperation<DeviceTaintRule, DeviceTaintRuleList, Resource<DeviceTaintRule>> deviceTaintRules();
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/impl/V1CertificatesAPIGroupClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/impl/V1CertificatesAPIGroupClient.java
@@ -19,7 +19,10 @@ import io.fabric8.kubernetes.api.model.certificates.v1.CertificateSigningRequest
 import io.fabric8.kubernetes.api.model.certificates.v1.CertificateSigningRequestList;
 import io.fabric8.kubernetes.api.model.certificates.v1.ClusterTrustBundle;
 import io.fabric8.kubernetes.api.model.certificates.v1.ClusterTrustBundleList;
+import io.fabric8.kubernetes.api.model.certificates.v1.PodCertificateRequest;
+import io.fabric8.kubernetes.api.model.certificates.v1.PodCertificateRequestList;
 import io.fabric8.kubernetes.client.dsl.CertificateSigningRequestResource;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.V1CertificatesAPIGroupDSL;
@@ -39,6 +42,11 @@ public class V1CertificatesAPIGroupClient extends ClientAdapter<V1CertificatesAP
   @Override
   public NonNamespaceOperation<ClusterTrustBundle, ClusterTrustBundleList, Resource<ClusterTrustBundle>> clusterTrustBundles() {
     return resources(ClusterTrustBundle.class, ClusterTrustBundleList.class);
+  }
+
+  @Override
+  public MixedOperation<PodCertificateRequest, PodCertificateRequestList, Resource<PodCertificateRequest>> podCertificateRequests() {
+    return resources(PodCertificateRequest.class, PodCertificateRequestList.class);
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/impl/V1DynamicResourceAllocationAPIGroupClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/impl/V1DynamicResourceAllocationAPIGroupClient.java
@@ -48,4 +48,9 @@ public class V1DynamicResourceAllocationAPIGroupClient extends
   public NonNamespaceOperation<ResourceSlice, ResourceSliceList, Resource<ResourceSlice>> resourcesSlices() {
     return resources(ResourceSlice.class, ResourceSliceList.class);
   }
+
+  @Override
+  public NonNamespaceOperation<DeviceTaintRule, DeviceTaintRuleList, Resource<DeviceTaintRule>> deviceTaintRules() {
+    return resources(DeviceTaintRule.class, DeviceTaintRuleList.class);
+  }
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodCertificateRequestTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodCertificateRequestTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock;
+
+import io.fabric8.kubernetes.api.model.certificates.v1.PodCertificateRequest;
+import io.fabric8.kubernetes.api.model.certificates.v1.PodCertificateRequestBuilder;
+import io.fabric8.kubernetes.api.model.certificates.v1.PodCertificateRequestList;
+import io.fabric8.kubernetes.api.model.certificates.v1.PodCertificateRequestListBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnableKubernetesMockClient(https = false)
+class PodCertificateRequestTest {
+  KubernetesMockServer server;
+  KubernetesClient client;
+
+  @Test
+  void get() {
+    // Given
+    server.expect().get()
+        .withPath("/apis/certificates.k8s.io/v1/namespaces/test/podcertificaterequests/test-pcr")
+        .andReturn(HttpURLConnection.HTTP_OK, createNewPodCertificateRequest("test-pcr"))
+        .once();
+
+    // When
+    PodCertificateRequest podCertificateRequest = client.certificates().v1().podCertificateRequests()
+        .inNamespace("test").withName("test-pcr").get();
+
+    // Then
+    assertThat(podCertificateRequest)
+        .isNotNull()
+        .hasFieldOrPropertyWithValue("metadata.name", "test-pcr");
+  }
+
+  @Test
+  void list() {
+    // Given
+    server.expect().get().withPath("/apis/certificates.k8s.io/v1/namespaces/test/podcertificaterequests")
+        .andReturn(HttpURLConnection.HTTP_OK, new PodCertificateRequestListBuilder()
+            .addToItems(createNewPodCertificateRequest("pcr1"))
+            .addToItems(createNewPodCertificateRequest("pcr2"))
+            .build())
+        .once();
+
+    // When
+    PodCertificateRequestList podCertificateRequestList = client.certificates().v1().podCertificateRequests()
+        .inNamespace("test").list();
+
+    // Then
+    assertThat(podCertificateRequestList).isNotNull();
+    assertThat(podCertificateRequestList.getItems()).hasSize(2);
+  }
+
+  @Test
+  void create() {
+    // Given
+    PodCertificateRequest podCertificateRequest = createNewPodCertificateRequest("new-pcr");
+    server.expect().post().withPath("/apis/certificates.k8s.io/v1/namespaces/test/podcertificaterequests")
+        .andReturn(HttpURLConnection.HTTP_CREATED, podCertificateRequest)
+        .once();
+
+    // When
+    PodCertificateRequest created = client.certificates().v1().podCertificateRequests()
+        .inNamespace("test").resource(podCertificateRequest).create();
+
+    // Then
+    assertThat(created)
+        .isNotNull()
+        .hasFieldOrPropertyWithValue("metadata.name", "new-pcr");
+  }
+
+  @Test
+  void delete() {
+    // Given
+    server.expect().delete()
+        .withPath("/apis/certificates.k8s.io/v1/namespaces/test/podcertificaterequests/pcr-to-delete")
+        .andReturn(HttpURLConnection.HTTP_OK, createNewPodCertificateRequest("pcr-to-delete"))
+        .once();
+
+    // When
+    boolean isDeleted = client.certificates().v1().podCertificateRequests()
+        .inNamespace("test").withName("pcr-to-delete").withGracePeriod(0).delete().size() == 1;
+
+    // Then
+    assertThat(isDeleted).isTrue();
+  }
+
+  private PodCertificateRequest createNewPodCertificateRequest(String name) {
+    return new PodCertificateRequestBuilder()
+        .withNewMetadata()
+        .withName(name)
+        .withNamespace("test")
+        .endMetadata()
+        .withNewSpec()
+        .withPodName("test-pod")
+        .withPodUID("test-pod-uid")
+        .withServiceAccountName("test-sa")
+        .withServiceAccountUID("test-sa-uid")
+        .withNodeName("test-node")
+        .withNodeUID("test-node-uid")
+        .withSignerName("example.com/signer")
+        .withMaxExpirationSeconds(86400)
+        .endSpec()
+        .build();
+  }
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1DynamicResourceAllocationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1DynamicResourceAllocationTest.java
@@ -19,6 +19,10 @@ import io.fabric8.kubernetes.api.model.resource.v1.DeviceClass;
 import io.fabric8.kubernetes.api.model.resource.v1.DeviceClassBuilder;
 import io.fabric8.kubernetes.api.model.resource.v1.DeviceClassList;
 import io.fabric8.kubernetes.api.model.resource.v1.DeviceClassListBuilder;
+import io.fabric8.kubernetes.api.model.resource.v1.DeviceTaintRule;
+import io.fabric8.kubernetes.api.model.resource.v1.DeviceTaintRuleBuilder;
+import io.fabric8.kubernetes.api.model.resource.v1.DeviceTaintRuleList;
+import io.fabric8.kubernetes.api.model.resource.v1.DeviceTaintRuleListBuilder;
 import io.fabric8.kubernetes.api.model.resource.v1.ResourceClaim;
 import io.fabric8.kubernetes.api.model.resource.v1.ResourceClaimBuilder;
 import io.fabric8.kubernetes.api.model.resource.v1.ResourceClaimList;
@@ -325,6 +329,75 @@ class V1DynamicResourceAllocationTest {
     assertThat(isDeleted).isTrue();
   }
 
+  // DeviceTaintRule Tests (Cluster-scoped)
+  @Test
+  void deviceTaintRuleGet() {
+    // Given
+    server.expect().get().withPath("/apis/resource.k8s.io/v1/devicetaintrules/test-device-taint-rule")
+        .andReturn(HttpURLConnection.HTTP_OK, createNewDeviceTaintRule("test-device-taint-rule"))
+        .once();
+
+    // When
+    DeviceTaintRule deviceTaintRule = client.dynamicResourceAllocation().v1().deviceTaintRules()
+        .withName("test-device-taint-rule").get();
+
+    // Then
+    assertThat(deviceTaintRule)
+        .isNotNull()
+        .hasFieldOrPropertyWithValue("metadata.name", "test-device-taint-rule");
+  }
+
+  @Test
+  void deviceTaintRuleList() {
+    // Given
+    server.expect().get().withPath("/apis/resource.k8s.io/v1/devicetaintrules")
+        .andReturn(HttpURLConnection.HTTP_OK, new DeviceTaintRuleListBuilder()
+            .addToItems(createNewDeviceTaintRule("rule1"))
+            .addToItems(createNewDeviceTaintRule("rule2"))
+            .build())
+        .once();
+
+    // When
+    DeviceTaintRuleList deviceTaintRuleList = client.dynamicResourceAllocation().v1().deviceTaintRules().list();
+
+    // Then
+    assertThat(deviceTaintRuleList).isNotNull();
+    assertThat(deviceTaintRuleList.getItems()).hasSize(2);
+  }
+
+  @Test
+  void deviceTaintRuleCreate() {
+    // Given
+    DeviceTaintRule deviceTaintRule = createNewDeviceTaintRule("new-device-taint-rule");
+    server.expect().post().withPath("/apis/resource.k8s.io/v1/devicetaintrules")
+        .andReturn(HttpURLConnection.HTTP_CREATED, deviceTaintRule)
+        .once();
+
+    // When
+    DeviceTaintRule created = client.dynamicResourceAllocation().v1().deviceTaintRules()
+        .resource(deviceTaintRule).create();
+
+    // Then
+    assertThat(created)
+        .isNotNull()
+        .hasFieldOrPropertyWithValue("metadata.name", "new-device-taint-rule");
+  }
+
+  @Test
+  void deviceTaintRuleDelete() {
+    // Given
+    server.expect().delete().withPath("/apis/resource.k8s.io/v1/devicetaintrules/device-taint-rule-to-delete")
+        .andReturn(HttpURLConnection.HTTP_OK, createNewDeviceTaintRule("device-taint-rule-to-delete"))
+        .once();
+
+    // When
+    boolean isDeleted = client.dynamicResourceAllocation().v1().deviceTaintRules()
+        .withName("device-taint-rule-to-delete").withGracePeriod(0).delete().size() == 1;
+
+    // Then
+    assertThat(isDeleted).isTrue();
+  }
+
   // Helper methods to create test resources
   private ResourceClaim createNewResourceClaim(String name) {
     return new ResourceClaimBuilder()
@@ -396,6 +469,21 @@ class V1DynamicResourceAllocationTest {
         .withGeneration(1L)
         .withResourceSliceCount(1L)
         .endPool()
+        .endSpec()
+        .build();
+  }
+
+  private DeviceTaintRule createNewDeviceTaintRule(String name) {
+    return new DeviceTaintRuleBuilder()
+        .withNewMetadata()
+        .withName(name)
+        .endMetadata()
+        .withNewSpec()
+        .withNewTaint()
+        .withKey("example.com/taint")
+        .withValue("true")
+        .withEffect("NoSchedule")
+        .endTaint()
         .endSpec()
         .build();
   }


### PR DESCRIPTION
## Description

Add podCertificateRequests() to V1CertificatesAPIGroupDSL and deviceTaintRules() to V1DynamicresourceAllocationAPIGroupDSL, matching the typed-DSL treatment already given to other v1.37 resources (e.g. ClusterTrustBundle). Both resources were previously reachable only through the generic client.resources(...) API.

- podCertificateRequests(): namespaced MixedOperation<PodCertificateRequest, ...>
- deviceTaintRules(): cluster-scoped NonNamespaceOperation<DeviceTaintRule, ...>

Adds CRUD mock-server tests for both (PodCertificateRequestTest.java, new DeviceTaintRule cases in V1DynamicResourceAllocationTest.java) and a CHANGELOG.md entry.

Fix #8041

## Type of change

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase; test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: Apache 2.0
 - [x] I Added CHANGELOG entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the javadocs and other documentation accordingly
 - [ ] No new bugs, code smells, etc. in SonarCloud report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift