### PR TITLE
chore(deps): track the jackson-annotations bundle pin and block the OAI replacement

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,18 @@
   "enabledManagers": [
     "maven",
     "gomod",
-    "github-actions"
+    "github-actions",
+    "custom.regex"
+  ],
+  "customManagers": [
+    {
+      "description": "jackson.bundle.version.annotations pins the jackson-annotations OSGi bundle in the Karaf feature. jackson-bom decouples it from jackson.version (2.20+ drops the patch segment), and it is not a dependency declaration, so the maven manager never sees it. Tracking it here keeps it in the same grouped jackson PR",
+      "customType": "regex",
+      "managerFilePatterns": ["/^pom\\.xml$/"],
+      "matchStrings": ["<jackson\\.bundle\\.version\\.annotations>(?<currentValue>.*?)</jackson\\.bundle\\.version\\.annotations>"],
+      "depNameTemplate": "com.fasterxml.jackson.core:jackson-annotations",
+      "datasourceTemplate": "maven"
+    }
   ],
   "ignorePaths": [
     "**/src/it/**"
@@ -31,9 +42,9 @@
       "enabled": false
     },
     {
-      "description": "swagger-request-validator 3.x requires Java 21; we still target Java 17",
+      "description": "swagger-request-validator 3.x requires Java 21; we still target Java 17. 3.x also renamed the artifact to openapi-request-validator-core, which arrives as a replacement rather than a major, so both update types are disabled",
       "matchPackageNames": ["com.atlassian.oai:**"],
-      "matchUpdateTypes": ["major"],
+      "matchUpdateTypes": ["major", "replacement"],
       "enabled": false
     },
     {


### PR DESCRIPTION
Two Renovate gaps surfaced while working through the update queue.

### `jackson.bundle.version.annotations` was invisible to Renovate

That property pins the `jackson-annotations` OSGi bundle installed by the Karaf feature (`platforms/karaf/features/src/main/resources/feature.xml`). `jackson-bom` decouples the annotations version from `jackson.version` (since 2.20 it drops the patch segment: `2.20`, `2.21`, `2.22`), and the property backs no dependency declaration, so the `maven` manager never saw it.

A `jackson.version` bump on its own therefore leaves the Karaf feature installing a stale annotations bundle while every model bundle imports the newer package range. That is #8080: `jackson-bom` 2.22.2 against a `2.21` bundle pin, and every `kubernetes-karaf-itests` test fails with

```
org.apache.felix.resolver.reason.ReasonException: Unable to resolve io.fabric8.kubernetes-client/999.0.0.SNAPSHOT:
  missing requirement [io.fabric8.kubernetes-client/999.0.0.SNAPSHOT] osgi.wiring.package;
  filter:="(&(osgi.wiring.package=com.fasterxml.jackson.annotation)(version>=2.22.0)(!(version>=3.0.0)))"
```

A regex custom manager now tracks the property as `com.fasterxml.jackson.core:jackson-annotations`. The existing `"matchPackageNames": ["com.fasterxml.jackson**"]` group rule matches that coordinate, so it rides along in the same `renovate/jackson` PR instead of drifting behind it.

### The `com.atlassian.oai` rule only covered majors

The rule disables major updates because swagger-request-validator 3.x requires Java 21 and we target Java 17. 3.x also renamed the artifact to `openapi-request-validator-core`, which Renovate offers as updateType `replacement`, not `major`, so it walked straight past the rule. That is #8077, which fails to compile with

```
bad class file: .../openapi-request-validator-core-3.0.0.jar(/com/atlassian/oai/validator/report/ValidationReport.class)
  class file has wrong version 65.0, should be 61.0
```

`matchUpdateTypes` now lists both.

Validated with `renovate-config-validator` (Renovate 44.79.1, the version running on this repo).