### PR TITLE
Fix #8041: Add typed DSL accessors for PodCertificateRequest and DeviceTaintRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Fix #8033: bump gateway-api from 1.5.1 to 1.6.1
 
 #### New Features
+* Fix #8041: (kubernetes-client-api, kubernetes-client) Add typed DSL accessors for `PodCertificateRequest` and `DeviceTaintRule`
 * Fix #7752: Support for Kubernetes v1.37.0 (Garhwal)
 * Fix #8033: gateway-api model gains `v1.TCPRoute` and `v1.UDPRoute` (both graduated from `v1alpha2` upstream in gateway-api v1.6.0). The `v1alpha2` types remain available, but upstream has deprecated them and will remove them in a future release, so new code should use the `v1` types
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/V1CertificatesAPIGroupDSL.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/V1CertificatesAPIGroupDSL.java
@@ -19,10 +19,14 @@ import io.fabric8.kubernetes.api.model.certificates.v1.CertificateSigningRequest
 import io.fabric8.kubernetes.api.model.certificates.v1.CertificateSigningRequestList;
 import io.fabric8.kubernetes.api.model.certificates.v1.ClusterTrustBundle;
 import io.fabric8.kubernetes.api.model.certificates.v1.ClusterTrustBundleList;
+import io.fabric8.kubernetes.api.model.certificates.v1.PodCertificateRequest;
+import io.fabric8.kubernetes.api.model.certificates.v1.PodCertificateRequestList;
 import io.fabric8.kubernetes.client.Client;
 
 public interface V1CertificatesAPIGroupDSL extends Client {
   NonNamespaceOperation<CertificateSigningRequest, CertificateSigningRequestList, CertificateSigningRequestResource<CertificateSigningRequest>> certificateSigningRequests();
 
   NonNamespaceOperation<ClusterTrustBundle, ClusterTrustBundleList, Resource<ClusterTrustBundle>> clusterTrustBundles();
+
+  MixedOperation<PodCertificateRequest, PodCertificateRequestList, Resource<PodCertificateRequest>> podCertificateRequests();
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/V1DynamicresourceAllocationAPIGroupDSL.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/V1DynamicresourceAllocationAPIGroupDSL.java
@@ -41,6 +41,13 @@ public interface V1DynamicresourceAllocationAPIGroupDSL extends Client {
   NonNamespaceOperation<DeviceClass, DeviceClassList, Resource<DeviceClass>> deviceClasses();
 
   /**
+   * API entrypoint for resource.k8s.io/v1 DeviceTaintRule (cluster-scoped)
+   *
+   * @return {@link NonNamespaceOperation} for DeviceTaintRule
+   */
+  NonNamespaceOperation<DeviceTaintRule, DeviceTaintRuleList, Resource<DeviceTaintRule>> deviceTaintRules();
+
+  /**
    * API entrypoint for resource.k8s.io/v1 ResourceSlice (cluster-scoped)
    *
    * @return {@link NonNamespaceOperation} for ResourceSlice

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/impl/V1CertificatesAPIGroupClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/impl/V1CertificatesAPIGroupClient.java
@@ -19,7 +19,10 @@ import io.fabric8.kubernetes.api.model.certificates.v1.CertificateSigningRequest
 import io.fabric8.kubernetes.api.model.certificates.v1.CertificateSigningRequestList;
 import io.fabric8.kubernetes.api.model.certificates.v1.ClusterTrustBundle;
 import io.fabric8.kubernetes.api.model.certificates.v1.ClusterTrustBundleList;
+import io.fabric8.kubernetes.api.model.certificates.v1.PodCertificateRequest;
+import io.fabric8.kubernetes.api.model.certificates.v1.PodCertificateRequestList;
 import io.fabric8.kubernetes.client.dsl.CertificateSigningRequestResource;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.V1CertificatesAPIGroupDSL;
@@ -39,6 +42,11 @@ public class V1CertificatesAPIGroupClient extends ClientAdapter<V1CertificatesAP
   @Override
   public NonNamespaceOperation<ClusterTrustBundle, ClusterTrustBundleList, Resource<ClusterTrustBundle>> clusterTrustBundles() {
     return resources(ClusterTrustBundle.class, ClusterTrustBundleList.class);
+  }
+
+  @Override
+  public MixedOperation<PodCertificateRequest, PodCertificateRequestList, Resource<PodCertificateRequest>> podCertificateRequests() {
+    return resources(PodCertificateRequest.class, PodCertificateRequestList.class);
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/impl/V1DynamicResourceAllocationAPIGroupClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/impl/V1DynamicResourceAllocationAPIGroupClient.java
@@ -45,6 +45,11 @@ public class V1DynamicResourceAllocationAPIGroupClient extends
   }
 
   @Override
+  public NonNamespaceOperation<DeviceTaintRule, DeviceTaintRuleList, Resource<DeviceTaintRule>> deviceTaintRules() {
+    return resources(DeviceTaintRule.class, DeviceTaintRuleList.class);
+  }
+
+  @Override
   public NonNamespaceOperation<ResourceSlice, ResourceSliceList, Resource<ResourceSlice>> resourcesSlices() {
     return resources(ResourceSlice.class, ResourceSliceList.class);
   }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodCertificateRequestTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodCertificateRequestTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock;
+
+import io.fabric8.kubernetes.api.model.certificates.v1.PodCertificateRequest;
+import io.fabric8.kubernetes.api.model.certificates.v1.PodCertificateRequestBuilder;
+import io.fabric8.kubernetes.api.model.certificates.v1.PodCertificateRequestList;
+import io.fabric8.kubernetes.api.model.certificates.v1.PodCertificateRequestListBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnableKubernetesMockClient(https = false)
+class PodCertificateRequestTest {
+  KubernetesMockServer server;
+  KubernetesClient client;
+
+  @Test
+  void get() {
+    // Given
+    server.expect().get().withPath("/apis/certificates.k8s.io/v1/namespaces/test/podcertificaterequests/test-get")
+        .andReturn(HttpURLConnection.HTTP_OK, createNewPodCertificateRequest("test-get"))
+        .once();
+
+    // When
+    PodCertificateRequest podCertificateRequest = client.certificates().v1().podCertificateRequests()
+        .inNamespace("test").withName("test-get").get();
+
+    // Then
+    assertThat(podCertificateRequest)
+        .isNotNull()
+        .hasFieldOrPropertyWithValue("metadata.name", "test-get");
+  }
+
+  @Test
+  void list() {
+    // Given
+    server.expect().get().withPath("/apis/certificates.k8s.io/v1/namespaces/test/podcertificaterequests")
+        .andReturn(HttpURLConnection.HTTP_OK, new PodCertificateRequestListBuilder()
+            .addToItems(createNewPodCertificateRequest("test-list"))
+            .build())
+        .once();
+
+    // When
+    PodCertificateRequestList podCertificateRequestList = client.certificates().v1().podCertificateRequests()
+        .inNamespace("test").list();
+
+    // Then
+    assertThat(podCertificateRequestList).isNotNull();
+    assertThat(podCertificateRequestList.getItems()).hasSize(1);
+    assertThat(podCertificateRequestList.getItems().get(0))
+        .hasFieldOrPropertyWithValue("metadata.name", "test-list");
+  }
+
+  @Test
+  void create() {
+    // Given
+    PodCertificateRequest podCertificateRequest = createNewPodCertificateRequest("test-create");
+    server.expect().post().withPath("/apis/certificates.k8s.io/v1/namespaces/test/podcertificaterequests")
+        .andReturn(HttpURLConnection.HTTP_CREATED, podCertificateRequest)
+        .once();
+
+    // When
+    PodCertificateRequest created = client.certificates().v1().podCertificateRequests().inNamespace("test")
+        .resource(podCertificateRequest).create();
+
+    // Then
+    assertThat(created)
+        .isNotNull()
+        .hasFieldOrPropertyWithValue("metadata.name", "test-create");
+  }
+
+  @Test
+  void delete() {
+    // Given
+    server.expect().delete()
+        .withPath("/apis/certificates.k8s.io/v1/namespaces/test/podcertificaterequests/test-delete")
+        .andReturn(HttpURLConnection.HTTP_OK, createNewPodCertificateRequest("test-delete"))
+        .once();
+
+    // When
+    boolean isDeleted = client.certificates().v1().podCertificateRequests().inNamespace("test")
+        .withName("test-delete").withGracePeriod(0).delete().size() == 1;
+
+    // Then
+    assertThat(isDeleted).isTrue();
+  }
+
+  private PodCertificateRequest createNewPodCertificateRequest(String name) {
+    return new PodCertificateRequestBuilder()
+        .withNewMetadata()
+        .withName(name)
+        .endMetadata()
+        .build();
+  }
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1DynamicResourceAllocationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1DynamicResourceAllocationTest.java
@@ -19,6 +19,10 @@ import io.fabric8.kubernetes.api.model.resource.v1.DeviceClass;
 import io.fabric8.kubernetes.api.model.resource.v1.DeviceClassBuilder;
 import io.fabric8.kubernetes.api.model.resource.v1.DeviceClassList;
 import io.fabric8.kubernetes.api.model.resource.v1.DeviceClassListBuilder;
+import io.fabric8.kubernetes.api.model.resource.v1.DeviceTaintRule;
+import io.fabric8.kubernetes.api.model.resource.v1.DeviceTaintRuleBuilder;
+import io.fabric8.kubernetes.api.model.resource.v1.DeviceTaintRuleList;
+import io.fabric8.kubernetes.api.model.resource.v1.DeviceTaintRuleListBuilder;
 import io.fabric8.kubernetes.api.model.resource.v1.ResourceClaim;
 import io.fabric8.kubernetes.api.model.resource.v1.ResourceClaimBuilder;
 import io.fabric8.kubernetes.api.model.resource.v1.ResourceClaimList;
@@ -256,6 +260,75 @@ class V1DynamicResourceAllocationTest {
     assertThat(isDeleted).isTrue();
   }
 
+  // DeviceTaintRule Tests (Cluster-scoped)
+  @Test
+  void deviceTaintRuleGet() {
+    // Given
+    server.expect().get().withPath("/apis/resource.k8s.io/v1/devicetaintrules/test-device-taint-rule")
+        .andReturn(HttpURLConnection.HTTP_OK, createNewDeviceTaintRule("test-device-taint-rule"))
+        .once();
+
+    // When
+    DeviceTaintRule deviceTaintRule = client.dynamicResourceAllocation().v1().deviceTaintRules()
+        .withName("test-device-taint-rule").get();
+
+    // Then
+    assertThat(deviceTaintRule)
+        .isNotNull()
+        .hasFieldOrPropertyWithValue("metadata.name", "test-device-taint-rule");
+  }
+
+  @Test
+  void deviceTaintRuleList() {
+    // Given
+    server.expect().get().withPath("/apis/resource.k8s.io/v1/devicetaintrules")
+        .andReturn(HttpURLConnection.HTTP_OK, new DeviceTaintRuleListBuilder()
+            .addToItems(createNewDeviceTaintRule("taint-rule1"))
+            .addToItems(createNewDeviceTaintRule("taint-rule2"))
+            .build())
+        .once();
+
+    // When
+    DeviceTaintRuleList deviceTaintRuleList = client.dynamicResourceAllocation().v1().deviceTaintRules().list();
+
+    // Then
+    assertThat(deviceTaintRuleList).isNotNull();
+    assertThat(deviceTaintRuleList.getItems()).hasSize(2);
+  }
+
+  @Test
+  void deviceTaintRuleCreate() {
+    // Given
+    DeviceTaintRule deviceTaintRule = createNewDeviceTaintRule("new-device-taint-rule");
+    server.expect().post().withPath("/apis/resource.k8s.io/v1/devicetaintrules")
+        .andReturn(HttpURLConnection.HTTP_CREATED, deviceTaintRule)
+        .once();
+
+    // When
+    DeviceTaintRule created = client.dynamicResourceAllocation().v1().deviceTaintRules()
+        .resource(deviceTaintRule).create();
+
+    // Then
+    assertThat(created)
+        .isNotNull()
+        .hasFieldOrPropertyWithValue("metadata.name", "new-device-taint-rule");
+  }
+
+  @Test
+  void deviceTaintRuleDelete() {
+    // Given
+    server.expect().delete().withPath("/apis/resource.k8s.io/v1/devicetaintrules/device-taint-rule-to-delete")
+        .andReturn(HttpURLConnection.HTTP_OK, createNewDeviceTaintRule("device-taint-rule-to-delete"))
+        .once();
+
+    // When
+    boolean isDeleted = client.dynamicResourceAllocation().v1().deviceTaintRules()
+        .withName("device-taint-rule-to-delete").withGracePeriod(0).delete().size() == 1;
+
+    // Then
+    assertThat(isDeleted).isTrue();
+  }
+
   // ResourceSlice Tests (Cluster-scoped)
   @Test
   void resourceSliceGet() {
@@ -381,6 +454,14 @@ class V1DynamicResourceAllocationTest {
         .endCel()
         .endSelector()
         .endSpec()
+        .build();
+  }
+
+  private DeviceTaintRule createNewDeviceTaintRule(String name) {
+    return new DeviceTaintRuleBuilder()
+        .withNewMetadata()
+        .withName(name)
+        .endMetadata()
         .build();
   }
 


### PR DESCRIPTION
## Description

Issue #8041 requests typed DSL accessors for the Kubernetes v1.37 `PodCertificateRequest` and `DeviceTaintRule` resources. Their generated model classes already exist, but they were not exposed through the versioned Fabric8 Kubernetes Client DSL.

This PR adds:

- `client.certificates().v1().podCertificateRequests()`
  - Uses `MixedOperation`
  - Correctly supports namespaced API paths
- `client.dynamicResourceAllocation().v1().deviceTaintRules()`
  - Uses `NonNamespaceOperation`
  - Correctly supports cluster-scoped API paths

Both accessors delegate through the existing `resources(resourceClass, listClass)` pattern.

Tests were added or updated to cover get, list, create, and delete operations, including verification of the expected namespaced and cluster-scoped request URLs.

No generated Kubernetes model files or unrelated files were modified.

Fixes #8041

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Breaking change
- [ ] Chore

## Verification

- Spotless check passed for the affected modules.
- Focused tests passed:
  - 24 tests
  - 0 failures
  - 0 errors
  - 0 skipped
- `git diff --check` passed.

## Checklist

- [x] Code contributed by me aligns with the Apache 2.0 license.
- [x] A CHANGELOG entry was added.
- [x] Unit tests were added or updated to cover the changes.
- [x] Accessor Javadocs and formatting follow existing project conventions.
- [ ] SonarCloud verification was not performed locally.
- [ ] Kubernetes integration testing was not performed; mock-server coverage was added.
- [ ] OpenShift testing is not applicable to this change.