### PR TITLE
fix(karaf): restore OSGi service activation under Java 17, and follow-ups from the baseline move

### DIFF
--- a/.claude/skills/k8s-model-update/SKILL.md
+++ b/.claude/skills/k8s-model-update/SKILL.md
@@ -29,11 +29,9 @@ The process has four user-confirmation checkpoints so nothing ships without revi
 
 ## Prerequisites
 
-- **Minimum Java 17** — required to build and run the project.
-- **Java 17 is the preferred JDK for model generation** (`make generate-model`). JDK 25 is NOT supported.
-- **`make format` requires minimum Java 17** — the Spotless formatter and license-header tooling need JDK 17+.
+- **Java 17** — required to build the project, to generate the model (`make generate-model`) and to run `make format`. JDK 25 is NOT supported.
 
-Before starting, verify the active JDK version (`java -version`). Switch JDK versions between steps as needed (e.g., JDK 17 for generation, JDK 17+ for formatting).
+Before starting, verify the active JDK version (`java -version`).
 
 ---
 

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -58,7 +58,10 @@ jobs:
           cache: 'maven'
       - name: Build Project
         shell: bash
-        run: ./mvnw ${MAVEN_ARGS} install
+        # The Karaf integration tests are skipped here: they take ~3x longer on Windows than on
+        # Linux and the Karaf shell emits a spurious "Terminal has been closed" error annotation
+        # on shutdown. The Linux build matrix covers them on both Java 17 and 21.
+        run: ./mvnw ${MAVEN_ARGS} install -Dkaraf.itest.skip=true
       - name: Drop in-repo artifacts before cache save
         # Don't let io.fabric8:* jars installed by this run leak into the cache that future
         # runs restore. Only third-party dependencies should be cached.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,14 @@
 * Fix #8050: (karaf) `KubernetesClient` can be activated as an OSGi service again under the Java 17 baseline. Aries SPI-Fly (1.3.0) and ASM (8.0.1) predate Java 17 bytecode, so SPI-Fly's weaving hook failed with `Unsupported class file major version 61`, `ServiceLoader` call sites were never woven, and no `HttpClient.Factory` could be found. The feature now ships Aries SPI-Fly 1.3.7 and ASM 9.10.1, which moves SPI-Fly's ASM import range from `[8.0,9)` to `[9.6,10)`. The `scr` feature the Karaf feature repository used to define (pinning Felix SCR 2.0.6, which provides `osgi.extender=osgi.component` 1.3 while the client requires 1.5+, and which shadowed Karaf's own `scr` feature) has been removed: `kubernetes-client` now depends on the `scr` feature provided by Karaf, so the Declarative Services API bundles and the `scr:*` shell commands come from the distribution. The Karaf integration tests no longer skip on JDK 17+, so this is covered by CI again
 
 #### Improvements
-* Fix #8009: Java baseline upgraded to Java 17, enabling access to modern language features, better performance, and long-term support
 
 #### Dependency Upgrade
 
 #### New Features
 
 #### _**Note**_: Breaking changes
-* Fix #8009: Java baseline upgraded from Java 11 to Java 17. The project now requires Java 17 or higher to compile and run (`maven.compiler.source`, `maven.compiler.target`, and `maven.compiler.release` are all set to 17). Users on Java 11 must upgrade to Java 17+ to use version 8.0.0 and later
+* Check detailed migration documentation for breaking changes in [8.0.0](./doc/MIGRATION-v8.md)
+* Fix #8009: Moved Java baseline from 11 to 17. In addition to the runtime requirement, the Maven plugins, the Gradle plugin and the annotation processor now require a Java 17+ JVM to run the build, and the OSGi bundles declare `osgi.ee=JavaSE 17`
 
 ### 7.9.0 (2026-09-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,18 @@
 ### 8.0-SNAPSHOT
 
 #### Bugs
-* Fix #8050: (karaf) `KubernetesClient` can be activated as an OSGi service again under the Java 17 baseline. Aries SPI-Fly (1.3.0) and ASM (8.0.1) predate Java 17 bytecode, so SPI-Fly's weaving hook failed with `Unsupported class file major version 61`, `ServiceLoader` call sites were never woven, and no `HttpClient.Factory` could be found. The feature now ships Aries SPI-Fly 1.3.7 and ASM 9.10.1, which moves SPI-Fly's ASM import range from `[8.0,9)` to `[9.6,10)`. The `scr` feature the Karaf feature repository used to define (pinning Felix SCR 2.0.6, which provides `osgi.extender=osgi.component` 1.3 while the client requires 1.5+, and which shadowed Karaf's own `scr` feature) has been removed: `kubernetes-client` now depends on the `scr` feature provided by Karaf, so the Declarative Services API bundles and the `scr:*` shell commands come from the distribution. The Karaf integration tests no longer skip on JDK 17+, so this is covered by CI again
 
 #### Improvements
 
 #### Dependency Upgrade
