### PR TITLE
fix(openapi-generator): pin the CI Go toolchain to an exact patch

### DIFF
--- a/.github/workflows/generate-model.yml
+++ b/.github/workflows/generate-model.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.27'
+          go-version: '1.27.1'
           cache-dependency-path: kubernetes-model-generator/openapi/generator/go.sum
       - name: Setup Java 17
         uses: actions/setup-java@v6


### PR DESCRIPTION
Fixes #8089

## Why

#7432 moved `go-version` off `'stable'` because Go 1.26 was picked up silently the morning after release, changed schema generation, and failed `Generate Model` on `main` against [b54c2eaf](https://github.com/fabric8io/kubernetes-client/commit/b54c2eaf406541955af3adadf8511e2cfca48d11), a WebSocket fix with nothing to do with Go.

Pinning to the minor left the same hole one level down. `actions/setup-go` resolves a minor spec to the newest patch, so the run on #8085 asked for `1.27` and executed `1.27.1`:

```
Setup go version spec 1.27
matching 1.27...
Acquiring 1.27.1 from https://github.com/actions/go-versions/releases/download/1.27.1-33583469715/...
```

A future `1.27.2` would land exactly the way `1.26.0` did: no PR, no review, first signal a red `main`.

## That sensitivity is measured, not hypothetical

Regenerating only the Go half (`make openapi-generate-schema`) on `b54c2eaf40`, the commit that went red:

| toolchain | result |
|---|---|
| `go1.25.6` | 0 changes, reproduces the committed schemas exactly |
| `go1.26.0` | `openapi/schemas/dev.knative.json` modified, 11 insertions / 11 deletions |

The channel is the declaration order and doc comments of reflected Go stdlib structs. Go 1.26 reordered `net/url.URL` and rewrote its comments; the schema's `required` array follows declaration order, so it changed too. Nothing about the toolchain promises the next release is quiet.

## No functional change

`go1.27.1` is already what CI resolves to. On current `main`, `go1.26.8` and `go1.27.1` produce byte-identical output across all 28 generated artifacts, with no drift against the committed tree.

## Effect

Renovate proposes each Go release as its own PR, and the drift check runs on it before anything reaches the committed schemas. That is exactly how the 1.26 to 1.27 move was validated in #8085. The cost is one PR per Go patch release.

While investigating this I also found #8088: a pre-existing bug where schema `description` values are attached to the wrong field for Go types documented with trailing comments. Independent of this change, and not addressed here.