### PR TITLE
chore(deps): clear the two Renovate package lookup failures

### DIFF
--- a/kubernetes-model-generator/openapi/generator/go.mod
+++ b/kubernetes-model-generator/openapi/generator/go.mod
@@ -89,7 +89,6 @@ replace (
 
 // Issues with dependabot, force pseudo-versions as replacements since dependabot will try to replace with invalid tagged major versions
 replace (
-	github.com/chaos-mesh/chaos-mesh => github.com/chaos-mesh/chaos-mesh v0.0.0-20250513055240-4db47f53978c
 	github.com/chaos-mesh/chaos-mesh/api => github.com/chaos-mesh/chaos-mesh/api v0.0.0-20250513055240-4db47f53978c
 	github.com/stolostron/multicluster-observability-operator => github.com/stolostron/multicluster-observability-operator v0.0.0-20250726172846-3a17a1a4168e
 	github.com/stolostron/multiclusterhub-operator => github.com/stolostron/multiclusterhub-operator v0.0.0-20250728181123-c3e46b4bdbbc

--- a/renovate.json
+++ b/renovate.json
@@ -48,6 +48,11 @@
       "enabled": false
     },
     {
+      "description": "org.gradle:gradle-all is not published to Maven Central. gradle-api-maven-plugin synthesizes it locally from the Gradle distribution, so the lookup can only ever fail. gradle-api.version is a compatibility floor for the Gradle plugin and is bumped deliberately",
+      "matchPackageNames": ["org.gradle:gradle-all"],
+      "enabled": false
+    },
+    {
       "matchPackageNames": ["org.bouncycastle:**"],
       "groupName": "bouncycastle"
     },


### PR DESCRIPTION
Follow-up to #8083. These are the two entries behind **Repository problems / Package lookup failures** on the dependency dashboard:

```
Could not determine new digest for update (go package github.com/chaos-mesh/chaos-mesh)
Failed to look up maven package org.gradle:gradle-all: no-result
```

### `org.gradle:gradle-all` is not on Maven Central

The `org/gradle/` group directory exists on Central, this artifact does not (`maven-metadata.xml` and `gradle-all-8.5.pom` both 404). `com.marcnuri.plugins:gradle-api-maven-plugin` registers itself with `<extensions>true</extensions>` and synthesizes the coordinate locally from the Gradle distribution, so a Maven lookup can only ever return `no-result`.

`gradle-api.version` is the compatibility floor the Gradle plugin compiles against rather than a dependency to keep current, so the lookup is disabled outright. If we ever want it tracked, the route would be a custom manager on the `gradle-version` datasource (`services.gradle.org`) rather than Maven, but raising the floor is a deliberate compatibility call each time.

### `github.com/chaos-mesh/chaos-mesh` was an inert replace directive

Go's major-version suffix rule means the unsuffixed module path tops out at what was tagged before v2:

```
$ curl -s https://proxy.golang.org/github.com/chaos-mesh/chaos-mesh/@latest
{"Version":"v1.2.4","Time":"2021-11-25T08:11:50Z"}
```

The proxy lists only v1.x tags for that path and zero pseudo-versions, so Renovate had a pseudo-version `currentDigest` (`4db47f53978c`) and nothing to resolve it against. The `/api` module is not affected and keeps working, because its version list is empty, so the proxy serves `@latest` as a pseudo-version carrying `Origin.Hash`, which is what the existing `allowedVersions: /^v0\.0\.0-/` rule pins it to.

The root module was never in the build graph, so the directive replaced nothing. Removing it takes the dependency out of Renovate's view entirely.

Verified inert:

- `go mod graph` is byte-identical before and after (106801 edges; only `github.com/chaos-mesh/chaos-mesh/api` is reachable, never the bare root)
- `go.sum` is byte-identical (md5 `e984786d8e0cd1a37aed074504694a37`), and had 0 entries for the root module against 2 for `/api`

The `/api` replace, which is real, is untouched.

Validated with `renovate-config-validator` (Renovate 44.79.1).