+* Fix #8050: (karaf) The Karaf feature bundles Aries SPI-Fly 1.3.7 (from 1.3.0) and ASM 9.10.1 (from 8.0.1), the versions required to weave Java 17 bytecode
 
 #### New Features
 
 #### _**Note**_: Breaking changes
 * Check detailed migration documentation for breaking changes in [8.0.0](./doc/MIGRATION-v8.md)
 * Fix #8009: Moved Java baseline from 11 to 17. In addition to the runtime requirement, the Maven plugins, the Gradle plugin and the annotation processor now require a Java 17+ JVM to run the build, and the OSGi bundles declare `osgi.ee=JavaSE 17`
+* Fix #8050: (karaf) The `kubernetes-karaf` feature repository no longer defines its own `scr` feature. `kubernetes-client` now depends on the `scr` feature provided by the Karaf distribution, which supplies the Declarative Services API bundles and the `scr:*` shell commands
 
 ### 7.9.0 (2026-09-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 8.0-SNAPSHOT
 
 #### Bugs
+* Fix #8050: (karaf) `KubernetesClient` can be activated as an OSGi service again under the Java 17 baseline. Aries SPI-Fly (1.3.0) and ASM (8.0.1) predate Java 17 bytecode, so SPI-Fly's weaving hook failed with `Unsupported class file major version 61`, `ServiceLoader` call sites were never woven, and no `HttpClient.Factory` could be found. The feature now ships Aries SPI-Fly 1.3.7 and ASM 9.10.1, which moves SPI-Fly's ASM import range from `[8.0,9)` to `[9.6,10)`. The `scr` feature the Karaf feature repository used to define (pinning Felix SCR 2.0.6, which provides `osgi.extender=osgi.component` 1.3 while the client requires 1.5+, and which shadowed Karaf's own `scr` feature) has been removed: `kubernetes-client` now depends on the `scr` feature provided by Karaf, so the Declarative Services API bundles and the `scr:*` shell commands come from the distribution. The Karaf integration tests no longer skip on JDK 17+, so this is covered by CI again
 
 #### Improvements
 * Fix #8009: Java baseline upgraded to Java 17, enabling access to modern language features, better performance, and long-term support

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ generate-model: openapi-generate-schema openapi-generate-java-classes
 
 .PHONY: sonar
 sonar: clean
-	mvn $(MAVEN_ARGS) -Pcoverage install
+	mvn $(MAVEN_ARGS) -Pcoverage,sonar install
 	mvn -Pcoverage,sonar sonar:sonar -DskipTests
 
 .PHONY: javadoc

--- a/crd-generator/gradle/README.md
+++ b/crd-generator/gradle/README.md
@@ -93,7 +93,7 @@ must run in a separate JVM process. This recipe uses a `JavaExec` task with Grad
 
 The `javaLauncher` is resolved from `java.toolchain.languageVersion` so it always matches the
 version used for compilation without duplicating the version number. If you need an explicit
-version, replace it with `JavaLanguageVersion.of(17)` (Kotlin) or `JavaLanguageVersion.of(17)`
+version, replace it with `JavaLanguageVersion.of(21)` (Kotlin) or `JavaLanguageVersion.of(21)`
 (Groovy).
 
 ### Kotlin DSL (`build.gradle.kts`)
@@ -107,9 +107,9 @@ group = "io.fabric8.crd-generator.gradle"
 version = "0.0.1-SNAPSHOT"
 
 java {
-    // Compile the project with JDK 17. Gradle will download it automatically if needed.
+    // Compile the project with JDK 21. Gradle will download it automatically if needed.
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 
@@ -180,9 +180,9 @@ group = 'io.fabric8.crd-generator.gradle'
 version = '0.0.1-SNAPSHOT'
 
 java {
-    // Compile the project with JDK 17. Gradle will download it automatically if needed.
+    // Compile the project with JDK 21. Gradle will download it automatically if needed.
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 

--- a/crd-generator/maven-plugin/README.md
+++ b/crd-generator/maven-plugin/README.md
@@ -201,7 +201,7 @@ This can be configured in the plugin `<configuration>` or passed on the command 
         <goal>generate</goal>
       </goals>
       <configuration>
-        <javaExecutable>/path/to/jdk17/bin/java</javaExecutable>
+        <javaExecutable>/path/to/jdk21/bin/java</javaExecutable>
       </configuration>
     </execution>
   </executions>
@@ -221,10 +221,10 @@ toolchain is active in the build — no extra `<configuration>` needed in the pl
   <toolchain>
     <type>jdk</type>
     <provides>
-      <version>17</version>
+      <version>21</version>
     </provides>
     <configuration>
-      <jdkHome>/path/to/jdk17</jdkHome>
+      <jdkHome>/path/to/jdk21</jdkHome>
     </configuration>
   </toolchain>
 </toolchains>
@@ -246,7 +246,7 @@ toolchain is active in the build — no extra `<configuration>` needed in the pl
   <configuration>
     <toolchains>
       <jdk>
-        <version>17</version>
+        <version>21</version>
       </jdk>
     </toolchains>
   </configuration>

--- a/crd-generator/maven-plugin/src/it/dependency-explicit/pom.xml
+++ b/crd-generator/maven-plugin/src/it/dependency-explicit/pom.xml
@@ -67,8 +67,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>@maven.compiler.plugin.version@</version>
         <configuration>
-          <source>17</source>
-          <target>17</target>
+          <source>@maven.compiler.source@</source>
+          <target>@maven.compiler.target@</target>
         </configuration>
       </plugin>
     </plugins>

--- a/crd-generator/maven-plugin/src/it/dependency-indexed-scan/pom.xml
+++ b/crd-generator/maven-plugin/src/it/dependency-indexed-scan/pom.xml
@@ -69,8 +69,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>@maven.compiler.plugin.version@</version>
         <configuration>
-          <source>17</source>
-          <target>17</target>
+          <source>@maven.compiler.source@</source>
+          <target>@maven.compiler.target@</target>
         </configuration>
       </plugin>
     </plugins>

--- a/crd-generator/maven-plugin/src/it/dependency-scan-package-exclusion/pom.xml
+++ b/crd-generator/maven-plugin/src/it/dependency-scan-package-exclusion/pom.xml
@@ -74,8 +74,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>@maven.compiler.plugin.version@</version>
         <configuration>
-          <source>17</source>
-          <target>17</target>
+          <source>@maven.compiler.source@</source>
+          <target>@maven.compiler.target@</target>
         </configuration>
       </plugin>
     </plugins>

--- a/crd-generator/maven-plugin/src/it/dependency-scan-package-inclusion/pom.xml
+++ b/crd-generator/maven-plugin/src/it/dependency-scan-package-inclusion/pom.xml
@@ -74,8 +74,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>@maven.compiler.plugin.version@</version>
         <configuration>
-          <source>17</source>
-          <target>17</target>
+          <source>@maven.compiler.source@</source>
+          <target>@maven.compiler.target@</target>
         </configuration>
       </plugin>
     </plugins>

--- a/crd-generator/maven-plugin/src/it/dependency-scan/pom.xml
+++ b/crd-generator/maven-plugin/src/it/dependency-scan/pom.xml
@@ -69,8 +69,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>@maven.compiler.plugin.version@</version>
         <configuration>
-          <source>17</source>
-          <target>17</target>
+          <source>@maven.compiler.source@</source>
+          <target>@maven.compiler.target@</target>
         </configuration>
       </plugin>
     </plugins>

--- a/crd-generator/maven-plugin/src/it/intermediate-class/pom.xml
+++ b/crd-generator/maven-plugin/src/it/intermediate-class/pom.xml
@@ -64,8 +64,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>@maven.compiler.plugin.version@</version>
         <configuration>
-          <source>17</source>
-          <target>17</target>
+          <source>@maven.compiler.source@</source>
+          <target>@maven.compiler.target@</target>
         </configuration>
       </plugin>
     </plugins>

--- a/crd-generator/maven-plugin/src/it/project-and-dependency-scan/pom.xml
+++ b/crd-generator/maven-plugin/src/it/project-and-dependency-scan/pom.xml
@@ -70,8 +70,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>@maven.compiler.plugin.version@</version>
         <configuration>
-          <source>17</source>
-          <target>17</target>
+          <source>@maven.compiler.source@</source>
+          <target>@maven.compiler.target@</target>
         </configuration>
       </plugin>
     </plugins>

--- a/crd-generator/maven-plugin/src/it/project-explicit/pom.xml
+++ b/crd-generator/maven-plugin/src/it/project-explicit/pom.xml
@@ -62,8 +62,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>@maven.compiler.plugin.version@</version>
         <configuration>
-          <source>17</source>
-          <target>17</target>
+          <source>@maven.compiler.source@</source>
+          <target>@maven.compiler.target@</target>
         </configuration>
       </plugin>
     </plugins>

--- a/crd-generator/maven-plugin/src/it/project-scan-forked/pom.xml
+++ b/crd-generator/maven-plugin/src/it/project-scan-forked/pom.xml
@@ -63,8 +63,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>@maven.compiler.plugin.version@</version>
         <configuration>
-          <source>17</source>
-          <target>17</target>
+          <source>@maven.compiler.source@</source>
+          <target>@maven.compiler.target@</target>
         </configuration>
       </plugin>
     </plugins>

--- a/crd-generator/maven-plugin/src/it/project-scan/pom.xml
+++ b/crd-generator/maven-plugin/src/it/project-scan/pom.xml
@@ -56,8 +56,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>@maven.compiler.plugin.version@</version>
         <configuration>
-          <source>17</source>
-          <target>17</target>
+          <source>@maven.compiler.source@</source>
+          <target>@maven.compiler.target@</target>
         </configuration>
       </plugin>
     </plugins>

--- a/crd-generator/maven-plugin/src/it/test-dependencies/pom.xml
+++ b/crd-generator/maven-plugin/src/it/test-dependencies/pom.xml
@@ -37,8 +37,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>@maven.compiler.plugin.version@</version>
         <configuration>
-          <source>17</source>
-          <target>17</target>
+          <source>@maven.compiler.source@</source>
+          <target>@maven.compiler.target@</target>
         </configuration>
       </plugin>
     </plugins>

--- a/doc/MIGRATION-v8.md
+++ b/doc/MIGRATION-v8.md
@@ -1,0 +1,42 @@
+# Migration from 7.x to 8.x
+
+## Contents
+- [Java baseline set to Java 17](#java-17)
+  - [Build tooling requires a Java 17 runtime](#java-17-build-tooling)
+  - [OSGi bundles require JavaSE 17](#java-17-osgi)
+
+
+> [!NOTE]
+> If you encounter any problems with the following "Migration from 7.x to 8.x" instructions, please let us know by creating an issue in our [GitHub repository](https://github.com/fabric8io/kubernetes-client/issues).
+>
+> We value your feedback and will work to address your issue promptly.
+> Your contribution is essential to improving our documentation, making our migration process smoother for everyone!
+
+## Java baseline set to Java 17 <a href="#java-17" id="java-17"/>
+
+Starting from version 8.0.0, you will need a Java 17+ runtime (using the latest Java release is always encouraged) to use the Fabric8 Kubernetes Client.
+
+Java 11 reached the end of its Oracle Premier Support window and most vendors have moved their free update streams on.
+Java 17 is the oldest release still receiving broad support across vendors, so it is where the baseline now sits.
+
+If you are still on Java 11, you have to upgrade your runtime before upgrading to 8.0.0. The 7.x line remains on the Java 11 baseline.
+
+### Build tooling requires a Java 17 runtime <a href="#java-17-build-tooling" id="java-17-build-tooling"/>
+
+This affects you even if your own application targets an older Java release.
+
+The CRD generator and Java generator ship as Maven plugins, a Gradle plugin, and an annotation processor. They are compiled for Java 17, so the JVM that *runs the build* must be Java 17 or newer:
+
+- **Maven plugins** (`crd-generator-maven-plugin`, `java-generator-maven-plugin`): the JVM running Maven.
+- **Gradle plugin** (`io.fabric8.java-generator`): the Gradle daemon. Gradle itself must be a version that supports running on Java 17 (Gradle 7.3+).
+- **Annotation processor** (`crd-generator-apt`): the `javac` that runs annotation processing.
+
+Running any of them on an older JVM fails with `UnsupportedClassVersionError`. Note that your *compilation target* is independent of this: you can still set `maven.compiler.release` (or the Gradle toolchain) to an older version for your own sources, as long as the build tool itself runs on Java 17+.
+
+If you need the build JVM to stay on an older release, the CRD generator Maven plugin can fork a separate JVM for generation. See [Cross-JDK version builds](../crd-generator/maven-plugin/README.md#cross-jdk-version-builds-forked-jvm).
+
+### OSGi bundles require JavaSE 17 <a href="#java-17-osgi" id="java-17-osgi"/>
+
+The published bundles now declare `Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"`, up from `version=11`.
+
+This is a *resolution* requirement, not just a runtime one: on an OSGi framework running Java 11 the bundles will fail to resolve rather than failing later at class load. Karaf users need a container running on Java 17 or newer.

--- a/doc/MIGRATION-v8.md
+++ b/doc/MIGRATION-v8.md
@@ -4,6 +4,7 @@
 - [Java baseline set to Java 17](#java-17)
   - [Build tooling requires a Java 17 runtime](#java-17-build-tooling)
   - [OSGi bundles require JavaSE 17](#java-17-osgi)
+- [Karaf: the bundled `scr` feature has been removed](#karaf-scr)
 
 
 > [!NOTE]
@@ -40,3 +41,16 @@ If you need the build JVM to stay on an older release, the CRD generator Maven p
 The published bundles now declare `Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"`, up from `version=11`.
 
 This is a *resolution* requirement, not just a runtime one: on an OSGi framework running Java 11 the bundles will fail to resolve rather than failing later at class load. Karaf users need a container running on Java 17 or newer.
+
+## Karaf: the bundled `scr` feature has been removed <a href="#karaf-scr" id="karaf-scr"/>
+
+The `io.fabric8.kubernetes:kubernetes-karaf` feature repository used to define its own `scr` feature, pinning a single Felix SCR bundle. That definition has been removed, and `kubernetes-client` now depends on the `scr` feature provided by the Karaf distribution.
+
+For most users this needs no action: Karaf provides `scr` out of the box, and installing `kubernetes-client` pulls it in as before.
+
+Two things change if you were relying on the old behaviour:
+
+- **If you installed our `scr` feature explicitly** (`feature:install scr` resolving against our repository, or a `<feature>scr</feature>` reference in your own descriptor), you now get Karaf's. Karaf's is a superset: besides the SCR implementation it also supplies the Declarative Services API bundles and, through its conditionals, the `scr:list` / `scr:info` shell commands and the SCR MBean.
+- **If you build a custom Karaf assembly**, make sure the Karaf standard feature repository is on the descriptor list. Our repository no longer carries a `scr` feature to fall back on, so an assembly that registers only the fabric8 repository will now fail to resolve `kubernetes-client` — loudly, at assembly time, rather than silently producing a container where the client cannot activate.
+
+The old definition was not self-contained: Felix SCR 2.0.6 exported the Declarative Services API itself, but 2.2.18 and later import it instead, so a single-bundle `scr` feature no longer carries everything it needs. Because ours was versioned with the project version it also outranked Karaf's, so an unversioned `scr` request selected the incomplete definition.

--- a/platforms/karaf/features/src/main/resources/feature.xml
+++ b/platforms/karaf/features/src/main/resources/feature.xml
@@ -16,9 +16,6 @@
 
 -->
 <features xmlns="http://karaf.apache.org/xmlns/features/v1.2.0" name="kuberntes-features-${project.version}">
-  <feature name="scr" description="Declarative Service support" version="${project.version}">
-    <bundle start-level="30">mvn:org.apache.felix/org.apache.felix.scr/${felix.scr.version}</bundle>
-  </feature>
   <feature name="kubernetes-client" description="Fabric8 Kubernetes Client" version="${project.version}">
     <feature>scr</feature>
     <bundle dependency='true'>mvn:com.google.code.findbugs/jsr305/${jsr305.version}</bundle>

--- a/platforms/karaf/itests/pom.xml
+++ b/platforms/karaf/itests/pom.xml
@@ -173,6 +173,9 @@
           <systemPropertyVariables>
             <features.xml>${project.build.directory}/features.xml</features.xml>
             <features.repo>${project.build.directory}/features-repo</features.repo>
+            <!-- TestBase derives the lib/endorsed patch-module paths from this; without it the
+                 paths point at a version that isn't there and the JVM silently ignores them -->
+            <karaf.version>${karaf.version}</karaf.version>
           </systemPropertyVariables>
         </configuration>
       </plugin>

--- a/platforms/karaf/itests/pom.xml
+++ b/platforms/karaf/itests/pom.xml
@@ -155,6 +155,9 @@
                 <feature>openshift-client</feature>
               </features>
               <descriptors>
+                <!-- Karaf's own repository provides the scr feature (and the DS API bundles it
+                     pulls in), which our features depend on but deliberately do not redefine -->
+                <descriptor>mvn:org.apache.karaf.features/standard/${karaf.version}/xml/features</descriptor>
                 <descriptor>file:${project.build.directory}/features.xml</descriptor>
               </descriptors>
             </configuration>

--- a/platforms/karaf/itests/src/test/java/io/fabric8/kubernetes/karaf/itests/TestBase.java
+++ b/platforms/karaf/itests/src/test/java/io/fabric8/kubernetes/karaf/itests/TestBase.java
@@ -29,9 +29,11 @@ import java.util.List;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.ops4j.pax.exam.CoreOptions.composite;
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureSecurity;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFileExtend;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFilePut;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
@@ -57,11 +59,15 @@ public class TestBase {
               "etc/io.fabric8.kubernetes.client.cfg", "junit", "ignored"),
           editConfigurationFileExtend(
               "etc/io.fabric8.openshift.client.cfg", "junit", "ignored"),
-          editConfigurationFileExtend(
+          // Replace the shipped repository list rather than appending to it: it still points at
+          // the decommissioned oss.sonatype.org OSSRH snapshot host, and appending duplicated
+          // Central. Everything under test resolves from the local repository.
+          editConfigurationFilePut(
               "etc/org.ops4j.pax.url.mvn.cfg",
               "org.ops4j.pax.url.mvn.repositories",
-              "https://repo1.maven.org/maven2/"),
-          keepRuntimeFolder(),
+              "https://repo1.maven.org/maven2@id=central"),
+          // Keeping the unpacked container costs ~100MB per test class; opt in when debugging.
+          Boolean.getBoolean("karaf.itest.keepRuntimeFolder") ? keepRuntimeFolder() : composite(),
           logLevel(LogLevelOption.LogLevel.INFO),
           new VMOption("--add-exports=java.base/"
               + "org.apache.karaf.specs.locator=java.xml,ALL-UNNAMED"),
@@ -98,11 +104,15 @@ public class TestBase {
               "etc/io.fabric8.kubernetes.client.cfg", "junit", "ignored"),
           editConfigurationFileExtend(
               "etc/io.fabric8.openshift.client.cfg", "junit", "ignored"),
-          editConfigurationFileExtend(
+          // Replace the shipped repository list rather than appending to it: it still points at
+          // the decommissioned oss.sonatype.org OSSRH snapshot host, and appending duplicated
+          // Central. Everything under test resolves from the local repository.
+          editConfigurationFilePut(
               "etc/org.ops4j.pax.url.mvn.cfg",
               "org.ops4j.pax.url.mvn.repositories",
-              "https://repo1.maven.org/maven2/"),
-          keepRuntimeFolder(),
+              "https://repo1.maven.org/maven2@id=central"),
+          // Keeping the unpacked container costs ~100MB per test class; opt in when debugging.
+          Boolean.getBoolean("karaf.itest.keepRuntimeFolder") ? keepRuntimeFolder() : composite(),
           logLevel(LogLevelOption.LogLevel.INFO)));
     }
     ret.addAll(extraOptions);

--- a/platforms/karaf/pom.xml
+++ b/platforms/karaf/pom.xml
@@ -36,6 +36,11 @@
   <properties>
     <karaf.version>4.4.11</karaf.version>
     <osgi.version>6.0.0</osgi.version>
+    <!-- Only consumed by features/src/main/resources/feature.xml. SPI-Fly weaves the
+         ServiceLoader call sites the client relies on, so ASM must be able to read the
+         bytecode we compile: keep ASM within the range SPI-Fly imports (1.3.7 -> [9.6,10)). -->
+    <aries-spifly.bundle.version>1.3.7</aries-spifly.bundle.version>
+    <asm.bundle.version>9.10.1</asm.bundle.version>
     <!--  NOT Updated because of: https://github.com/ops4j/org.ops4j.pax.exam2/issues/1020#issuecomment-1011133020 causing instability in CI -->
     <pax.exam.version>4.14.0</pax.exam.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -1025,27 +1025,34 @@
         <plugin>
           <artifactId>maven-enforcer-plugin</artifactId>
           <version>${maven.enforcer.plugin.version}</version>
-          <!-- <executions>
+          <executions>
             <execution>
-              <id>enforce-maven</id>
+              <id>enforce-java</id>
               <goals>
                 <goal>enforce</goal>
               </goals>
               <configuration>
                 <failFast>true</failFast>
                 <rules>
-                  <requireMavenVersion>
-                    <version>[3.2.5,)</version>
-                  </requireMavenVersion>
+                  <requireJavaVersion>
+                    <version>[17,)</version>
+                    <message>The Fabric8 Kubernetes Client requires JDK 17 or later to build (see doc/MIGRATION-v8.md).</message>
+                  </requireJavaVersion>
                 </rules>
               </configuration>
             </execution>
-          </executions> -->
+          </executions>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-plugin-plugin</artifactId>
           <version>${maven.plugin.plugin.version}</version>
+          <configuration>
+            <!-- Recorded in the generated plugin descriptor so that Maven reports a readable
+                 error when the plugin is used on an older JVM, instead of the
+                 UnsupportedClassVersionError the Java 17 bytecode would otherwise produce -->
+            <requiredJavaVersion>${maven.compiler.release}</requiredJavaVersion>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -128,8 +128,6 @@
 
     <conscrypt-openjdk-uber.bundle.version>1.4.2_1</conscrypt-openjdk-uber.bundle.version>
     <automaton.bundle.version>1.11-8_1</automaton.bundle.version>
-    <aries-spifly.bundle.version>1.3.0</aries-spifly.bundle.version>
-    <asm.bundle.version>8.0.1</asm.bundle.version>
     <slf4j.version>2.0.18</slf4j.version>
     <log4j.version>2.26.1</log4j.version>
     <lombok.version>1.18.46</lombok.version>
@@ -137,7 +135,6 @@
     <commons-io.version>2.22.0</commons-io.version> <!-- Required by Gradle Testing Toolkit -->
     <guava.version>33.6.0-jre</guava.version> <!-- Required by Gradle Testing Toolkit -->
     <osgi.annotations.version>1.5.1</osgi.annotations.version>
-    <felix.scr.version>2.0.6</felix.scr.version>
     <jmustache.version>1.16</jmustache.version>
     <picocli.version>4.7.7</picocli.version>
     <swagger-request-validator-core.version>2.46.1</swagger-request-validator-core.version>
@@ -1641,15 +1638,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-    <profile>
-      <id>java-17</id>
-      <activation>
-        <jdk>[17,)</jdk>
-      </activation>
-      <properties>
-        <karaf.itest.skip>true</karaf.itest.skip>
-      </properties>
     </profile>
     <profile>
       <id>javadoc-test</id>


### PR DESCRIPTION
## Description

Fixes #8050

Follow-up to #8020. The Karaf feature has been broken since the Java 17 baseline landed, and the review of that PR turned up a set of loose ends around the baseline move. One commit per concern.

### `fix(karaf)`: restore OSGi service activation under Java 17

Our bundles now compile to class file v61, but the feature pinned Aries SPI-Fly 1.3.0 and ASM 8.0.1 — ASM 8 can't read v61, so SPI-Fly's weaving hook fails, `ServiceLoader` call sites are never woven, `HttpClientUtils` finds no `HttpClient.Factory`, and `ManagedKubernetesClient` never activates.

- **SPI-Fly 1.3.0 → 1.3.7, ASM 8.0.1 → 9.10.1.** These have to move together because SPI-Fly imports ASM over OSGi (it does not embed it): the imported range moved from `[8.0,9)` in 1.3.0 to `[9.6,10)` in 1.3.7. Both properties are only read by the feature descriptor, so they now sit in `platforms/karaf/pom.xml` next to `karaf.version`.
- **Removed the `scr` feature this repository defined.** It pinned Felix SCR 2.0.6, which *exported* the Declarative Services API itself. 2.2.18 and later export none of it and import it mandatorily, so a single-bundle `scr` feature is no longer self-contained — Karaf's own ships `org.osgi.service.component/1.5.1`, `org.osgi.util.function/1.2.0` and `org.osgi.util.promise/1.3.0` alongside it. Ours was also versioned `${project.version}`, which always outranks Karaf's `4.4.11`, so an unversioned `scr` request selected the incomplete copy and suppressed Karaf's conditionals (`scr:list`, `scr:info`, the MBean). `kubernetes-client` now depends on the distribution's `scr` feature, and the itests resolve Karaf's standard repository so the offline closure contains those bundles.
- **Removed the `java-17` profile**, which set `karaf.itest.skip=true` on every JDK 17+ build and is what hid all of the above. Added in #5874 when the JDK 11 job still ran these tests; #8020 removed that job, so they ran nowhere.

### `chore(karaf)`: tidy up the integration test harness

Now that the ITs actually execute, several dormant problems are live on every build.

- The `lib/endorsed` patch-module options derived their path from a `karaf.version` system property surefire never set, so they defaulted to `4.4.1` while the container ships `4.4.11`. The JVM ignores patch-module paths that don't exist, so they had never done anything — and the Karaf specs locator was correspondingly unavailable, logging **47** `NoClassDefFoundError: org/apache/karaf/specs/locator/OsgiLocator` framework errors. Passing the property through drops that to **0**.
- `org.ops4j.pax.url.mvn.repositories` is now replaced rather than appended to. The shipped list still points at the decommissioned `oss.sonatype.org` OSSRH snapshot host, and appending re-added Central a second time.
- The unpacked container is kept only under `-Dkaraf.itest.keepRuntimeFolder=true`. It was ~420MB per run that an incremental build never reclaimed; CI runners are ephemeral.
- Karaf ITs are skipped on the Windows build (~3x slower there, plus a spurious `Terminal has been closed` error annotation on a green job). The Linux matrix covers 17 and 21.
- `make sonar` passes `-Psonar` to its `install` half — that profile is what sets `karaf.itest.skip` for the Sonar job, but it was only applied to `sonar:sonar`, which already skips tests.

### `docs(java17)`: v8 migration guide and baseline enforcement

- Adds `doc/MIGRATION-v8.md`, covering the two consequences that aren't obvious from "the baseline moved": the Maven/Gradle plugins and the annotation processor now need a Java 17+ JVM to run the *build*, independently of what the consuming project targets; and the OSGi bundles declare `osgi.ee=JavaSE 17`, which is a *resolution* requirement.
- Collapses the duplicated #8009 CHANGELOG entry to one line under breaking changes (matching how #6081 recorded the previous baseline move) and adds the migration-guide pointer.
- `maven-enforcer-plugin` had its only rule commented out; a `requireJavaVersion [17,)` rule now reports the requirement instead of failing with `invalid target release: 17`. `maven-plugin-plugin` records the same in the generated descriptor, so downstream users on an old JVM get a readable Maven error rather than `UnsupportedClassVersionError`.

### `docs`: cleanups

- The CRD generator READMEs' cross-JDK sections described a JDK 17 Maven / JDK 21 project while the remedies below still handed the reader a JDK 17 toolchain, which cannot load the JDK 21 classes described. Examples moved to 21.
- The model-update skill told the reader to switch JDKs between steps and then named 17 for both.
- The CRD generator IT poms interpolate `@maven.compiler.source@` / `@maven.compiler.target@` instead of hardcoding `17`, as the java-generator and openapi IT poms already do.

### Verification

7/7 Karaf ITs pass on **JDK 17** and **JDK 21**, with no skip override needed.

- `target/features-repo/org/` previously held only `apache ow2 snakeyaml yaml`; it now also contains `osgi/` with the three DS API bundles.
- Container feature state previously recorded both `scr/999.0.0.SNAPSHOT` and `scr/4.4.11`; now only `scr/4.4.11`.
- Container `ERROR` lines across a full run: **95 → 5** (the remainder is the jline shutdown message).
- `target/exam` after a run: **419MB → 0**.
- Enforcer verified to reject JDK 11 with the intended message and pass on 17; `crd-generator-maven-plugin`'s descriptor carries `<requiredJavaVersion>17</requiredJavaVersion>`; the filtered IT poms resolve to `<source>17</source>` and `project-scan` passes.

One caveat on the above: the pax-exam container resolves bundles from the local repository, so a local run validates whatever `999-SNAPSHOT` is installed rather than the reactor output. CI builds the reactor first, so its result is the authoritative one.

<details>
<summary>Considered and dropped: <code>karaf-maven-plugin:verify</code></summary>

Binding the `verify` goal in the features module looked like the systemic fix for a descriptor that is never validated. Measured against the two bugs here, it catches neither: an ASM pinned too low to read our bytecode resolves fine and only fails later in SPI-Fly's weaving hook, and an incomplete `scr` feature still resolves because Karaf's repository must be on the descriptor list for `scr` to be found at all — and that repository also supplies the DS bundles the incomplete feature omitted. It only catches a bundle GAV that does not exist.

It also breaks the build: the features module declares no Maven dependency on the ~100 bundles its descriptor references, so under `-T 1C` and a clean local repository `verify` runs before those artifacts are installed. Making it correct means declaring every bundle as a dependency, which is a design change rather than a drive-by. Dropped.
</details>

## Type of change
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

🤖 Generated with [Claude Code](https://claude.com/claude-code)
